### PR TITLE
Add views metric to Instagram analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ The Social Media Content Manager page retrieves Instagram analytics from the bac
 - `like_count`
 - `comment_count`
 - `share_count`
+- `view_count` (optional)
 - `thumbnail` (optional)
 
 These fields are provided by the backend endpoints `/api/insta/rapid-profile` and `/api/insta/rapid-posts`.

--- a/cicero-dashboard/app/content/page.jsx
+++ b/cicero-dashboard/app/content/page.jsx
@@ -122,6 +122,7 @@ export default function SocialMediaContentManagerPage() {
       like_count: p.like_count || 0,
       comment_count: p.comment_count || 0,
       share_count: p.share_count || 0,
+      view_count: p.view_count || 0,
     });
 
     if (!typeMap[p.type]) typeMap[p.type] = { total: 0, count: 0 };

--- a/cicero-dashboard/components/InstagramPostsGrid.jsx
+++ b/cicero-dashboard/components/InstagramPostsGrid.jsx
@@ -19,6 +19,7 @@ export default function InstagramPostsGrid({ posts = [] }) {
             <div className="text-xs text-gray-600 flex gap-4">
               {post.like_count != null && <span>❤️ {post.like_count}</span>}
               {post.comment_count != null && <span>💬 {post.comment_count}</span>}
+              {post.view_count != null && <span>👁️ {post.view_count}</span>}
             </div>
           </div>
         </div>

--- a/cicero-dashboard/components/PostMetricsChart.jsx
+++ b/cicero-dashboard/components/PostMetricsChart.jsx
@@ -35,6 +35,11 @@ export default function PostMetricsChart({ posts = [] }) {
         data: posts.map((p) => p.share_count || 0),
         backgroundColor: "rgba(234,88,12,0.6)",
       },
+      {
+        label: "Views",
+        data: posts.map((p) => p.view_count || 0),
+        backgroundColor: "rgba(139,92,246,0.6)",
+      },
     ],
   };
 


### PR DESCRIPTION
## Summary
- document optional `view_count` post field
- display view counts in InstagramPostsGrid
- chart views in PostMetricsChart
- include view count when aggregating post metrics

## Testing
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_684a645926f483279344e5adcf48518a