### PR TITLE
Modify content manager to show Instagram posts

### DIFF
--- a/cicero-dashboard/app/content/page.jsx
+++ b/cicero-dashboard/app/content/page.jsx
@@ -1,12 +1,12 @@
 "use client";
 import { useEffect, useState } from "react";
-import SocialMediaContentTable from "@/components/SocialMediaContentTable";
+import InstagramPostAnalysisTable from "@/components/InstagramPostAnalysisTable";
 import Loader from "@/components/Loader";
-import { getInstagramPosts, getTiktokPosts } from "@/utils/api";
+import { getClientProfile } from "@/utils/api";
+import { dummyInstagramPosts } from "@/utils/dummyClientInsta";
 
 export default function SocialMediaContentManagerPage() {
   const [igPosts, setIgPosts] = useState([]);
-  const [tiktokPosts, setTiktokPosts] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
 
@@ -24,13 +24,8 @@ export default function SocialMediaContentManagerPage() {
 
     async function fetchPosts() {
       try {
-        const igRes = await getInstagramPosts(token, client_id);
-        const igData = igRes.data || igRes.posts || igRes;
-        setIgPosts(Array.isArray(igData) ? igData : []);
-
-        const ttRes = await getTiktokPosts(token, client_id);
-        const ttData = ttRes.data || ttRes.posts || ttRes;
-        setTiktokPosts(Array.isArray(ttData) ? ttData : []);
+        await getClientProfile(token, client_id);
+        setIgPosts(dummyInstagramPosts);
       } catch (err) {
         setError("Gagal mengambil data: " + (err.message || err));
       } finally {
@@ -54,14 +49,11 @@ export default function SocialMediaContentManagerPage() {
   return (
     <div className="min-h-screen bg-gray-100 flex flex-col items-center py-12">
       <div className="w-full max-w-5xl flex flex-col gap-6">
-        <h1 className="text-2xl font-bold text-blue-700">Social Media Content Manager</h1>
+        <h1 className="text-2xl font-bold text-blue-700">Instagram Content Manager</h1>
         <p className="text-gray-600">
-          Manage and schedule posts for Instagram and TikTok in one place.
+          Analisa performa dan jadwalkan konten Instagram Anda.
         </p>
-        <div className="flex flex-col md:flex-row gap-6">
-          <SocialMediaContentTable platform="Instagram" initialPosts={igPosts} />
-          <SocialMediaContentTable platform="TikTok" initialPosts={tiktokPosts} />
-        </div>
+        <InstagramPostAnalysisTable posts={igPosts} />
       </div>
     </div>
   );

--- a/cicero-dashboard/components/InstagramPostAnalysisTable.jsx
+++ b/cicero-dashboard/components/InstagramPostAnalysisTable.jsx
@@ -1,0 +1,41 @@
+"use client";
+
+export default function InstagramPostAnalysisTable({ posts = [] }) {
+  return (
+    <div className="overflow-x-auto rounded-xl border">
+      <table className="min-w-full text-sm">
+        <thead className="bg-gray-50">
+          <tr>
+            <th className="py-2 px-2 text-left">Caption</th>
+            <th className="py-2 px-2 text-left">Tanggal</th>
+            <th className="py-2 px-2 text-left">Likes</th>
+            <th className="py-2 px-2 text-left">Komentar</th>
+            <th className="py-2 px-2 text-left">Reach</th>
+            <th className="py-2 px-2 text-left">Impresi</th>
+            <th className="py-2 px-2 text-left">Engagement %</th>
+          </tr>
+        </thead>
+        <tbody>
+          {posts.map((p, idx) => (
+            <tr key={idx} className="border-t">
+              <td className="py-1 px-2 break-words">{p.caption}</td>
+              <td className="py-1 px-2">{p.date}</td>
+              <td className="py-1 px-2">{p.likes}</td>
+              <td className="py-1 px-2">{p.comments}</td>
+              <td className="py-1 px-2">{p.reach}</td>
+              <td className="py-1 px-2">{p.impressions}</td>
+              <td className="py-1 px-2">{p.engagementRate}</td>
+            </tr>
+          ))}
+          {posts.length === 0 && (
+            <tr>
+              <td colSpan="7" className="py-4 text-center text-gray-500">
+                Tidak ada data post Instagram
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/cicero-dashboard/utils/dummyClientInsta.js
+++ b/cicero-dashboard/utils/dummyClientInsta.js
@@ -1,0 +1,32 @@
+export const dummyInstagramPosts = [
+  {
+    id: 1,
+    caption: "Promo Kemerdekaan 45%",
+    date: "2023-08-17",
+    likes: 150,
+    comments: 20,
+    reach: 1000,
+    impressions: 1200,
+    engagementRate: 15,
+  },
+  {
+    id: 2,
+    caption: "Behind the scenes pembuatan produk",
+    date: "2023-08-19",
+    likes: 200,
+    comments: 35,
+    reach: 1500,
+    impressions: 1800,
+    engagementRate: 15.7,
+  },
+  {
+    id: 3,
+    caption: "Testimoni pelanggan minggu ini",
+    date: "2023-08-20",
+    likes: 180,
+    comments: 25,
+    reach: 1300,
+    impressions: 1600,
+    engagementRate: 15.8,
+  },
+];


### PR DESCRIPTION
## Summary
- create dummy dataset for Instagram posts
- show post analytics in new `InstagramPostAnalysisTable`
- update content manager page to use the dummy data and display only Instagram posts

## Testing
- `npm install --legacy-peer-deps` *(fails: dependency conflicts)*
- `npm run lint` *(failed: prompts for ESLint config)*


------
https://chatgpt.com/codex/tasks/task_e_68493b6ea45c8327b9245dd31906c41c