### PR TITLE
Add Instagram monthly posts API support

### DIFF
--- a/cicero-dashboard/app/posts/instagram/page.jsx
+++ b/cicero-dashboard/app/posts/instagram/page.jsx
@@ -15,6 +15,7 @@ import useRequireAuth from "@/hooks/useRequireAuth";
 import {
   getInstagramProfileViaBackend,
   getInstagramPostsViaBackend,
+  getInstagramPostsThisMonthViaBackend,
   getInstagramInfoViaBackend,
   getClientProfile,
 } from "@/utils/api";
@@ -30,8 +31,15 @@ export default function InstagramPostAnalysisPage() {
   const [compareStats, setCompareStats] = useState(null);
   const [compareLoading, setCompareLoading] = useState(false);
   const [compareError, setCompareError] = useState("");
-  const [startDate, setStartDate] = useState("");
-  const [endDate, setEndDate] = useState("");
+  const now = new Date();
+  const firstDay = new Date(now.getFullYear(), now.getMonth(), 1)
+    .toISOString()
+    .split("T")[0];
+  const lastDay = new Date(now.getFullYear(), now.getMonth() + 1, 0)
+    .toISOString()
+    .split("T")[0];
+  const [startDate, setStartDate] = useState(firstDay);
+  const [endDate, setEndDate] = useState(lastDay);
   const [search, setSearch] = useState("");
 
   useEffect(() => {
@@ -62,7 +70,7 @@ export default function InstagramPostAnalysisPage() {
         const infoData = infoRes.data || infoRes.info || infoRes;
         setInfo(infoData);
 
-        const postRes = await getInstagramPostsViaBackend(token, username, 50);
+        const postRes = await getInstagramPostsThisMonthViaBackend(token, username);
         const postData = postRes.data || postRes.posts || postRes;
         setPosts(Array.isArray(postData) ? postData : []);
       } catch (err) {

--- a/cicero-dashboard/utils/api.js
+++ b/cicero-dashboard/utils/api.js
@@ -111,6 +111,18 @@ export async function getInstagramPostsViaBackend(token, username, limit = 10) {
   return res.json();
 }
 
+// Fetch Instagram posts for the current month via backend using username
+export async function getInstagramPostsThisMonthViaBackend(token, username) {
+  const params = new URLSearchParams({ username });
+  const url = `${API_BASE_URL}/api/insta/rapid-posts-month?${params.toString()}`;
+  const res = await fetchWithAuth(url, token);
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Failed to fetch instagram posts this month: ${text}`);
+  }
+  return res.json();
+}
+
 // Fetch Instagram profile via backend using username
 export async function getInstagramProfileViaBackend(token, username) {
   const params = new URLSearchParams({ username });


### PR DESCRIPTION
## Summary
- add `getInstagramPostsThisMonthViaBackend` helper to call new backend route
- default Instagram post analysis filters to the current month
- use new API in Instagram posts page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d38ced5f88327a86c391b6fcb361e