### PR TITLE
Fix wordcloud positioning

### DIFF
--- a/cicero-dashboard/components/WordCloudChart.jsx
+++ b/cicero-dashboard/components/WordCloudChart.jsx
@@ -4,7 +4,10 @@ import WordCloud from "react-d3-cloud";
 export default function WordCloudChart({ words = [] }) {
   if (typeof window === "undefined") return null;
   return (
-    <div style={{ height: 300 }} className="w-full overflow-hidden">
+    <div
+      style={{ height: 300 }}
+      className="w-full overflow-hidden flex justify-center items-start"
+    >
       <WordCloud data={words} width={300} height={300} />
     </div>
   );


### PR DESCRIPTION
## Summary
- adjust WordCloud container styles so the chart aligns to the top of the section

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d074e73a08327a2ed303bf5bc3c63