### PR TITLE
Improve basic accessibility

### DIFF
--- a/cicero-dashboard/app/globals.css
+++ b/cicero-dashboard/app/globals.css
@@ -24,3 +24,24 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+/* Skip link for improved accessibility */
+.skip-link {
+  position: absolute;
+  left: -999px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+
+.skip-link:focus {
+  left: 0;
+  top: 0;
+  width: auto;
+  height: auto;
+  background: #ffffff;
+  color: #1d4ed8; /* Tailwind blue-700 */
+  padding: 0.5rem 1rem;
+  z-index: 50;
+}

--- a/cicero-dashboard/app/layout.jsx
+++ b/cicero-dashboard/app/layout.jsx
@@ -23,6 +23,7 @@ export default function RootLayout({ children }) {
   return (
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+        <a href="#main-content" className="skip-link">Skip to main content</a>
         <LayoutClient>{children}</LayoutClient>
       </body>
     </html>

--- a/cicero-dashboard/components/LayoutClient.jsx
+++ b/cicero-dashboard/components/LayoutClient.jsx
@@ -5,14 +5,26 @@ import SidebarWrapper from "./SidebarWrapper";
 export default function LayoutClient({ children }) {
   const pathname = usePathname();
 
-  if (pathname === "/") {
-    return <main>{children}</main>;
+  // Landing and login pages render without sidebar
+  if (pathname === "/" || pathname === "/login") {
+    return (
+      <main id="main-content" className="min-h-screen">
+        {children}
+      </main>
+    );
   }
 
   return (
     <div className="flex min-h-screen bg-gray-100">
-      <SidebarWrapper />
-      <main className="flex-1 min-h-screen p-4 md:p-8">{children}</main>
+      <aside aria-label="Sidebar navigation">
+        <SidebarWrapper />
+      </aside>
+      <main
+        id="main-content"
+        className="flex-1 min-h-screen p-4 md:p-8"
+      >
+        {children}
+      </main>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add skip link to root layout and supporting CSS
- mark sidebar with semantic `<aside>`
- hide sidebar on login and route to more accessible `<main>` wrapper

## Testing
- `npm run lint` *(fails: prompts for setup)*

------
https://chatgpt.com/codex/tasks/task_e_684cc220669c8327ac3fb967038d4090