### PR TITLE
Limit Instagram data to current month

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ back to `/file.svg` if loading fails.
 The dashboard provides a single Instagram Post Analysis page at `/instagram`
 that combines the info and post analytics previously found under
 `/info/instagram` and `/posts/instagram`.
+By default, the page filters posts to the current month.
 
 ## TikTok Post Analysis API
 

--- a/cicero-dashboard/app/posts/instagram/page.jsx
+++ b/cicero-dashboard/app/posts/instagram/page.jsx
@@ -30,8 +30,15 @@ export default function InstagramPostAnalysisPage() {
   const [compareStats, setCompareStats] = useState(null);
   const [compareLoading, setCompareLoading] = useState(false);
   const [compareError, setCompareError] = useState("");
-  const [startDate, setStartDate] = useState("");
-  const [endDate, setEndDate] = useState("");
+  const now = new Date();
+  const firstDay = new Date(now.getFullYear(), now.getMonth(), 1)
+    .toISOString()
+    .split("T")[0];
+  const lastDay = new Date(now.getFullYear(), now.getMonth() + 1, 0)
+    .toISOString()
+    .split("T")[0];
+  const [startDate, setStartDate] = useState(firstDay);
+  const [endDate, setEndDate] = useState(lastDay);
   const [search, setSearch] = useState("");
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- filter Instagram posts page to the current month by default
- document this default behaviour in the README

## Testing
- `npm install --legacy-peer-deps`
- `npm run lint` *(fails: "How would you like to configure ESLint?")*

------
https://chatgpt.com/codex/tasks/task_e_684d35653db8832793584c299dd8072c