### PR TITLE
Fix TikTok recap charts

### DIFF
--- a/cicero-dashboard/app/comments/tiktok/page.jsx
+++ b/cicero-dashboard/app/comments/tiktok/page.jsx
@@ -212,8 +212,11 @@ export default function TiktokKomentarTrackingPage() {
               <ChartHorizontal
                 title="POLSEK"
                 users={kelompok.POLSEK}
-                totalTiktokPost={rekapSummary.totalTiktokPost}
+                totalPost={rekapSummary.totalTiktokPost}
                 fieldJumlah="jumlah_komentar"
+                labelSudah="User Sudah Komentar"
+                labelBelum="User Belum Komentar"
+                labelTotal="Total Komentar"
               />
             </div>
 
@@ -262,8 +265,11 @@ function ChartBox({
           users={users}
           title={title}
           orientation={orientation}
-          totalTiktokPost={totalTiktokPost}
+          totalPost={totalTiktokPost}
           fieldJumlah={fieldJumlah}
+          labelSudah="User Sudah Komentar"
+          labelBelum="User Belum Komentar"
+          labelTotal="Total Komentar"
         />
       ) : (
         <div className="text-center text-gray-400 text-sm">Tidak ada data</div>

--- a/cicero-dashboard/components/ChartHorizontal.jsx
+++ b/cicero-dashboard/components/ChartHorizontal.jsx
@@ -15,33 +15,45 @@ function isException(val) {
   return val === true || val === "true" || val === 1 || val === "1";
 }
 function bersihkanSatfung(divisi = "") {
-  return divisi.replace(/polsek\s*/i, "").trim();
+  return divisi
+    .replace(/polsek\s*/i, "")
+    .replace(/^[0-9.\-\s]+/, "")
+    .trim();
 }
 
 export default function ChartHorizontal({
   users,
   title = "POLSEK - Absensi Likes",
-  totalIGPost = 1, // ← tambahkan prop ini, default 1 agar chart tetap jalan jika tidak dikirim
+  totalPost = 1,
+  totalIGPost,
+  fieldJumlah = "jumlah_like",
+  labelSudah = "User Sudah Like",
+  labelBelum = "User Belum Like",
+  labelTotal = "Total Likes",
 }) {
-  // Jika IG POST 0, semua user masuk belum (termasuk exception)
-  const isZeroPost = (totalIGPost || 0) === 0;
+  const effectiveTotal =
+    typeof totalPost !== "undefined" ? totalPost : totalIGPost;
+
+  // Jika tidak ada post, semua user masuk belum (termasuk exception)
+  const isZeroPost = (effectiveTotal || 0) === 0;
 
   // Matrix 3 metrik per polsek
   const divisiMap = {};
-  users.forEach(u => {
+  users.forEach((u) => {
     const key = bersihkanSatfung(u.divisi || "LAINNYA");
-    // Logic: sudahLike hanya berlaku kalau IG Post > 0
-    const sudahLike = !isZeroPost && (Number(u.jumlah_like) > 0 || isException(u.exception));
+    // Logic: sudahLike hanya berlaku kalau ada post
+    const sudah =
+      !isZeroPost && (Number(u[fieldJumlah]) > 0 || isException(u.exception));
     if (!divisiMap[key])
       divisiMap[key] = {
         divisi: key,
         user_sudah: 0,
         user_belum: 0,
-        total_like: 0,
+        total_value: 0,
       };
-    if (sudahLike) {
+    if (sudah) {
       divisiMap[key].user_sudah += 1;
-      divisiMap[key].total_like += Number(u.jumlah_like || 0);
+      divisiMap[key].total_value += Number(u[fieldJumlah] || 0);
     } else {
       divisiMap[key].user_belum += 1;
     }
@@ -90,21 +102,25 @@ export default function ChartHorizontal({
               formatter={(value, name) =>
                 [
                   value,
-                  name === "user_sudah" ? "User Sudah Like"
-                  : name === "user_belum" ? "User Belum Like"
-                  : name === "total_like" ? "Total Likes" : name,
+                  name === "user_sudah"
+                    ? labelSudah
+                    : name === "user_belum"
+                    ? labelBelum
+                    : name === "total_value"
+                    ? labelTotal
+                    : name,
                 ]
               }
               labelFormatter={label => `Divisi: ${label}`}
             />
             <Legend />
-            <Bar dataKey="user_sudah" fill="#22c55e" name="User Sudah Like" barSize={10}>
+            <Bar dataKey="user_sudah" fill="#22c55e" name={labelSudah} barSize={10}>
               <LabelList dataKey="user_sudah" position="right" fontSize={10} />
             </Bar>
-            <Bar dataKey="total_like" fill="#2563eb" name="Total Likes" barSize={10}>
-              <LabelList dataKey="total_like" position="right" fontSize={10} />
+            <Bar dataKey="total_value" fill="#2563eb" name={labelTotal} barSize={10}>
+              <LabelList dataKey="total_value" position="right" fontSize={10} />
             </Bar>
-            <Bar dataKey="user_belum" fill="#ef4444" name="User Belum Like" barSize={10}>
+            <Bar dataKey="user_belum" fill="#ef4444" name={labelBelum} barSize={10}>
               <LabelList dataKey="user_belum" position="right" fontSize={10} />
             </Bar>
           </BarChart>

--- a/cicero-dashboard/components/RekapKomentarTiktok.jsx
+++ b/cicero-dashboard/components/RekapKomentarTiktok.jsx
@@ -5,6 +5,13 @@ function isException(val) {
   return val === true || val === "true" || val === 1 || val === "1";
 }
 
+function bersihkanSatfung(divisi = "") {
+  return divisi
+    .replace(/polsek\s*/i, "")
+    .replace(/^[0-9.\-\s]+/, "")
+    .trim();
+}
+
 const PAGE_SIZE = 25;
 
 export default function RekapKomentarTiktok({ users = [], totalTiktokPost = 0 }) {
@@ -31,7 +38,7 @@ export default function RekapKomentarTiktok({ users = [], totalTiktokPost = 0 })
       users.filter(u =>
         (u.nama || "").toLowerCase().includes(search.toLowerCase()) ||
         (u.username || "").toLowerCase().includes(search.toLowerCase()) ||
-        (u.divisi || "").toLowerCase().includes(search.toLowerCase())
+        bersihkanSatfung(u.divisi || "").toLowerCase().includes(search.toLowerCase())
       ),
     [users, search]
   );
@@ -129,7 +136,7 @@ export default function RekapKomentarTiktok({ users = [], totalTiktokPost = 0 })
                   <td className="py-1 px-2">{(page - 1) * PAGE_SIZE + i + 1}</td>
                   <td className="py-1 px-2">{u.title ? `${u.title} ${u.nama}` : u.nama}</td>
                   <td className="py-1 px-2 font-mono text-pink-700">{u.username}</td>
-                  <td className="py-1 px-2"><span className="inline-block px-2 py-0.5 rounded bg-sky-100 text-sky-800 font-medium">{u.divisi || "-"}</span></td>
+                  <td className="py-1 px-2"><span className="inline-block px-2 py-0.5 rounded bg-sky-100 text-sky-800 font-medium">{bersihkanSatfung(u.divisi || "-")}</span></td>
                   <td className="py-1 px-2 text-center">
                     {sudahKomentar ? (
                       <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs bg-green-500 text-white font-semibold">


### PR DESCRIPTION
## Summary
- support generic totals and value fields in chart components
- show TikTok comment stats correctly in ChartBox
- strip numeric prefixes from satfung names so chart labels are readable

## Testing
- `npm install` *(fails: unable to resolve dependency tree)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68494faa8e608327808b2120db729818