### PR TITLE
Add User Directory page

### DIFF
--- a/cicero-dashboard/app/users/page.jsx
+++ b/cicero-dashboard/app/users/page.jsx
@@ -1,15 +1,97 @@
 "use client";
+import { useEffect, useState, useMemo } from "react";
+import { getUserDirectory } from "@/utils/api";
+import Loader from "@/components/Loader";
+
 export default function UserDirectoryPage() {
+  const [users, setUsers] = useState([]);
+  const [search, setSearch] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    const token =
+      typeof window !== "undefined" ? localStorage.getItem("cicero_token") : null;
+    if (!token) {
+      setError("Token tidak ditemukan. Silakan login ulang.");
+      setLoading(false);
+      return;
+    }
+
+    async function fetchUsers() {
+      try {
+        const res = await getUserDirectory(token);
+        const data = res.data || res.users || res;
+        setUsers(Array.isArray(data) ? data : []);
+      } catch (err) {
+        setError("Gagal mengambil data: " + (err.message || err));
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchUsers();
+  }, []);
+
+  const filtered = useMemo(
+    () =>
+      users.filter(
+        (u) =>
+          (u.nama || "").toLowerCase().includes(search.toLowerCase()) ||
+          (u.username || "").toLowerCase().includes(search.toLowerCase()) ||
+          (u.divisi || "").toLowerCase().includes(search.toLowerCase())
+      ),
+    [users, search]
+  );
+
+  if (loading) return <Loader />;
+  if (error)
+    return (
+      <div className="flex items-center justify-center min-h-screen bg-gray-100">
+        <div className="bg-white rounded-lg shadow-md p-6 text-red-500 font-bold">
+          {error}
+        </div>
+      </div>
+    );
+
   return (
     <div className="min-h-screen bg-gray-100 flex flex-col items-center py-12">
-      <div className="max-w-3xl w-full bg-white rounded-2xl shadow-md p-8">
+      <div className="max-w-4xl w-full bg-white rounded-2xl shadow-md p-8">
         <h1 className="text-2xl font-bold text-blue-700 mb-6">User Directory</h1>
-        <p className="text-gray-600 mb-4">
-          Manage, search, and view all users registered in the system. Add, edit, or remove user accounts as needed.
-        </p>
-        {/* TODO: Tambahkan table/list pengguna di sini */}
-        <div className="bg-slate-50 rounded-lg border border-slate-200 text-center py-12 text-slate-400">
-          <span>User management table will appear here.</span>
+        <div className="flex justify-end mb-4">
+          <input
+            type="text"
+            placeholder="Cari pengguna..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="px-3 py-2 border rounded-lg text-sm shadow focus:outline-none focus:ring-2 focus:ring-blue-300"
+          />
+        </div>
+        <div className="overflow-x-auto rounded-xl border">
+          <table className="min-w-full text-sm">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="py-2 px-2 text-left">Nama</th>
+                <th className="py-2 px-2 text-left">Username</th>
+                <th className="py-2 px-2 text-left">Divisi</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.map((u, idx) => (
+                <tr key={idx} className="border-t">
+                  <td className="py-1 px-2">{u.nama || "-"}</td>
+                  <td className="py-1 px-2 font-mono text-blue-700">@{u.username}</td>
+                  <td className="py-1 px-2">{u.divisi || "-"}</td>
+                </tr>
+              ))}
+              {filtered.length === 0 && (
+                <tr>
+                  <td colSpan="3" className="py-4 text-center text-gray-500">
+                    Tidak ada pengguna
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
         </div>
       </div>
     </div>

--- a/cicero-dashboard/utils/api.js
+++ b/cicero-dashboard/utils/api.js
@@ -49,3 +49,17 @@ export async function getClientProfile(token, client_id) {
   if (!res.ok) throw new Error("Gagal fetch profile client");
   return res.json();
 }
+
+// Ambil daftar user untuk User Directory
+export async function getUserDirectory(token) {
+  const url = `${API_BASE_URL}/api/users/list`;
+
+  const res = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+  });
+  if (!res.ok) throw new Error("Gagal fetch daftar user");
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- fetch user directory data from Cicero API
- implement user directory UI with search/filter table

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848d16cf83c8327b75ca89bcb46da51