### PR TITLE
Align TikTok analysis layout with Instagram

### DIFF
--- a/cicero-dashboard/app/tiktok/page.jsx
+++ b/cicero-dashboard/app/tiktok/page.jsx
@@ -6,9 +6,11 @@ import useRequireAuth from "@/hooks/useRequireAuth";
 export default function TiktokCombinedPage() {
   useRequireAuth();
   return (
-    <>
-      <TiktokInfo />
-      <TiktokPostAnalysis />
-    </>
+    <div className="min-h-screen bg-gray-100 flex flex-col items-center py-8">
+      <div className="w-full max-w-5xl flex flex-col gap-8">
+        <TiktokInfo embedded />
+        <TiktokPostAnalysis embedded />
+      </div>
+    </div>
   );
 }

--- a/cicero-dashboard/components/tiktok/Info.jsx
+++ b/cicero-dashboard/components/tiktok/Info.jsx
@@ -12,7 +12,7 @@ import {
   getClientProfile,
 } from "@/utils/api";
 
-export default function TiktokInfoPage() {
+export default function TiktokInfoPage({ embedded = false }) {
   const [profile, setProfile] = useState(null);
   const [info, setInfo] = useState(null);
   const [posts, setPosts] = useState([]);
@@ -201,10 +201,9 @@ export default function TiktokInfoPage() {
   const privacyStatus = info?.is_private ? "Privat" : "Terbuka";
 
 
-  return (
-    <div className="min-h-screen bg-gray-100 flex flex-col items-center py-8">
-      <div className="w-full max-w-4xl flex flex-col gap-8">
-        <h1 className="text-2xl font-bold text-blue-700">TikTok Info</h1>
+  const content = (
+    <>
+      <h1 className="text-2xl font-bold text-blue-700">TikTok Info</h1>
         <form onSubmit={handleCompare} className="flex gap-2">
           <input
             type="text"
@@ -365,6 +364,17 @@ export default function TiktokInfoPage() {
             </Narrative>
           </div>
         )}
+    </>
+  );
+
+  if (embedded) {
+    return content;
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-100 flex flex-col items-center py-8">
+      <div className="w-full max-w-5xl flex flex-col gap-8">
+        {content}
       </div>
     </div>
   );

--- a/cicero-dashboard/components/tiktok/PostAnalysis.jsx
+++ b/cicero-dashboard/components/tiktok/PostAnalysis.jsx
@@ -16,7 +16,7 @@ import {
   getClientProfile,
 } from "@/utils/api";
 
-export default function TiktokPostAnalysisPage() {
+export default function TiktokPostAnalysisPage({ embedded = false }) {
   const [profile, setProfile] = useState(null);
   const [posts, setPosts] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -250,9 +250,8 @@ export default function TiktokPostAnalysisPage() {
     .sort((a, b) => b[1] - a[1])
     .slice(0, 5);
 
-  return (
-    <div className="min-h-screen bg-gray-100 flex flex-col items-center py-8">
-      <div className="w-full max-w-5xl flex flex-col gap-8">
+  const content = (
+    <>
         <h1 className="text-2xl font-bold text-blue-700">TikTok Post Analysis</h1>
         <p className="text-gray-600">Analisis performa postingan TikTok.</p>
 
@@ -373,7 +372,17 @@ export default function TiktokPostAnalysisPage() {
           </div>
         )}
 
+    </>
+  );
 
+  if (embedded) {
+    return content;
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-100 flex flex-col items-center py-8">
+      <div className="w-full max-w-5xl flex flex-col gap-8">
+        {content}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- unify TikTok analysis page layout with Instagram
- add `embedded` option to `TiktokInfo` and `TiktokPostAnalysis`
- wrap TikTok analysis page with a single container

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d0ed8fd58832788090e2115d88db0