### PR TITLE
Use HD profile picture URL

### DIFF
--- a/cicero-dashboard/app/info/instagram/page.jsx
+++ b/cicero-dashboard/app/info/instagram/page.jsx
@@ -82,10 +82,10 @@ export default function InstagramInfoPage() {
   ];
 
   const profilePic =
-    profile.profile_pic_url ||
     info?.hd_profile_pic_url_info?.url ||
     info?.profile_pic_url_hd ||
     info?.profile_pic_url ||
+    profile.profile_pic_url ||
     "";
 
   const biography = profile.bio || info?.biography || "";


### PR DESCRIPTION
## Summary
- prioritize `hd_profile_pic_url_info.url` on the Instagram info page

## Testing
- `npm run build` *(fails: Failed to fetch fonts and missing module `recharts`)*

------
https://chatgpt.com/codex/tasks/task_e_684a75575ddc8327b08dc6195c5194d3