### PR TITLE
Add backend data fetch for content manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,25 @@ NEXT_PUBLIC_API_URL=<backend base url>
 
 For more information about Next.js features, refer to the documentation inside `cicero-dashboard/README.md`.
 
+
+## Content Manager API
+
+The Social Media Content Manager page retrieves Instagram analytics from the backend. Data is fetched via `getInstagramProfileViaBackend` and `getInstagramPostsViaBackend` in `cicero-dashboard/utils/api.js`.
+
+### Profile Fields
+- `username`
+- `followers`
+- `following`
+- `bio`
+
+### Post Fields
+- `id`
+- `created_at`
+- `type`
+- `caption`
+- `like_count`
+- `comment_count`
+- `share_count`
+- `thumbnail` (optional)
+
+These fields are provided by the backend endpoints `/api/insta/rapid-profile` and `/api/insta/rapid-posts`.

--- a/cicero-dashboard/app/content/page.jsx
+++ b/cicero-dashboard/app/content/page.jsx
@@ -1,90 +1,15 @@
 "use client";
+import { useEffect, useState } from "react";
 import CardStat from "@/components/CardStat";
 import EngagementLineChart from "@/components/EngagementLineChart";
 import EngagementByTypeChart from "@/components/EngagementByTypeChart";
 import HeatmapTable from "@/components/HeatmapTable";
