### PR TITLE
Remove login limits note

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,8 @@ NEXT_PUBLIC_API_URL=<backend base url>
 - The login page expects a valid API endpoint provided by `NEXT_PUBLIC_API_URL`.
 - Pages under the `app/` directory automatically refresh during development when files are edited.
 - Static assets such as icons reside in `cicero-dashboard/public`.
-- The maximum number of concurrent logins for a client is controlled by the backend.
-  If you need more than three users logged in at the same time, update the server
-  configuration to allow at least five simultaneous sessions.
+- The backend no longer restricts how many users can log in at once.
+- Clients may allow an unlimited number of concurrent sessions.
 
 For more information about Next.js features, refer to the documentation inside `cicero-dashboard/README.md`.
 


### PR DESCRIPTION
## Summary
- update README to reflect that the backend no longer limits concurrent logins

## Testing
- `npm run lint` *(fails: interactive ESLint setup prompt)*

------
https://chatgpt.com/codex/tasks/task_e_684ccdb834e4832794cae15c2837dfed