### PR TITLE
Fix metadata export error

### DIFF
--- a/cicero-dashboard/app/layout.jsx
+++ b/cicero-dashboard/app/layout.jsx
@@ -1,8 +1,6 @@
-"use client";
-import { usePathname } from "next/navigation";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-import SidebarWrapper from "@/components/SidebarWrapper";
+import LayoutClient from "@/components/LayoutClient";
 
 export const metadata = {
   title: "CICERO Dashboard",
@@ -22,27 +20,10 @@ const geistMono = Geist_Mono({
 });
 
 export default function RootLayout({ children }) {
-  const pathname = usePathname();
-
-  // Jika halaman landing page ("/"), render langsung children saja (tanpa sidebar, tanpa wrapper)
-  if (pathname === "/") {
-    return (
-      <html lang="en">
-        <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
-          <main>{children}</main>
-        </body>
-      </html>
-    );
-  }
-
-  // Untuk halaman lain, tetap render sidebar + wrapper
   return (
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
-        <div className="flex min-h-screen bg-gray-100">
-          <SidebarWrapper />
-          <main className="flex-1 min-h-screen p-4 md:p-8">{children}</main>
-        </div>
+        <LayoutClient>{children}</LayoutClient>
       </body>
     </html>
   );

--- a/cicero-dashboard/app/login/page.jsx
+++ b/cicero-dashboard/app/login/page.jsx
@@ -4,11 +4,6 @@ import useAuthRedirect from "@/hooks/useAuthRedirect";
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 
-export const metadata = {
-  title: "Login - CICERO Dashboard",
-  description: "Masuk ke dashboard CICERO",
-};
-
 export default function LoginPage() {
   useAuthRedirect(); // Akan redirect ke /dashboard jika sudah login
 

--- a/cicero-dashboard/app/page.jsx
+++ b/cicero-dashboard/app/page.jsx
@@ -3,12 +3,6 @@ import useAuthRedirect from "@/hooks/useAuthRedirect";
 import Image from "next/image";
 import Link from "next/link";
 
-export const metadata = {
-  title: "CICERO Dashboard",
-  description:
-    "Next-Gen Dashboard for Social Media Monitoring & Team Management",
-};
-
 export default function LandingPage() {
   useAuthRedirect();
 

--- a/cicero-dashboard/components/LayoutClient.jsx
+++ b/cicero-dashboard/components/LayoutClient.jsx
@@ -1,0 +1,18 @@
+"use client";
+import { usePathname } from "next/navigation";
+import SidebarWrapper from "./SidebarWrapper";
+
+export default function LayoutClient({ children }) {
+  const pathname = usePathname();
+
+  if (pathname === "/") {
+    return <main>{children}</main>;
+  }
+
+  return (
+    <div className="flex min-h-screen bg-gray-100">
+      <SidebarWrapper />
+      <main className="flex-1 min-h-screen p-4 md:p-8">{children}</main>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- avoid exporting `metadata` from client components
- handle layout path logic in a new `LayoutClient` client component

## Testing
- `npm run lint` *(fails: prompts for config)*
- `npm run build` *(fails: network restrictions for fonts and missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_684cbee610608327b48136d90499300b