### PR TITLE
Add Node 20 engine field

### DIFF
--- a/cicero-dashboard/package.json
+++ b/cicero-dashboard/package.json
@@ -23,5 +23,8 @@
     "@types/react-dom": "^19",
     "tailwindcss": "^4",
     "typescript": "^5"
+  },
+  "engines": {
+    "node": ">=20"
   }
 }


### PR DESCRIPTION
## Summary
- enforce Node.js 20+ via `engines` in `package.json`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68485f53c7b4832780068e8a37e10ce0