### PR TITLE
Fix Tailwind PostCSS plugin config

### DIFF
--- a/cicero-dashboard/postcss.config.js
+++ b/cicero-dashboard/postcss.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   plugins: {
-    tailwindcss: {},
+    "@tailwindcss/postcss": {},
     autoprefixer: {},
   },
 };


### PR DESCRIPTION
## Summary
- update PostCSS config to reference `@tailwindcss/postcss`

## Testing
- `npm install` *(fails: Invalid tag name `^latest`)*
- `npm run lint` *(fails: `next` not found since install failed)*

------
https://chatgpt.com/codex/tasks/task_e_684864527dcc8327a759213a5c7b2af6