### PR TITLE
Add TikTok Post Analysis menu

### DIFF
--- a/cicero-dashboard/components/Sidebar.jsx
+++ b/cicero-dashboard/components/Sidebar.jsx
@@ -12,6 +12,7 @@ const menu = [
   { label: "Instagram Likes Tracking", path: "/likes/instagram", icon: "❤️" },
   { label: "Instagram Post Analysis", path: "/posts/instagram", icon: "📸" },
   { label: "TikTok Info", path: "/info/tiktok", icon: "🎵" },
+  { label: "TikTok Post Analysis", path: "/posts/tiktok", icon: "🎬" },
   { label: "TikTok Comments Tracking", path: "/comments/tiktok", icon: "💬" },
 ];
 


### PR DESCRIPTION
## Summary
- include **TikTok Post Analysis** in sidebar menu

## Testing
- `npx next lint` *(fails: needs Next package install)*

------
https://chatgpt.com/codex/tasks/task_e_684ab487e720832782608800eb8cfe47