### PR TITLE
Redirect unauthorized users to landing page

### DIFF
--- a/cicero-dashboard/app/comments/tiktok/page.jsx
+++ b/cicero-dashboard/app/comments/tiktok/page.jsx
@@ -7,8 +7,10 @@ import ChartHorizontal from "@/components/ChartHorizontal";
 import { groupUsersByKelompok } from "@/utils/grouping";
 import Link from "next/link";
 import Narrative from "@/components/Narrative";
+import useRequireAuth from "@/hooks/useRequireAuth";
 
 export default function TiktokKomentarTrackingPage() {
+  useRequireAuth();
   const [chartData, setChartData] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");

--- a/cicero-dashboard/app/comments/tiktok/rekap/page.jsx
+++ b/cicero-dashboard/app/comments/tiktok/rekap/page.jsx
@@ -4,8 +4,10 @@ import { getDashboardStats, getRekapKomentarTiktok } from "@/utils/api";
 import Loader from "@/components/Loader";
 import RekapKomentarTiktok from "@/components/RekapKomentarTiktok";
 import Link from "next/link";
+import useRequireAuth from "@/hooks/useRequireAuth";
 
 export default function RekapKomentarTiktokPage() {
+  useRequireAuth();
   const [chartData, setChartData] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");

--- a/cicero-dashboard/app/dashboard/page.jsx
+++ b/cicero-dashboard/app/dashboard/page.jsx
@@ -2,8 +2,10 @@
 import { useEffect, useState } from "react";
 import { getClientProfile } from "@/utils/api";
 import Loader from "@/components/Loader";
+import useRequireAuth from "@/hooks/useRequireAuth";
 
 export default function DashboardPage() {
+  useRequireAuth();
   const [clientProfile, setClientProfile] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");

--- a/cicero-dashboard/app/info/instagram/page.jsx
+++ b/cicero-dashboard/app/info/instagram/page.jsx
@@ -10,8 +10,10 @@ import {
   getInstagramPostsViaBackend,
   getClientProfile,
 } from "@/utils/api";
+import useRequireAuth from "@/hooks/useRequireAuth";
 
 export default function InstagramInfoPage() {
+  useRequireAuth();
   const [profile, setProfile] = useState(null);
   const [info, setInfo] = useState(null);
   const [posts, setPosts] = useState([]);

--- a/cicero-dashboard/app/instagram/page.jsx
+++ b/cicero-dashboard/app/instagram/page.jsx
@@ -1,8 +1,10 @@
 "use client";
 import InstagramInfoPage from "../info/instagram/page";
 import InstagramPostAnalysisPage from "../posts/instagram/page";
+import useRequireAuth from "@/hooks/useRequireAuth";
 
 export default function InstagramCombinedPage() {
+  useRequireAuth();
   return (
     <>
       <InstagramInfoPage />

--- a/cicero-dashboard/app/likes/instagram/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/page.jsx
@@ -7,8 +7,10 @@ import ChartHorizontal from "@/components/ChartHorizontal";
 import { groupUsersByKelompok } from "@/utils/grouping"; // pastikan path benar
 import Link from "next/link";
 import Narrative from "@/components/Narrative";
+import useRequireAuth from "@/hooks/useRequireAuth";
 
 export default function InstagramLikesTrackingPage() {
+  useRequireAuth();
   const [stats, setStats] = useState(null);
   const [chartData, setChartData] = useState([]);
   const [loading, setLoading] = useState(true);

--- a/cicero-dashboard/app/likes/instagram/rekap/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/rekap/page.jsx
@@ -4,8 +4,10 @@ import { getDashboardStats, getRekapLikesIG } from "@/utils/api";
 import Loader from "@/components/Loader";
 import RekapLikesIG from "@/components/RekapLikesIG";
 import Link from "next/link";
+import useRequireAuth from "@/hooks/useRequireAuth";
 
 export default function RekapLikesIGPage() {
+  useRequireAuth();
   const [chartData, setChartData] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");

--- a/cicero-dashboard/app/posts/instagram/page.jsx
+++ b/cicero-dashboard/app/posts/instagram/page.jsx
@@ -9,6 +9,7 @@ import InstagramPostsGrid from "@/components/InstagramPostsGrid";
 import Loader from "@/components/Loader";
 import Narrative from "@/components/Narrative";
 import PostCompareChart from "@/components/PostCompareChart";
+import useRequireAuth from "@/hooks/useRequireAuth";
 import {
   getInstagramProfileViaBackend,
   getInstagramPostsViaBackend,
@@ -16,6 +17,7 @@ import {
 } from "@/utils/api";
 
 export default function InstagramPostAnalysisPage() {
+  useRequireAuth();
   const [profile, setProfile] = useState(null);
   const [posts, setPosts] = useState([]);
   const [loading, setLoading] = useState(true);

--- a/cicero-dashboard/app/tiktok/page.jsx
+++ b/cicero-dashboard/app/tiktok/page.jsx
@@ -1,8 +1,10 @@
 "use client";
 import TiktokInfo from "@/components/tiktok/Info";
 import TiktokPostAnalysis from "@/components/tiktok/PostAnalysis";
+import useRequireAuth from "@/hooks/useRequireAuth";
 
 export default function TiktokCombinedPage() {
+  useRequireAuth();
   return (
     <>
       <TiktokInfo />

--- a/cicero-dashboard/app/users/page.jsx
+++ b/cicero-dashboard/app/users/page.jsx
@@ -2,10 +2,12 @@
 import { useEffect, useState, useMemo } from "react";
 import { getUserDirectory } from "@/utils/api";
 import Loader from "@/components/Loader";
+import useRequireAuth from "@/hooks/useRequireAuth";
 
 const PAGE_SIZE = 50;
 
 export default function UserDirectoryPage() {
+  useRequireAuth();
   const [users, setUsers] = useState([]);
   const [search, setSearch] = useState("");
   const [loading, setLoading] = useState(true);

--- a/cicero-dashboard/hooks/useRequireAuth.js
+++ b/cicero-dashboard/hooks/useRequireAuth.js
@@ -1,0 +1,18 @@
+"use client";
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+export default function useRequireAuth() {
+  const router = useRouter();
+
+  useEffect(() => {
+    const token =
+      typeof window !== "undefined" ? localStorage.getItem("cicero_token") : null;
+    const clientId =
+      typeof window !== "undefined" ? localStorage.getItem("client_id") : null;
+
+    if (!token || !clientId) {
+      router.replace("/");
+    }
+  }, [router]);
+}

--- a/cicero-dashboard/utils/api.js
+++ b/cicero-dashboard/utils/api.js
@@ -12,7 +12,7 @@ function handleTokenExpired() {
   if (typeof window !== "undefined") {
     localStorage.removeItem("cicero_token");
     localStorage.removeItem("client_id");
-    window.location.href = "/login";
+    window.location.href = "/";
   }
 }
 


### PR DESCRIPTION
## Summary
- add `useRequireAuth` hook
- redirect token-expired events to landing page
- require auth on dashboard, user management, and analytics pages

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b81f8071083278882bd33013a9c31