### PR TITLE
Fix dev script to avoid turbopack

### DIFF
--- a/cicero-dashboard/package.json
+++ b/cicero-dashboard/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack",
+    "dev": "next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"


### PR DESCRIPTION
## Summary
- remove `--turbopack` from the development script

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm run build` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68485a7c9b10832798bb4c35d955e4d8