### PR TITLE
Improve metadata and semantics

### DIFF
--- a/cicero-dashboard/app/layout.jsx
+++ b/cicero-dashboard/app/layout.jsx
@@ -4,6 +4,13 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import SidebarWrapper from "@/components/SidebarWrapper";
 
+export const metadata = {
+  title: "CICERO Dashboard",
+  description:
+    "Next-Gen Dashboard for Social Media Monitoring & Team Management",
+  viewport: "width=device-width, initial-scale=1",
+};
+
 const geistSans = Geist({
   variable: "--font-geist-sans",
   subsets: ["latin"],
@@ -22,7 +29,7 @@ export default function RootLayout({ children }) {
     return (
       <html lang="en">
         <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
-          {children}
+          <main>{children}</main>
         </body>
       </html>
     );

--- a/cicero-dashboard/app/login/page.jsx
+++ b/cicero-dashboard/app/login/page.jsx
@@ -4,6 +4,11 @@ import useAuthRedirect from "@/hooks/useAuthRedirect";
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 
+export const metadata = {
+  title: "Login - CICERO Dashboard",
+  description: "Masuk ke dashboard CICERO",
+};
+
 export default function LoginPage() {
   useAuthRedirect(); // Akan redirect ke /dashboard jika sudah login
 
@@ -47,14 +52,18 @@ export default function LoginPage() {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-slate-100">
+    <main className="min-h-screen flex items-center justify-center bg-slate-100 p-4">
       <form
         onSubmit={handleLogin}
-        className="bg-white p-8 rounded-2xl shadow-xl min-w-[340px] w-full max-w-sm"
+        className="bg-white p-8 rounded-2xl shadow-xl w-full max-w-sm"
       >
         <h2 className="mb-6 text-2xl font-bold text-blue-600 text-center">Login Cicero</h2>
         <div className="mb-4">
+          <label htmlFor="client_id" className="sr-only">
+            Client ID
+          </label>
           <input
+            id="client_id"
             type="text"
             placeholder="Client ID"
             value={client_id}
@@ -64,7 +73,11 @@ export default function LoginPage() {
           />
         </div>
         <div className="mb-4">
+          <label htmlFor="client_operator" className="sr-only">
+            Operator
+          </label>
           <input
+            id="client_operator"
             type="text"
             placeholder="Operator"
             value={client_operator}
@@ -86,6 +99,6 @@ export default function LoginPage() {
           {loading ? "Logging in..." : "Login"}
         </button>
       </form>
-    </div>
+    </main>
   );
 }

--- a/cicero-dashboard/app/page.jsx
+++ b/cicero-dashboard/app/page.jsx
@@ -3,19 +3,17 @@ import useAuthRedirect from "@/hooks/useAuthRedirect";
 import Image from "next/image";
 import Link from "next/link";
 
+export const metadata = {
+  title: "CICERO Dashboard",
+  description:
+    "Next-Gen Dashboard for Social Media Monitoring & Team Management",
+};
+
 export default function LandingPage() {
   useAuthRedirect();
 
   return (
-    <div
-      className="fixed inset-0 bg-gradient-to-br from-gray-900 via-blue-950 to-black flex items-center justify-center"
-      style={{
-        width: "100vw",
-        height: "100vh",
-        overflow: "hidden",
-        minHeight: "100dvh",
-      }}
-    >
+    <main className="min-h-screen bg-gradient-to-br from-gray-900 via-blue-950 to-black flex items-center justify-center p-4">
       <div
         className={`
           max-w-2xl w-full mx-auto flex flex-col items-center
@@ -59,6 +57,6 @@ export default function LandingPage() {
           Login
         </Link>
       </div>
-    </div>
+    </main>
   );
 }


### PR DESCRIPTION
## Summary
- add metadata defaults in layout
- add metadata and labels on login page
- make landing page responsive and add metadata

## Testing
- `npm install` *(fails: unable to resolve dependency tree)*
- `npm run lint` *(fails: `next` not found due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684cbd404c90832782262acbb4a25874