### PR TITLE
Fix WhatsApp link in pricing

### DIFF
--- a/cicero-dashboard/.env.example
+++ b/cicero-dashboard/.env.example
@@ -1,4 +1,4 @@
 # Optional fallback username if client data has no Instagram handle
 NEXT_PUBLIC_INSTAGRAM_USER=instagram
 # WhatsApp number for pricing contact
-NEXT_PUBLIC_ADMIN_WHATSAPP=081235114745
+NEXT_PUBLIC_ADMIN_WHATSAPP=+6281235114745

--- a/cicero-dashboard/app/page.jsx
+++ b/cicero-dashboard/app/page.jsx
@@ -185,7 +185,7 @@ export default function LandingPage() {
                   ))}
                 </ul>
                 <a
-                  href="https://wa.me/081235114745"
+                  href="https://wa.me/+6281235114745"
                   target="_blank"
                   rel="noopener noreferrer"
                   aria-label={`Kirim pesan paket ${pkg.name}`}


### PR DESCRIPTION
## Summary
- fix the WhatsApp link on the pricing page so the +62 prefix remains
- update example env file

## Testing
- `npm run lint` *(fails: next not found)*
- `npm install` *(fails: dependency conflict)*

------
https://chatgpt.com/codex/tasks/task_e_68500b8e604c83279df9a5e57d75fc13