### PR TITLE
Remove example text from landing page

### DIFF
--- a/cicero-dashboard/app/page.jsx
+++ b/cicero-dashboard/app/page.jsx
@@ -112,47 +112,36 @@ export default function LandingPage() {
                 title: "Monitoring & Evaluasi Terpusat",
                 desc:
                   "Cicero otomatis menarik aktivitas Instagram/TikTok anggota dan mencocokkannya dengan database organisasi.",
-                useCase:
-                  "Contoh: tim marketing kampus memantau seberapa aktif mahasiswa mempromosikan acara.",
               },
               {
                 icon: CheckCircle,
                 title: "Absensi Digital & Penilaian Kinerja",
                 desc:
                   "Sistem menandai siapa yang sudah like, komen atau repost sehingga keaktifan mudah dipantau.",
-                useCase:
-                  "Contoh: instansi pemerintah menilai kepatuhan pegawai dalam amplifikasi konten resmi.",
               },
               {
                 icon: MessageCircle,
                 title: "Laporan Otomatis via WhatsApp",
                 desc:
                   "Rekap harian langsung dikirim ke WhatsApp admin atau pimpinan untuk monitoring real-time.",
-                useCase:
-                  "Contoh: komandan mendapatkan laporan tiap pagi tanpa menunggu rekap manual.",
               },
               {
                 icon: Database,
                 title: "Minim Administrasi Manual",
                 desc:
                   "Data dapat diimpor massal dari Google Sheet dan diproses otomatis tanpa kerepotan.",
-                useCase:
-                  "Contoh: admin cukup unggah daftar akun lalu fokus pada strategi konten.",
               },
               {
                 icon: BarChart3,
                 title: "Visualisasi & Analisis Lengkap",
                 desc:
                   "Dashboard menampilkan grafik tren serta insight performa tim untuk evaluasi menyeluruh.",
-                useCase:
-                  "Contoh: manajemen melihat grafik harian guna menentukan strategi kampanye berikutnya.",
               },
-            ].map(({ icon: Icon, title, desc, useCase }) => (
+            ].map(({ icon: Icon, title, desc }) => (
               <div key={title} className="bg-white/5 p-6 rounded-xl flex flex-col">
                 <Icon className="h-8 w-8 text-blue-400" />
                 <h3 className="mt-4 font-semibold text-lg">{title}</h3>
                 <p className="mt-2 text-sm text-blue-100">{desc}</p>
-                <p className="mt-2 text-xs text-blue-300 italic">{useCase}</p>
               </div>
             ))}
           </div>


### PR DESCRIPTION
## Summary
- remove `useCase` example lines from landing page features

## Testing
- `npm run lint` *(fails: requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_6850093c99b08327a7ba8d87acd3355c