### PR TITLE
Improve social profile display

### DIFF
--- a/cicero-dashboard/app/dashboard/page.jsx
+++ b/cicero-dashboard/app/dashboard/page.jsx
@@ -247,6 +247,11 @@ function SocialCard({ platform, profile, posts }) {
           <div className="text-sm text-gray-500">
             {profile.following} following
           </div>
+          {profile.bio && (
+            <div className="text-sm text-gray-500 whitespace-pre-line">
+              {profile.bio}
+            </div>
+          )}
         </div>
       </div>
       {posts && posts.length > 0 && (

--- a/cicero-dashboard/app/info/instagram/page.jsx
+++ b/cicero-dashboard/app/info/instagram/page.jsx
@@ -153,6 +153,9 @@ export default function InstagramInfoPage() {
   ];
 
   const profilePic =
+    profile?.profile_pic_url_hd ||
+    profile?.profile_pic_url ||
+    profile?.hd_profile_pic_url_info?.url ||
     info?.hd_profile_pic_url_info?.url ||
     info?.hd_profile_pic_versions?.[0]?.url ||
     "";

--- a/cicero-dashboard/components/tiktok/Info.jsx
+++ b/cicero-dashboard/components/tiktok/Info.jsx
@@ -156,6 +156,9 @@ export default function TiktokInfoPage() {
   ];
 
   const profilePic =
+    profile?.avatar ||
+    profile?.hd_profile_pic_url_info?.url ||
+    profile?.hd_profile_pic_versions?.[0]?.url ||
     info?.hd_profile_pic_url_info?.url ||
     info?.hd_profile_pic_versions?.[0]?.url ||
     "";


### PR DESCRIPTION
## Summary
- show biography in dashboard social cards
- support more profile pic fields for Instagram and TikTok info pages

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684cf19241d083278282c41ad8281cd7