### PR TITLE
Add Instagram post page to sidebar

### DIFF
--- a/cicero-dashboard/app/instagram/post/page.jsx
+++ b/cicero-dashboard/app/instagram/post/page.jsx
@@ -1,0 +1,1 @@
+export { default } from "../../posts/instagram/page";

--- a/cicero-dashboard/components/Sidebar.jsx
+++ b/cicero-dashboard/components/Sidebar.jsx
@@ -11,6 +11,7 @@ const menu = [
   { label: "Social Media Content Manager", path: "/content", icon: "🗂️" },
   { label: "Instagram Info", path: "/info/instagram", icon: "ℹ️" },
   { label: "Instagram Likes Tracking", path: "/likes/instagram", icon: "❤️" },
+  { label: "Instagram Post Analysis", path: "/posts/instagram", icon: "📸" },
   { label: "TikTok Comments Tracking", path: "/comments/tiktok", icon: "💬" },
 ];
 


### PR DESCRIPTION
## Summary
- link Instagram Post Analysis page in sidebar
- alias `/instagram/post` path to existing Instagram post analysis page

## Testing
- `npm install` *(fails: unable to resolve dependency tree)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a5db707548327899dd68fcced8d0c