### PR TITLE
Update TikTok analysis page

### DIFF
--- a/cicero-dashboard/app/tiktok/page.jsx
+++ b/cicero-dashboard/app/tiktok/page.jsx
@@ -8,8 +8,10 @@ export default function TiktokCombinedPage() {
   return (
     <div className="min-h-screen bg-gray-100 flex flex-col items-center py-8">
       <div className="w-full max-w-5xl flex flex-col gap-8">
-        <TiktokInfo embedded />
-        <TiktokPostAnalysis embedded />
+        <h1 className="text-2xl font-bold text-blue-700">TikTok Analysis</h1>
+        <p className="text-gray-600">Gabungan info profil dan analisis posting TikTok.</p>
+        <TiktokInfo embedded hideHeader />
+        <TiktokPostAnalysis embedded hideHeader />
       </div>
     </div>
   );

--- a/cicero-dashboard/components/tiktok/Info.jsx
+++ b/cicero-dashboard/components/tiktok/Info.jsx
@@ -12,7 +12,7 @@ import {
   getClientProfile,
 } from "@/utils/api";
 
-export default function TiktokInfoPage({ embedded = false }) {
+export default function TiktokInfoPage({ embedded = false, hideHeader = false }) {
   const [profile, setProfile] = useState(null);
   const [info, setInfo] = useState(null);
   const [posts, setPosts] = useState([]);
@@ -203,7 +203,9 @@ export default function TiktokInfoPage({ embedded = false }) {
 
   const content = (
     <>
-      <h1 className="text-2xl font-bold text-blue-700">TikTok Info</h1>
+      {!hideHeader && (
+        <h1 className="text-2xl font-bold text-blue-700">TikTok Info</h1>
+      )}
         <form onSubmit={handleCompare} className="flex gap-2">
           <input
             type="text"

--- a/cicero-dashboard/components/tiktok/PostAnalysis.jsx
+++ b/cicero-dashboard/components/tiktok/PostAnalysis.jsx
@@ -16,7 +16,7 @@ import {
   getClientProfile,
 } from "@/utils/api";
 
-export default function TiktokPostAnalysisPage({ embedded = false }) {
+export default function TiktokPostAnalysisPage({ embedded = false, hideHeader = false }) {
   const [profile, setProfile] = useState(null);
   const [posts, setPosts] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -252,8 +252,12 @@ export default function TiktokPostAnalysisPage({ embedded = false }) {
 
   const content = (
     <>
-        <h1 className="text-2xl font-bold text-blue-700">TikTok Post Analysis</h1>
-        <p className="text-gray-600">Analisis performa postingan TikTok.</p>
+        {!hideHeader && (
+          <>
+            <h1 className="text-2xl font-bold text-blue-700">TikTok Post Analysis</h1>
+            <p className="text-gray-600">Analisis performa postingan TikTok.</p>
+          </>
+        )}
 
         <div className="bg-white p-4 rounded-xl shadow flex gap-4 items-start">
           {profilePic && (


### PR DESCRIPTION
## Summary
- hide headers when TikTok info or post analysis components are embedded
- show a single heading on `/tiktok`

## Testing
- `npm run lint` *(fails: asks for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_684d10a2a3f08327a4d04a36282df910