### PR TITLE
Add doc note on Instagram analysis page

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ Thumbnails from Instagram occasionally use the `.heic` extension which many brow
 cannot display. The frontend automatically replaces `.heic` with `.jpg` and falls
 back to `/file.svg` if loading fails.
 
+The dashboard also provides a combined Instagram Analysis view at `/instagram`
+which merges the info and post analytics previously found under
+`/info/instagram` and `/posts/instagram` into a single page.
+
 ## TikTok Post Analysis API
 
 The TikTok Post Analysis page works similarly to the Instagram one but uses the TikTok endpoints `getTiktokProfileViaBackend` and `getTiktokPostsViaBackend` found in `cicero-dashboard/utils/api.js`.


### PR DESCRIPTION
## Summary
- clarify README to mention `/instagram` combined analysis page

## Testing
- `npm run lint` *(fails: next not found)*
- `npm install` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684cfa8d53408327b1b2f4fcbf928e37