### PR TITLE
Add narratives to visualize data

### DIFF
--- a/cicero-dashboard/app/comments/tiktok/page.jsx
+++ b/cicero-dashboard/app/comments/tiktok/page.jsx
@@ -6,6 +6,7 @@ import ChartDivisiAbsensi from "@/components/ChartDivisiAbsensi";
 import ChartHorizontal from "@/components/ChartHorizontal";
 import { groupUsersByKelompok } from "@/utils/grouping";
 import Link from "next/link";
+import Narrative from "@/components/Narrative";
 
 export default function TiktokKomentarTrackingPage() {
   const [chartData, setChartData] = useState([]);
@@ -196,18 +197,21 @@ export default function TiktokKomentarTrackingPage() {
                 users={kelompok.BAG}
                 totalTiktokPost={rekapSummary.totalTiktokPost}
                 fieldJumlah="jumlah_komentar"
+                narrative="Grafik ini menampilkan perbandingan jumlah komentar TikTok dari user di divisi BAG."
               />
               <ChartBox
                 title="SAT"
                 users={kelompok.SAT}
                 totalTiktokPost={rekapSummary.totalTiktokPost}
                 fieldJumlah="jumlah_komentar"
+                narrative="Grafik ini menampilkan perbandingan jumlah komentar TikTok dari user di divisi SAT."
               />
               <ChartBox
                 title="SI & SPKT"
                 users={kelompok["SI & SPKT"]}
                 totalTiktokPost={rekapSummary.totalTiktokPost}
                 fieldJumlah="jumlah_komentar"
+                narrative="Grafik ini menampilkan perbandingan jumlah komentar TikTok dari user di divisi SI & SPKT."
               />
               <ChartHorizontal
                 title="POLSEK"
@@ -218,6 +222,10 @@ export default function TiktokKomentarTrackingPage() {
                 labelBelum="User Belum Komentar"
                 labelTotal="Total Komentar"
               />
+              <Narrative>
+                Grafik POLSEK menggambarkan distribusi komentar antar user dari
+                setiap polsek serta total komentar yang berhasil dikumpulkan.
+              </Narrative>
             </div>
 
             <div className="flex justify-end my-2">
@@ -250,12 +258,14 @@ export default function TiktokKomentarTrackingPage() {
 }
 
 // Komponen ChartBox di file yang sama
+
 function ChartBox({
   title,
   users,
   orientation = "vertical",
   totalTiktokPost,
   fieldJumlah,
+  narrative,
 }) {
   return (
     <div className="bg-white rounded-xl shadow p-4">
@@ -274,6 +284,7 @@ function ChartBox({
       ) : (
         <div className="text-center text-gray-400 text-sm">Tidak ada data</div>
       )}
+      {narrative && <Narrative>{narrative}</Narrative>}
     </div>
   );
 }

--- a/cicero-dashboard/app/likes/instagram/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/page.jsx
@@ -6,6 +6,7 @@ import ChartDivisiAbsensi from "@/components/ChartDivisiAbsensi";
 import ChartHorizontal from "@/components/ChartHorizontal";
 import { groupUsersByKelompok } from "@/utils/grouping"; // pastikan path benar
 import Link from "next/link";
+import Narrative from "@/components/Narrative";
 
 export default function InstagramLikesTrackingPage() {
   const [stats, setStats] = useState(null);
@@ -190,22 +191,29 @@ export default function InstagramLikesTrackingPage() {
                 title="BAG"
                 users={kelompok.BAG}
                 totalIGPost={rekapSummary.totalIGPost}
+                narrative="Grafik ini menunjukkan perbandingan jumlah like dari user di divisi BAG."
               />
               <ChartBox
                 title="SAT"
                 users={kelompok.SAT}
                 totalIGPost={rekapSummary.totalIGPost}
+                narrative="Grafik ini menunjukkan perbandingan jumlah like dari user di divisi SAT."
               />
               <ChartBox
                 title="SI & SPKT"
                 users={kelompok["SI & SPKT"]}
                 totalIGPost={rekapSummary.totalIGPost}
+                narrative="Grafik ini menunjukkan perbandingan jumlah like dari user di divisi SI & SPKT."
               />
               <ChartHorizontal
                 title="POLSEK"
                 users={kelompok.POLSEK}
                 totalIGPost={rekapSummary.totalIGPost}
               />
+              <Narrative>
+                Grafik POLSEK memperlihatkan jumlah like Instagram dari setiap
+                polsek dan membandingkan partisipasi pengguna.
+              </Narrative>
             </div>
 
             <div className="flex justify-end my-2">
@@ -238,7 +246,13 @@ export default function InstagramLikesTrackingPage() {
 }
 
 // Komponen ChartBox di file yang sama
-function ChartBox({ title, users, orientation = "vertical", totalIGPost }) {
+function ChartBox({
+  title,
+  users,
+  orientation = "vertical",
+  totalIGPost,
+  narrative,
+}) {
   return (
     <div className="bg-white rounded-xl shadow p-4">
       <div className="font-bold text-blue-700 mb-2 text-center">{title}</div>
@@ -252,6 +266,7 @@ function ChartBox({ title, users, orientation = "vertical", totalIGPost }) {
       ) : (
         <div className="text-center text-gray-400 text-sm">Tidak ada data</div>
       )}
+      {narrative && <Narrative>{narrative}</Narrative>}
     </div>
   );
 }

--- a/cicero-dashboard/components/Narrative.jsx
+++ b/cicero-dashboard/components/Narrative.jsx
@@ -1,0 +1,8 @@
+"use client";
+export default function Narrative({ children }) {
+  return (
+    <p className="mt-2 text-sm text-gray-500 italic leading-snug">
+      {children}
+    </p>
+  );
+}

--- a/cicero-dashboard/components/RekapKomentarTiktok.jsx
+++ b/cicero-dashboard/components/RekapKomentarTiktok.jsx
@@ -157,6 +157,10 @@ export default function RekapKomentarTiktok({ users = [], totalTiktokPost = 0 })
           </tbody>
         </table>
       </div>
+      <p className="mt-2 text-sm text-gray-500 italic">
+        Tabel ini merangkum status komentar TikTok setiap user dan total jumlah
+        komentar yang diberikan.
+      </p>
 
       {totalPages > 1 && (
         <div className="flex items-center justify-between mt-4">

--- a/cicero-dashboard/components/RekapLikesIG.jsx
+++ b/cicero-dashboard/components/RekapLikesIG.jsx
@@ -194,6 +194,10 @@ export default function RekapLikesIG({ users = [], totalIGPost = 0 }) {
           </tbody>
         </table>
       </div>
+      <p className="mt-2 text-sm text-gray-500 italic">
+        Tabel ini menampilkan status like Instagram setiap user serta jumlah
+        like yang berhasil dihimpun.
+      </p>
 
       {/* Pagination Controls */}
       {totalPages > 1 && (


### PR DESCRIPTION
## Summary
- add `Narrative` component for descriptive text under charts and tables
- show short explanations for each TikTok and Instagram chart
- append narrative paragraphs beneath TikTok and Instagram recap tables

## Testing
- `npm install --legacy-peer-deps`
- `npm run lint` *(fails: requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_684a258a4474832799872cde2fd7be24