### PR TITLE
Fix Radix dialog warning

### DIFF
--- a/cicero-dashboard/components/Sidebar.jsx
+++ b/cicero-dashboard/components/Sidebar.jsx
@@ -8,6 +8,7 @@ import {
   SheetTrigger,
   SheetContent,
   SheetClose,
+  SheetTitle,
 } from "@/components/ui/sheet";
 
 const menu = [
@@ -45,6 +46,7 @@ export default function Sidebar() {
         </button>
       </SheetTrigger>
       <SheetContent side="left" className="w-64 p-6 flex flex-col">
+        <SheetTitle className="sr-only">Navigation Menu</SheetTitle>
         <div className="text-2xl font-bold text-blue-700 mb-6">CICERO Dashboard</div>
         <nav className="flex-1 space-y-2">
           {menu.map((item) => (


### PR DESCRIPTION
## Summary
- add `SheetTitle` to `Sidebar`'s sheet content for accessibility

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cfe028b6883279fdfa636af610859