### PR TITLE
Update README on concurrent login limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ NEXT_PUBLIC_API_URL=<backend base url>
 - The login page expects a valid API endpoint provided by `NEXT_PUBLIC_API_URL`.
 - Pages under the `app/` directory automatically refresh during development when files are edited.
 - Static assets such as icons reside in `cicero-dashboard/public`.
+- The maximum number of concurrent logins for a client is controlled by the backend.
+  If you need more than three users logged in at the same time, update the server
+  configuration to allow at least five simultaneous sessions.
 
 For more information about Next.js features, refer to the documentation inside `cicero-dashboard/README.md`.
 


### PR DESCRIPTION
## Summary
- clarify that concurrent login limit is handled by backend configuration

## Testing
- `npm install` *(fails: could not resolve dependency lucide-react)*

------
https://chatgpt.com/codex/tasks/task_e_684ccbc8ece08327965bc42a5538fd59