### PR TITLE
Fix PostCSS config export

### DIFF
--- a/cicero-dashboard/postcss.config.js
+++ b/cicero-dashboard/postcss.config.js
@@ -1,8 +1,6 @@
-const config = {
+module.exports = {
   plugins: {
     tailwindcss: {},
     autoprefixer: {},
   },
 };
-
-export default config;


### PR DESCRIPTION
## Summary
- rename the dashboard PostCSS config to `postcss.config.js`
- use CommonJS `module.exports` instead of ESM export

## Testing
- `npm test --silent` *(fails: no test specified)*
- `npm run lint --silent` in `cicero-dashboard` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68485f54d4248327bb02fb51148264fe