### PR TITLE
Connect pricing CTA to WhatsApp

### DIFF
--- a/cicero-dashboard/.env.example
+++ b/cicero-dashboard/.env.example
@@ -1,2 +1,4 @@
 # Optional fallback username if client data has no Instagram handle
 NEXT_PUBLIC_INSTAGRAM_USER=instagram
+# WhatsApp number for pricing contact
+NEXT_PUBLIC_ADMIN_WHATSAPP=6281234567890

--- a/cicero-dashboard/app/page.jsx
+++ b/cicero-dashboard/app/page.jsx
@@ -123,12 +123,15 @@ export default function LandingPage() {
                     </li>
                   ))}
                 </ul>
-                <button
+                <a
+                  href={`https://wa.me/${process.env.NEXT_PUBLIC_ADMIN_WHATSAPP}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
                   aria-label={`Daftar paket ${pkg.name}`}
                   className="mt-6 bg-blue-600 hover:bg-blue-700 text-white font-semibold py-2 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400"
                 >
                   Daftar Sekarang
-                </button>
+                </a>
               </div>
             ))}
           </div>


### PR DESCRIPTION
## Summary
- make pricing button open WhatsApp with `NEXT_PUBLIC_ADMIN_WHATSAPP`
- add `NEXT_PUBLIC_ADMIN_WHATSAPP` to `.env.example`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d030e7958832799058f8873eb9772