### PR TITLE
Add fallback post thumbnail image

### DIFF
--- a/cicero-dashboard/components/InstagramPostsGrid.jsx
+++ b/cicero-dashboard/components/InstagramPostsGrid.jsx
@@ -7,13 +7,11 @@ export default function InstagramPostsGrid({ posts = [] }) {
           key={post.id || post.post_id}
           className="bg-white rounded-lg shadow border overflow-hidden"
         >
-          {post.thumbnail && (
-            <img
-              src={post.thumbnail}
-              alt={post.caption || "thumbnail"}
-              className="w-full h-48 object-cover"
-            />
-          )}
+          <img
+            src={post.thumbnail || "/file.svg"}
+            alt={post.caption || "thumbnail"}
+            className="w-full h-48 object-cover"
+          />
           <div className="p-4 flex flex-col gap-2">
             <p className="font-semibold text-sm break-words">
               {post.caption || "-"}


### PR DESCRIPTION
## Summary
- ensure each post shows an image in InstagramPostsGrid

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a5ee6157c83278feae2046617b102