### PR TITLE
Fix WordCloud size initialization

### DIFF
--- a/cicero-dashboard/components/WordCloudChart.jsx
+++ b/cicero-dashboard/components/WordCloudChart.jsx
@@ -7,7 +7,7 @@ export default function WordCloudChart({ words = [] }) {
   const options = { rotations: 2, rotationAngles: [0, 0], fontSizes: [12, 40] };
   return (
     <div style={{ height: 300 }} className="w-full">
-      <ReactWordcloud words={words} options={options} />
+      <ReactWordcloud words={words} options={options} size={[300, 300]} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- fix WordCloudChart default size to avoid undefined size errors

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cfbb773ac8327ac000e13986f4c58