### PR TITLE
Use client_id for TikTok rapid posts

### DIFF
--- a/cicero-dashboard/app/info/tiktok/page.jsx
+++ b/cicero-dashboard/app/info/tiktok/page.jsx
@@ -8,6 +8,7 @@ import {
   getTiktokProfileViaBackend,
   getTiktokInfoViaBackend,
   getTiktokPostsViaBackend,
+  getTiktokPostsByUsernameViaBackend,
   getClientProfile,
 } from "@/utils/api";
 
@@ -55,7 +56,7 @@ export default function TiktokInfoPage() {
         const infoData = infoRes.data || infoRes.info || infoRes;
         setInfo(infoData);
 
-        const postsRes = await getTiktokPostsViaBackend(token, username, 20);
+        const postsRes = await getTiktokPostsViaBackend(token, clientId, 20);
         const postsData = postsRes.data || postsRes.posts || postsRes;
         setPosts(Array.isArray(postsData) ? postsData : []);
 
@@ -97,7 +98,11 @@ export default function TiktokInfoPage() {
       const profileRes = await getTiktokProfileViaBackend(token, username);
       const infoRes = await getTiktokInfoViaBackend(token, username);
       const infoData = infoRes.data || infoRes.info || infoRes;
-      const postsRes = await getTiktokPostsViaBackend(token, username, 20);
+      const postsRes = await getTiktokPostsByUsernameViaBackend(
+        token,
+        username,
+        20
+      );
       const postsData = postsRes.data || postsRes.posts || postsRes;
       const avgLikes =
         postsData.reduce((s, p) => s + (p.like_count || 0), 0) /

--- a/cicero-dashboard/utils/api.js
+++ b/cicero-dashboard/utils/api.js
@@ -178,7 +178,23 @@ export async function getTiktokInfoViaBackend(token, username) {
 }
 
 // Fetch TikTok posts via backend using username
-export async function getTiktokPostsViaBackend(token, username, limit = 10) {
+export async function getTiktokPostsViaBackend(token, client_id, limit = 10) {
+  const params = new URLSearchParams({ client_id, limit });
+  const url = `${API_BASE_URL}/api/tiktok/rapid-posts?${params.toString()}`;
+  const res = await fetchWithAuth(url, token);
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Failed to fetch tiktok posts: ${text}`);
+  }
+  return res.json();
+}
+
+// Fetch TikTok posts via backend using username (for compare feature)
+export async function getTiktokPostsByUsernameViaBackend(
+  token,
+  username,
+  limit = 10
+) {
   const params = new URLSearchParams({ username, limit });
   const url = `${API_BASE_URL}/api/tiktok/rapid-posts?${params.toString()}`;
   const res = await fetchWithAuth(url, token);


### PR DESCRIPTION
## Summary
- update API utils to request TikTok rapid posts using `client_id`
- add helper for fetching TikTok posts by username
- adjust TikTok Info page to call the updated function

## Testing
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_684a9f0e55dc832797b808c452349431