### PR TITLE
Fix Instagram thumbnail display

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,3 +85,7 @@ The Instagram Post Analysis page retrieves Instagram analytics from the backend.
 - `thumbnail` (optional)
 
 These fields are provided by the backend endpoints `/api/insta/rapid-profile` and `/api/insta/rapid-posts`.
+
+Thumbnails from Instagram occasionally use the `.heic` extension which many browsers
+cannot display. The frontend automatically replaces `.heic` with `.jpg` and falls
+back to `/file.svg` if loading fails.

--- a/cicero-dashboard/components/InstagramPostsGrid.jsx
+++ b/cicero-dashboard/components/InstagramPostsGrid.jsx
@@ -1,5 +1,10 @@
 "use client";
 export default function InstagramPostsGrid({ posts = [] }) {
+  const getThumbnailSrc = (url) => {
+    if (!url) return "/file.svg";
+    return url.replace(/\.heic(\?|$)/, ".jpg$1");
+  };
+
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
       {posts.map((post) => (
@@ -8,9 +13,12 @@ export default function InstagramPostsGrid({ posts = [] }) {
           className="bg-white rounded-lg shadow border overflow-hidden"
         >
           <img
-            src={post.thumbnail || "/file.svg"}
+            src={getThumbnailSrc(post.thumbnail)}
             alt={post.caption || "thumbnail"}
             className="w-full h-48 object-cover"
+            onError={(e) => {
+              e.currentTarget.src = "/file.svg";
+            }}
           />
           <div className="p-4 flex flex-col gap-2">
             <p className="font-semibold text-sm break-words">


### PR DESCRIPTION
## Summary
- handle `.heic` thumbnails in InstagramPostsGrid
- describe new fallback behaviour in README

## Testing
- `npm install --legacy-peer-deps`
- `npm run lint` *(fails: requires ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_684a7421bf388327a04a04e161cd99cc