### PR TITLE
Add post thumbnail and metrics chart

### DIFF
--- a/cicero-dashboard/app/content/page.jsx
+++ b/cicero-dashboard/app/content/page.jsx
@@ -4,6 +4,7 @@ import CardStat from "@/components/CardStat";
 import EngagementLineChart from "@/components/EngagementLineChart";
 import EngagementByTypeChart from "@/components/EngagementByTypeChart";
 import HeatmapTable from "@/components/HeatmapTable";
+import PostMetricsChart from "@/components/PostMetricsChart";
 import Loader from "@/components/Loader";
 import {
   getInstagramProfileViaBackend,
@@ -100,6 +101,7 @@ export default function SocialMediaContentManagerPage() {
   const typeMap = {};
   const heatmap = {};
   const sentimentCount = { Positive: 0, Neutral: 0, Negative: 0 };
+  const postCompareData = [];
   const buckets = ["0-5", "6-11", "12-17", "18-23"];
   const dayNames = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 
@@ -113,6 +115,13 @@ export default function SocialMediaContentManagerPage() {
         day: "numeric",
       }),
       rate: parseFloat(eng.toFixed(2)),
+    });
+
+    postCompareData.push({
+      created_at: p.created_at,
+      like_count: p.like_count || 0,
+      comment_count: p.comment_count || 0,
+      share_count: p.share_count || 0,
     });
 
     if (!typeMap[p.type]) typeMap[p.type] = { total: 0, count: 0 };
@@ -156,6 +165,10 @@ export default function SocialMediaContentManagerPage() {
     { user: "@friend", interactions: 3 },
     { user: "@chef", interactions: 2 },
   ];
+
+  const postChartData = postCompareData.sort(
+    (a, b) => new Date(a.created_at) - new Date(b.created_at)
+  );
 
   return (
     <div className="min-h-screen bg-gray-100 flex flex-col items-center py-8">
@@ -220,6 +233,10 @@ export default function SocialMediaContentManagerPage() {
               <li key={n.user}>{n.user} - {n.interactions} interactions</li>
             ))}
           </ul>
+        </div>
+        <div className="bg-white p-4 rounded-xl shadow">
+          <h3 className="font-semibold mb-2">Post Metrics Comparison</h3>
+          <PostMetricsChart posts={postChartData} />
         </div>
       </div>
     </div>

--- a/cicero-dashboard/app/info/instagram/page.jsx
+++ b/cicero-dashboard/app/info/instagram/page.jsx
@@ -75,6 +75,12 @@ export default function InstagramInfoPage() {
     { title: "Account Type", value: info?.account_type || "-" },
   ];
 
+  const sortedPosts = [...posts].sort(
+    (a, b) => new Date(b.created_at) - new Date(a.created_at)
+  );
+  const latestPost = sortedPosts[0];
+  const otherPosts = sortedPosts.slice(1);
+
   return (
     <div className="min-h-screen bg-gray-100 flex flex-col items-center py-8">
       <div className="w-full max-w-4xl flex flex-col gap-8">
@@ -84,9 +90,22 @@ export default function InstagramInfoPage() {
             <CardStat key={s.title} title={s.title} value={s.value ?? "-"} />
           ))}
         </div>
+        {latestPost && (
+          <div className="bg-white p-4 rounded-xl shadow">
+            <h2 className="font-semibold mb-2">Latest Post</h2>
+            {latestPost.thumbnail && (
+              <img
+                src={latestPost.thumbnail}
+                alt={latestPost.caption || "thumbnail"}
+                className="w-full max-h-64 object-cover rounded"
+              />
+            )}
+            <p className="mt-2 text-sm">{latestPost.caption || "-"}</p>
+          </div>
+        )}
         <div className="bg-white p-4 rounded-xl shadow">
-          <h2 className="font-semibold mb-2">Latest Posts</h2>
-          <InstagramPostsGrid posts={posts} />
+          <h2 className="font-semibold mb-2">Other Recent Posts</h2>
+          <InstagramPostsGrid posts={otherPosts} />
         </div>
         <div className="bg-white p-4 rounded-xl shadow overflow-x-auto text-sm">
           <h2 className="font-semibold mb-2">Raw Info</h2>

--- a/cicero-dashboard/components/PostMetricsChart.jsx
+++ b/cicero-dashboard/components/PostMetricsChart.jsx
@@ -1,0 +1,47 @@
+"use client";
+import { Bar } from "react-chartjs-2";
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Tooltip,
+  Legend,
+} from "chart.js";
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend);
+
+export default function PostMetricsChart({ posts = [] }) {
+  const chartData = {
+    labels: posts.map((p) =>
+      new Date(p.created_at).toLocaleDateString("en-US", {
+        month: "short",
+        day: "numeric",
+      })
+    ),
+    datasets: [
+      {
+        label: "Likes",
+        data: posts.map((p) => p.like_count || 0),
+        backgroundColor: "rgba(37,99,235,0.6)",
+      },
+      {
+        label: "Comments",
+        data: posts.map((p) => p.comment_count || 0),
+        backgroundColor: "rgba(16,185,129,0.6)",
+      },
+      {
+        label: "Shares",
+        data: posts.map((p) => p.share_count || 0),
+        backgroundColor: "rgba(234,88,12,0.6)",
+      },
+    ],
+  };
+
+  const options = {
+    responsive: true,
+    scales: { y: { beginAtZero: true } },
+  };
+
+  return <Bar data={chartData} options={options} />;
+}


### PR DESCRIPTION
## Summary
- show bigger thumbnail for latest post on Instagram Info page
- add `PostMetricsChart` for comparing likes, comments and shares
- display post metrics chart on Social Media Content Manager

## Testing
- `npm run lint` *(fails: next not found)*
- `npm install` *(fails: dependency conflict)*

------
https://chatgpt.com/codex/tasks/task_e_684a2384980083279618b8a2a1062fec