### PR TITLE
Add combined TikTok analysis menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ back to `/file.svg` if loading fails.
 
 The TikTok Post Analysis page works similarly to the Instagram one but uses the TikTok endpoints `getTiktokProfileViaBackend` and `getTiktokPostsViaBackend` found in `cicero-dashboard/utils/api.js`.
 
+Additionally, the dashboard provides a combined TikTok Analysis view at `/tiktok`
+which merges the info and post analytics into a single page.
+
 ### Profile Fields
 - `username`
 - `followers`

--- a/cicero-dashboard/components/Sidebar.jsx
+++ b/cicero-dashboard/components/Sidebar.jsx
@@ -10,6 +10,7 @@ const menu = [
   { label: "User Directory", path: "/users", icon: "👤" },
   { label: "Instagram Analysis", path: "/instagram", icon: "📸" },
   { label: "Instagram Likes Tracking", path: "/likes/instagram", icon: "❤️" },
+  { label: "TikTok Analysis", path: "/tiktok", icon: "🎵" },
   { label: "TikTok Info", path: "/info/tiktok", icon: "🎵" },
   { label: "TikTok Post Analysis", path: "/posts/tiktok", icon: "🎬" },
   { label: "TikTok Comments Tracking", path: "/comments/tiktok", icon: "💬" },


### PR DESCRIPTION
## Summary
- add a sidebar entry for TikTok Analysis that links to `/tiktok`
- mention the new combined TikTok page in the README

## Testing
- `npm install` *(fails: dependency conflict)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ac32d71c88327bb6f97dd98e88a5c