### PR TITLE
Fix word cloud overflow

### DIFF
--- a/cicero-dashboard/components/WordCloudChart.jsx
+++ b/cicero-dashboard/components/WordCloudChart.jsx
@@ -4,7 +4,7 @@ import WordCloud from "react-d3-cloud";
 export default function WordCloudChart({ words = [] }) {
   if (typeof window === "undefined") return null;
   return (
-    <div style={{ height: 300 }} className="w-full">
+    <div style={{ height: 300 }} className="w-full overflow-hidden">
       <WordCloud data={words} width={300} height={300} />
     </div>
   );


### PR DESCRIPTION
## Summary
- tweak WordCloud wrapper to hide overflow

## Testing
- `npm install --legacy-peer-deps`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_684d046f71a8832782d673426840dbaf