### PR TITLE
Fix TikTok recap post count

### DIFF
--- a/cicero-dashboard/app/comments/tiktok/rekap/page.jsx
+++ b/cicero-dashboard/app/comments/tiktok/rekap/page.jsx
@@ -31,9 +31,11 @@ export default function RekapKomentarTiktokPage() {
     async function fetchData() {
       try {
         const statsRes = await getDashboardStats(token);
+        const statsData = statsRes.data || statsRes;
+
         const client_id =
-          statsRes.data?.client_id ||
-          statsRes.client_id ||
+          statsData?.client_id ||
+          statsData.client_id ||
           localStorage.getItem("client_id");
         if (!client_id) {
           setError("Client ID tidak ditemukan.");
@@ -46,10 +48,10 @@ export default function RekapKomentarTiktokPage() {
 
         // Sumber utama TikTok Post Hari Ini dari statsRes
         const totalTiktokPost =
-          statsRes.data?.tiktok_posts ||
-          statsRes.tiktok_posts ||
-          statsRes.data?.tiktokPosts ||
-          statsRes.tiktokPosts ||
+          statsData?.ttPosts ||
+          statsData?.tiktokPosts ||
+          statsData.ttPosts ||
+          statsData.tiktokPosts ||
           0;
         const isZeroPost = (totalTiktokPost || 0) === 0;
         const totalUser = users.length;


### PR DESCRIPTION
## Summary
- align TikTok recap page with updated dashboard stats fields

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6849363a0d3c832795e887f4642268f9