### PR TITLE
Add engagement summary visualization

### DIFF
--- a/cicero-dashboard/app/info/instagram/page.jsx
+++ b/cicero-dashboard/app/info/instagram/page.jsx
@@ -4,6 +4,7 @@ import CardStat from "@/components/CardStat";
 import Loader from "@/components/Loader";
 import Narrative from "@/components/Narrative";
 import InstagramCompareChart from "@/components/InstagramCompareChart";
+import SummaryEngagementChart from "@/components/SummaryEngagementChart";
 import {
   getInstagramProfileViaBackend,
   getInstagramInfoViaBackend,
@@ -276,12 +277,24 @@ export default function InstagramInfoPage() {
         {posts.length > 0 && (
           <div className="bg-white p-4 rounded-xl shadow text-sm">
             <h2 className="font-semibold mb-2">Summary Engagement</h2>
-            <ul className="list-disc ml-5">
-              <li>Avg Likes: {avgLikes.toFixed(1)}</li>
-              <li>Avg Comments: {avgComments.toFixed(1)}</li>
-              <li>Avg Views: {avgViews.toFixed(1)}</li>
-              <li>Engagement Rate: {engagementRate}%</li>
-            </ul>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 items-center">
+              <div>
+                <ul className="list-disc ml-5 mb-4">
+                  <li>Avg Likes: {avgLikes.toFixed(1)}</li>
+                  <li>Avg Comments: {avgComments.toFixed(1)}</li>
+                  <li>Avg Views: {avgViews.toFixed(1)}</li>
+                  <li>Engagement Rate: {engagementRate}%</li>
+                </ul>
+                <Narrative>
+                  {`Rata-rata posting memperoleh ${avgLikes.toFixed(1)} likes dan ${avgComments.toFixed(1)} komentar dengan ${avgViews.toFixed(1)} views, menghasilkan engagement rate ${engagementRate}%.`}
+                </Narrative>
+              </div>
+              <SummaryEngagementChart
+                likes={avgLikes}
+                comments={avgComments}
+                views={avgViews}
+              />
+            </div>
           </div>
         )}
 

--- a/cicero-dashboard/components/SummaryEngagementChart.jsx
+++ b/cicero-dashboard/components/SummaryEngagementChart.jsx
@@ -1,0 +1,37 @@
+"use client";
+import { Bar } from "react-chartjs-2";
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Tooltip,
+  Legend,
+} from "chart.js";
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend);
+
+export default function SummaryEngagementChart({ likes = 0, comments = 0, views = 0 }) {
+  const chartData = {
+    labels: ["Avg Likes", "Avg Comments", "Avg Views"],
+    datasets: [
+      {
+        label: "Avg",
+        data: [likes, comments, views],
+        backgroundColor: [
+          "rgba(37,99,235,0.6)",
+          "rgba(16,185,129,0.6)",
+          "rgba(234,88,12,0.6)",
+        ],
+      },
+    ],
+  };
+
+  const options = {
+    responsive: true,
+    scales: { y: { beginAtZero: true } },
+    plugins: { legend: { display: false } },
+  };
+
+  return <Bar data={chartData} options={options} />;
+}


### PR DESCRIPTION
## Summary
- add a new `SummaryEngagementChart` component for visualizing average likes, comments, and views
- display this chart on the Instagram info page with narrative text

## Testing
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_684a812e0ce48327b72c7ba989ec3ac4