### PR TITLE
Merge Instagram info and posts

### DIFF
--- a/cicero-dashboard/app/instagram/page.jsx
+++ b/cicero-dashboard/app/instagram/page.jsx
@@ -1,0 +1,12 @@
+"use client";
+import InstagramInfoPage from "../info/instagram/page";
+import InstagramPostAnalysisPage from "../posts/instagram/page";
+
+export default function InstagramCombinedPage() {
+  return (
+    <>
+      <InstagramInfoPage />
+      <InstagramPostAnalysisPage />
+    </>
+  );
+}

--- a/cicero-dashboard/app/instagram/post/page.jsx
+++ b/cicero-dashboard/app/instagram/post/page.jsx
@@ -1,1 +1,1 @@
-export { default } from "../../posts/instagram/page";
+export { default } from "../page";

--- a/cicero-dashboard/components/Sidebar.jsx
+++ b/cicero-dashboard/components/Sidebar.jsx
@@ -8,9 +8,8 @@ import { Menu as IconMenu, X as IconX } from "lucide-react"; // Import lucide ic
 const menu = [
   { label: "Dashboard", path: "/dashboard", icon: "🏠" },
   { label: "User Directory", path: "/users", icon: "👤" },
-  { label: "Instagram Info", path: "/info/instagram", icon: "ℹ️" },
+  { label: "Instagram Analysis", path: "/instagram", icon: "📸" },
   { label: "Instagram Likes Tracking", path: "/likes/instagram", icon: "❤️" },
-  { label: "Instagram Post Analysis", path: "/posts/instagram", icon: "📸" },
   { label: "TikTok Info", path: "/info/tiktok", icon: "🎵" },
   { label: "TikTok Post Analysis", path: "/posts/tiktok", icon: "🎬" },
   { label: "TikTok Comments Tracking", path: "/comments/tiktok", icon: "💬" },


### PR DESCRIPTION
## Summary
- add combined page showing both Instagram info and post analysis
- update sidebar to link to the new combined page
- keep old /instagram/post route as alias

## Testing
- `npm run lint` *(fails: asks for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_684abc8a283c832796893cac015e7304