### PR TITLE
Fix Instagram profile image loading

### DIFF
--- a/cicero-dashboard/app/info/instagram/page.jsx
+++ b/cicero-dashboard/app/info/instagram/page.jsx
@@ -83,10 +83,15 @@ export default function InstagramInfoPage() {
 
   ];
 
-  const profilePic = 
+  const profilePic =
     info?.hd_profile_pic_url_info?.url ||
-    info?.hd_profile_pic_versions.url ||
+    info?.hd_profile_pic_versions?.[0]?.url ||
     "";
+
+  const getProfilePicSrc = (url) => {
+    if (!url) return "/file.svg";
+    return url.replace(/\.heic(\?|$)/, ".jpg$1");
+  };
 
   const biography = profile.bio || info?.biography || "";
 
@@ -127,9 +132,12 @@ export default function InstagramInfoPage() {
         <div className="bg-white p-4 rounded-xl shadow flex gap-4 items-start">
           {profilePic && (
             <img
-              src={profilePic}
+              src={getProfilePicSrc(profilePic)}
               alt="profile"
               className="w-24 h-24 rounded-full object-cover flex-shrink-0"
+              onError={(e) => {
+                e.currentTarget.src = "/file.svg";
+              }}
             />
           )}
           <div className="flex-1">


### PR DESCRIPTION
## Summary
- handle hd_profile_pic_versions array correctly
- normalize Instagram profile image URLs and add fallback

## Testing
- `npm run lint` *(fails: prompts for config)*

------
https://chatgpt.com/codex/tasks/task_e_684a795543688327a566a5f3ee531a6e