### PR TITLE
Fix auth redirect token key

### DIFF
--- a/cicero-dashboard/hooks/useAuthRedirect.js
+++ b/cicero-dashboard/hooks/useAuthRedirect.js
@@ -7,8 +7,8 @@ export default function useAuthRedirect() {
   const router = useRouter();
 
   useEffect(() => {
-    // Ganti dengan cek autentikasi sesuai implementasimu (misal cek token di localStorage/cookie)
-    const isLoggedIn = !!localStorage.getItem("token"); // atau cek cookie
+    // Check the token stored by the login page
+    const isLoggedIn = !!localStorage.getItem("cicero_token");
     if (isLoggedIn) {
       router.replace("/dashboard");
     }


### PR DESCRIPTION
## Summary
- update `useAuthRedirect` to check the `cicero_token` value in localStorage

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684857e9c4948327ba9a06ea1592309c