### PR TITLE
Fix TikTok post count extraction

### DIFF
--- a/cicero-dashboard/app/comments/tiktok/page.jsx
+++ b/cicero-dashboard/app/comments/tiktok/page.jsx
@@ -53,7 +53,12 @@ export default function TiktokKomentarTrackingPage() {
 
         // Rekap summary
         const totalUser = users.length;
-        const totalTiktokPost = statsRes.data?.tiktokPosts || statsRes.tiktokPosts || 0;
+        const totalTiktokPost =
+          statsRes.data?.tiktok_posts ||
+          statsRes.tiktok_posts ||
+          statsRes.data?.tiktokPosts ||
+          statsRes.tiktokPosts ||
+          0;
         const isZeroPost = (totalTiktokPost || 0) === 0;
         const totalSudahKomentar = isZeroPost
           ? 0

--- a/cicero-dashboard/app/comments/tiktok/rekap/page.jsx
+++ b/cicero-dashboard/app/comments/tiktok/rekap/page.jsx
@@ -45,7 +45,12 @@ export default function RekapKomentarTiktokPage() {
         const users = Array.isArray(rekapRes.data) ? rekapRes.data : [];
 
         // Sumber utama TikTok Post Hari Ini dari statsRes
-        const totalTiktokPost = statsRes.data?.tiktokPosts || statsRes.tiktokPosts || 0;
+        const totalTiktokPost =
+          statsRes.data?.tiktok_posts ||
+          statsRes.tiktok_posts ||
+          statsRes.data?.tiktokPosts ||
+          statsRes.tiktokPosts ||
+          0;
         const isZeroPost = (totalTiktokPost || 0) === 0;
         const totalUser = users.length;
         const totalSudahKomentar = isZeroPost


### PR DESCRIPTION
## Summary
- check for both camelCase and snake_case fields when deriving TikTok post counts

## Testing
- `npm run lint` *(fails: requires interactive config)*

------
https://chatgpt.com/codex/tasks/task_e_68493184b64083279496edacf9fb3f90