### PR TITLE
Limit TikTok post analysis to current month

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ that combines the info and post analytics previously found under
 The TikTok Post Analysis page works similarly to the Instagram one but uses the TikTok endpoints `getTiktokProfileViaBackend` and `getTiktokPostsViaBackend` found in `cicero-dashboard/utils/api.js`.
 
 The dashboard provides a single TikTok Post Analysis page at `/tiktok`
-that merges the info and post analytics into one view.
+that merges the info and post analytics into one view. By default,
+the visualized posts are limited to the current month.
 
 ### Profile Fields
 - `username`

--- a/cicero-dashboard/app/posts/tiktok/page.jsx
+++ b/cicero-dashboard/app/posts/tiktok/page.jsx
@@ -31,8 +31,15 @@ export default function TiktokPostAnalysisPage() {
   const [compareStats, setCompareStats] = useState(null);
   const [compareLoading, setCompareLoading] = useState(false);
   const [compareError, setCompareError] = useState("");
-  const [startDate, setStartDate] = useState("");
-  const [endDate, setEndDate] = useState("");
+  const now = new Date();
+  const firstDay = new Date(now.getFullYear(), now.getMonth(), 1)
+    .toISOString()
+    .split("T")[0];
+  const lastDay = new Date(now.getFullYear(), now.getMonth() + 1, 0)
+    .toISOString()
+    .split("T")[0];
+  const [startDate, setStartDate] = useState(firstDay);
+  const [endDate, setEndDate] = useState(lastDay);
   const [search, setSearch] = useState("");
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- default TikTok post filters to the current month
- document the monthly filter in the README

## Testing
- `npm install --legacy-peer-deps`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_684d1c72fca08327a6d8eb2e882f8c7b