-
-const profile = {
-  username: "john_doe",
-  followers: 1500,
-  following: 300,
-  bio: "Travel enthusiast and foodie",
-};
-
-const posts = [
-  {
-    id: 1,
-    created_at: "2024-06-01T08:00:00Z",
-    type: "image",
-    caption: "Exploring mountains #adventure @buddy",
-    like_count: 200,
-    comment_count: 20,
-    share_count: 5,
-  },
-  {
-    id: 2,
-    created_at: "2024-06-03T12:00:00Z",
-    type: "video",
-    caption: "Delicious food #foodie",
-    like_count: 150,
-    comment_count: 25,
-    share_count: 8,
-  },
-  {
-    id: 3,
-    created_at: "2024-06-05T18:30:00Z",
-    type: "carousel",
-    caption: "Sunset view #travel #sunset",
-    like_count: 300,
-    comment_count: 30,
-    share_count: 12,
-  },
-  {
-    id: 4,
-    created_at: "2024-06-06T09:15:00Z",
-    type: "image",
-    caption: "Morning vibes #coffee @cafe",
-    like_count: 180,
-    comment_count: 15,
-    share_count: 3,
-  },
-  {
-    id: 5,
-    created_at: "2024-06-07T20:45:00Z",
-    type: "video",
-    caption: "Night walk #citylife",
-    like_count: 220,
-    comment_count: 28,
-    share_count: 6,
-  },
-  {
-    id: 6,
-    created_at: "2024-06-09T14:20:00Z",
-    type: "image",
-    caption: "Beach day #vacation #sun",
-    like_count: 260,
-    comment_count: 18,
-    share_count: 10,
-  },
-  {
-    id: 7,
-    created_at: "2024-06-10T11:00:00Z",
-    type: "carousel",
-    caption: "Weekend trip #travel @friend",
-    like_count: 240,
-    comment_count: 22,
-    share_count: 7,
-  },
-  {
-    id: 8,
-    created_at: "2024-06-11T15:30:00Z",
-    type: "video",
-    caption: "Cooking time #foodie @chef",
-    like_count: 210,
-    comment_count: 26,
-    share_count: 9,
-  },
-];
+import Loader from "@/components/Loader";
+import {
+  getInstagramProfileViaBackend,
+  getInstagramPostsViaBackend,
+  getClientProfile,
+} from "@/utils/api";
 
 function analyzeSentiment(text) {
   const positive = ["love", "great", "happy", "enjoy", "good", "nice"];
@@ -101,17 +26,73 @@ function analyzeSentiment(text) {
 }
 
 export default function SocialMediaContentManagerPage() {
-  const followerRatio = (profile.followers / profile.following).toFixed(2);
+  const [profile, setProfile] = useState(null);
+  const [posts, setPosts] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    const token =
+      typeof window !== "undefined" ? localStorage.getItem("cicero_token") : null;
+    const clientId =
+      typeof window !== "undefined" ? localStorage.getItem("client_id") : null;
+
+    if (!token || !clientId) {
+      setError("Token / Client ID tidak ditemukan. Silakan login ulang.");
+      setLoading(false);
+      return;
+    }
+
+    async function fetchData() {
+      try {
+        const clientProfile = await getClientProfile(token, clientId);
+        const username =
+          clientProfile.client?.client_insta?.replace(/^@/, "") ||
+          clientProfile.client_insta?.replace(/^@/, "") ||
+          process.env.NEXT_PUBLIC_INSTAGRAM_USER ||
+          "instagram";
+
+        const profileRes = await getInstagramProfileViaBackend(token, username);
+        setProfile(profileRes.data || profileRes.profile || profileRes);
+
+        const postRes = await getInstagramPostsViaBackend(token, username, 50);
+        const postData = postRes.data || postRes.posts || postRes;
+        setPosts(Array.isArray(postData) ? postData : []);
+      } catch (err) {
+        setError("Gagal mengambil data: " + (err.message || err));
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    fetchData();
+  }, []);
+
+  if (loading) return <Loader />;
+  if (error)
+    return (
+      <div className="flex items-center justify-center min-h-screen bg-gray-100">
+        <div className="bg-white rounded-lg shadow-md p-6 text-red-500 font-bold">
+          {error}
+        </div>
+      </div>
+    );
+  if (!profile) return null;
 
   const sortedPosts = [...posts].sort(
     (a, b) => new Date(a.created_at) - new Date(b.created_at)
   );
-
-  const firstDate = new Date(sortedPosts[0].created_at);
-  const lastDate = new Date(sortedPosts[sortedPosts.length - 1].created_at);
-  const diffDays =
-    (lastDate - firstDate) / (1000 * 60 * 60 * 24) || 1;
+  const firstDate = sortedPosts.length
+    ? new Date(sortedPosts[0].created_at)
+    : new Date();
+  const lastDate = sortedPosts.length
+    ? new Date(sortedPosts[sortedPosts.length - 1].created_at)
+    : new Date();
+  const diffDays = (lastDate - firstDate) / (1000 * 60 * 60 * 24) || 1;
   const postingFreq = (sortedPosts.length / diffDays).toFixed(2);
+  const followerRatio = profile.followers
+    ? (profile.followers / profile.following).toFixed(2)
+    : "0";
 
   const hashtagMap = {};
   const mentionMap = {};
@@ -155,7 +136,7 @@ export default function SocialMediaContentManagerPage() {
     const bucket = buckets[Math.floor(d.getHours() / 6)];
     if (!heatmap[day]) heatmap[day] = {};
     if (!heatmap[day][bucket]) heatmap[day][bucket] = 0;
-    heatmap[day][bucket] += eng / 10; // scale for color
+    heatmap[day][bucket] += eng / 10;
   });
 
   const typeData = Object.entries(typeMap).map(([type, v]) => ({
@@ -179,10 +160,8 @@ export default function SocialMediaContentManagerPage() {
   return (
     <div className="min-h-screen bg-gray-100 flex flex-col items-center py-8">
       <div className="w-full max-w-5xl flex flex-col gap-8">
-        <h1 className="text-2xl font-bold text-blue-700">
-          Social Media Content Manager
-        </h1>
-        <p className="text-gray-600">Analisis konten menggunakan data dummy.</p>
+        <h1 className="text-2xl font-bold text-blue-700">Social Media Content Manager</h1>
+        <p className="text-gray-600">Analisis konten berdasarkan data terbaru.</p>
 
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
           <CardStat title="Followers" value={profile.followers} />

--- a/cicero-dashboard/utils/api.js
+++ b/cicero-dashboard/utils/api.js
@@ -124,6 +124,23 @@ export async function getInstagramPostsViaBackend(token, username, limit = 10) {
   return res.json();
 }
 
+// Fetch Instagram profile via backend using username
+export async function getInstagramProfileViaBackend(token, username) {
+  const params = new URLSearchParams({ username });
+  const url = `${API_BASE_URL}/api/insta/rapid-profile?${params.toString()}`;
+  const res = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Failed to fetch instagram profile: ${text}`);
+  }
+  return res.json();
+}
+
 export async function getTiktokPosts(token, client_id) {
   const params = new URLSearchParams({ client_id });
   const url = `${API_BASE_URL}/api/tiktok/posts?${params.toString()}`;


### PR DESCRIPTION
## Summary
- add API helper for Instagram profile
- fetch real Instagram posts and profile on Social Media Content Manager page
- document required backend data for the content manager

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849879f34f88327b0c2593930fae0a1