### PR TITLE
Add avatar_url support in TikTok profile views

### DIFF
--- a/cicero-dashboard/app/dashboard/page.jsx
+++ b/cicero-dashboard/app/dashboard/page.jsx
@@ -206,6 +206,7 @@ function SocialCard({ platform, profile, posts }) {
     );
 
   const avatar =
+    profile.avatar_url ||
     profile.avatar ||
     profile.hd_profile_pic_url_info?.url ||
     profile.hd_profile_pic_versions?.[0]?.url ||

--- a/cicero-dashboard/components/tiktok/Info.jsx
+++ b/cicero-dashboard/components/tiktok/Info.jsx
@@ -156,6 +156,7 @@ export default function TiktokInfoPage() {
   ];
 
   const profilePic =
+    profile?.avatar_url ||
     profile?.avatar ||
     profile?.hd_profile_pic_url_info?.url ||
     profile?.hd_profile_pic_versions?.[0]?.url ||

--- a/cicero-dashboard/components/tiktok/PostAnalysis.jsx
+++ b/cicero-dashboard/components/tiktok/PostAnalysis.jsx
@@ -185,6 +185,7 @@ export default function TiktokPostAnalysisPage() {
     (latestPosts.length || 1);
 
   const profilePic =
+    profile.avatar_url ||
     profile.hd_profile_pic_url_info?.url ||
     profile.hd_profile_pic_versions?.[0]?.url ||
     profile.profile_pic_url ||


### PR DESCRIPTION
## Summary
- show `avatar_url` in SocialCard, TikTok info, and post analysis

## Testing
- `npm install --legacy-peer-deps`
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_684cf3c450008327bd7ad9b336b5d9e7