### PR TITLE
Update content page to use backend posts endpoint

### DIFF
--- a/cicero-dashboard/.env.example
+++ b/cicero-dashboard/.env.example
@@ -1,0 +1,2 @@
+# Optional fallback username if client data has no Instagram handle
+NEXT_PUBLIC_INSTAGRAM_USER=instagram

--- a/cicero-dashboard/app/content/page.jsx
+++ b/cicero-dashboard/app/content/page.jsx
@@ -1,36 +1,38 @@
 "use client";
 import { useEffect, useState } from "react";
-import SocialMediaContentTable from "@/components/SocialMediaContentTable";
+import InstagramPostsGrid from "@/components/InstagramPostsGrid";
 import Loader from "@/components/Loader";
-import { getInstagramPosts, getTiktokPosts } from "@/utils/api";
+import { getInstagramPostsViaBackend, getClientProfile } from "@/utils/api";
 
 export default function SocialMediaContentManagerPage() {
   const [igPosts, setIgPosts] = useState([]);
-  const [tiktokPosts, setTiktokPosts] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
 
   useEffect(() => {
-    const token =
-      typeof window !== "undefined" ? localStorage.getItem("cicero_token") : null;
-    const client_id =
-      typeof window !== "undefined" ? localStorage.getItem("client_id") : null;
-
-    if (!token || !client_id) {
-      setError("Token / Client ID tidak ditemukan. Silakan login ulang.");
-      setLoading(false);
-      return;
-    }
-
     async function fetchPosts() {
       try {
-        const igRes = await getInstagramPosts(token, client_id);
+        const token =
+          typeof window !== "undefined" ? localStorage.getItem("cicero_token") : null;
+        const clientId =
+          typeof window !== "undefined" ? localStorage.getItem("client_id") : null;
+
+        if (!token || !clientId) {
+          setError("Token / Client ID tidak ditemukan. Silakan login ulang.");
+          setLoading(false);
+          return;
+        }
+
+        const profile = await getClientProfile(token, clientId);
+        const username =
+          profile.client?.client_insta?.replace(/^@/, "") ||
+          profile.client_insta?.replace(/^@/, "") ||
+          process.env.NEXT_PUBLIC_INSTAGRAM_USER ||
+          "instagram";
+
+        const igRes = await getInstagramPostsViaBackend(token, username, 12);
         const igData = igRes.data || igRes.posts || igRes;
         setIgPosts(Array.isArray(igData) ? igData : []);
-
-        const ttRes = await getTiktokPosts(token, client_id);
-        const ttData = ttRes.data || ttRes.posts || ttRes;
-        setTiktokPosts(Array.isArray(ttData) ? ttData : []);
       } catch (err) {
         setError("Gagal mengambil data: " + (err.message || err));
       } finally {
@@ -55,13 +57,8 @@ export default function SocialMediaContentManagerPage() {
     <div className="min-h-screen bg-gray-100 flex flex-col items-center py-12">
       <div className="w-full max-w-5xl flex flex-col gap-6">
         <h1 className="text-2xl font-bold text-blue-700">Social Media Content Manager</h1>
-        <p className="text-gray-600">
-          Manage and schedule posts for Instagram and TikTok in one place.
-        </p>
-        <div className="flex flex-col md:flex-row gap-6">
-          <SocialMediaContentTable platform="Instagram" initialPosts={igPosts} />
-          <SocialMediaContentTable platform="TikTok" initialPosts={tiktokPosts} />
-        </div>
+        <p className="text-gray-600">Kumpulan posting Instagram terbaru.</p>
+        <InstagramPostsGrid posts={igPosts} />
       </div>
     </div>
   );

--- a/cicero-dashboard/components/InstagramPostsGrid.jsx
+++ b/cicero-dashboard/components/InstagramPostsGrid.jsx
@@ -1,0 +1,35 @@
+"use client";
+export default function InstagramPostsGrid({ posts = [] }) {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+      {posts.map((post) => (
+        <div
+          key={post.id || post.post_id}
+          className="bg-white rounded-lg shadow border overflow-hidden"
+        >
+          {post.thumbnail && (
+            <img
+              src={post.thumbnail}
+              alt={post.caption || "thumbnail"}
+              className="w-full h-48 object-cover"
+            />
+          )}
+          <div className="p-4 flex flex-col gap-2">
+            <p className="font-semibold text-sm break-words">
+              {post.caption || "-"}
+            </p>
+            <div className="text-xs text-gray-600 flex gap-4">
+              {post.like_count != null && <span>❤️ {post.like_count}</span>}
+              {post.comment_count != null && <span>💬 {post.comment_count}</span>}
+            </div>
+          </div>
+        </div>
+      ))}
+      {posts.length === 0 && (
+        <div className="col-span-full text-center text-gray-500">
+          No posts available
+        </div>
+      )}
+    </div>
+  );
+}

--- a/cicero-dashboard/utils/api.js
+++ b/cicero-dashboard/utils/api.js
@@ -107,6 +107,23 @@ export async function getInstagramPosts(token, client_id) {
   return res.json();
 }
 
+// Fetch Instagram posts via backend using username (backend handles RapidAPI call)
+export async function getInstagramPostsViaBackend(token, username, limit = 10) {
+  const params = new URLSearchParams({ username, limit });
+  const url = `${API_BASE_URL}/api/insta/rapid-posts?${params.toString()}`;
+  const res = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Failed to fetch instagram posts: ${text}`);
+  }
+  return res.json();
+}
+
 export async function getTiktokPosts(token, client_id) {
   const params = new URLSearchParams({ client_id });
   const url = `${API_BASE_URL}/api/tiktok/posts?${params.toString()}`;
@@ -119,3 +136,4 @@ export async function getTiktokPosts(token, client_id) {
   if (!res.ok) throw new Error("Failed to fetch tiktok posts");
   return res.json();
 }
+


### PR DESCRIPTION
## Summary
- trim `.env.example` to only document optional Instagram username fallback
- implement `getInstagramPostsViaBackend` to use API server for RapidAPI posts
- update Social Media Content Manager page to fetch posts from backend

## Testing
- `npm run lint` *(fails: next not found)*
- `npm install` *(fails: dependency conflict)*

------
https://chatgpt.com/codex/tasks/task_e_684977aa07288327811bcdc0c1dcfa73