### PR TITLE
Add Instagram engagement comparison chart

### DIFF
--- a/cicero-dashboard/app/info/instagram/page.jsx
+++ b/cicero-dashboard/app/info/instagram/page.jsx
@@ -4,6 +4,7 @@ import CardStat from "@/components/CardStat";
 import Loader from "@/components/Loader";
 import Narrative from "@/components/Narrative";
 import InstagramCompareChart from "@/components/InstagramCompareChart";
+import InstagramEngagementSummaryChart from "@/components/InstagramEngagementSummaryChart";
 import {
   getInstagramProfileViaBackend,
   getInstagramInfoViaBackend,
@@ -342,16 +343,30 @@ export default function InstagramInfoPage() {
                   competitor={compareStats}
                 />
               </div>
-              <div className="text-sm flex-1">
-                <h3 className="font-semibold md:mt-0 mt-2">Summary Engagement</h3>
-                <ul className="list-disc ml-5">
-                  <li>Avg Likes: {compareStats.avgLikes.toFixed(1)}</li>
-                  <li>Avg Comments: {compareStats.avgComments.toFixed(1)}</li>
-                  <li>Avg Views: {compareStats.avgViews.toFixed(1)}</li>
-                  <li>Engagement Rate: {compareStats.engagementRate}%</li>
-                  <li>Total Posts: {compareStats.totalPosts ?? "-"}</li>
-                  <li>Total IG-TV: {compareStats.totalIgtv ?? "-"}</li>
-                </ul>
+              <div className="flex-1 flex flex-col gap-4">
+                <InstagramEngagementSummaryChart
+                  client={{
+                    username: profile.username,
+                    avgLikes,
+                    avgComments,
+                    avgViews,
+                    engagementRate,
+                    totalPosts: info?.media_count ?? info?.post_count,
+                    totalIgtv: info?.total_igtv_videos,
+                  }}
+                  competitor={compareStats}
+                />
+                <div className="text-sm">
+                  <h3 className="font-semibold md:mt-0 mt-2">Summary Engagement</h3>
+                  <ul className="list-disc ml-5">
+                    <li>Avg Likes: {compareStats.avgLikes.toFixed(1)}</li>
+                    <li>Avg Comments: {compareStats.avgComments.toFixed(1)}</li>
+                    <li>Avg Views: {compareStats.avgViews.toFixed(1)}</li>
+                    <li>Engagement Rate: {compareStats.engagementRate}%</li>
+                    <li>Total Posts: {compareStats.totalPosts ?? "-"}</li>
+                    <li>Total IG-TV: {compareStats.totalIgtv ?? "-"}</li>
+                  </ul>
+                </div>
               </div>
             </div>
             <Narrative>

--- a/cicero-dashboard/components/InstagramEngagementSummaryChart.jsx
+++ b/cicero-dashboard/components/InstagramEngagementSummaryChart.jsx
@@ -1,0 +1,55 @@
+"use client";
+import { Bar } from "react-chartjs-2";
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Tooltip,
+  Legend,
+} from "chart.js";
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend);
+
+export default function InstagramEngagementSummaryChart({ client, competitor }) {
+  if (!client || !competitor) return null;
+  const chartData = {
+    labels: [
+      "Avg Likes",
+      "Avg Comments",
+      "Avg Views",
+      "Engagement %",
+      "Total Posts",
+      "Total IG-TV",
+    ],
+    datasets: [
+      {
+        label: client.username,
+        data: [
+          client.avgLikes || 0,
+          client.avgComments || 0,
+          client.avgViews || 0,
+          parseFloat(client.engagementRate) || 0,
+          client.totalPosts || 0,
+          client.totalIgtv || 0,
+        ],
+        backgroundColor: "rgba(37,99,235,0.6)",
+      },
+      {
+        label: competitor.username,
+        data: [
+          competitor.avgLikes || 0,
+          competitor.avgComments || 0,
+          competitor.avgViews || 0,
+          parseFloat(competitor.engagementRate) || 0,
+          competitor.totalPosts || 0,
+          competitor.totalIgtv || 0,
+        ],
+        backgroundColor: "rgba(234,88,12,0.6)",
+      },
+    ],
+  };
+
+  const options = { responsive: true, scales: { y: { beginAtZero: true } } };
+  return <Bar data={chartData} options={options} />;
+}


### PR DESCRIPTION
## Summary
- visualize client vs competitor engagement stats in new `InstagramEngagementSummaryChart`
- display new chart on Instagram comparison page

## Testing
- `npm run lint` *(fails: requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_684a85d68958832783dc19059470b3cc