### PR TITLE
Add Instagram Basic page

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,13 @@ The dashboard provides a single Instagram Post Analysis page at `/instagram`
 that combines the info and post analytics previously found under
 `/info/instagram` and `/posts/instagram`.
 
+## Instagram Basic API
+
+The `/instagram-basic` page demonstrates using the official Instagram Basic
+Display API. Paste an access token in the form to load your profile and recent
+posts. Data is retrieved via `getInstagramBasicProfile` and
+`getInstagramBasicPosts` in `cicero-dashboard/utils/api.ts`.
+
 ## TikTok Post Analysis API
 
 The TikTok Post Analysis page works similarly to the Instagram one but uses the TikTok endpoints `getTiktokProfileViaBackend` and `getTiktokPostsViaBackend` found in `cicero-dashboard/utils/api.js`.

--- a/cicero-dashboard/__tests__/api.test.ts
+++ b/cicero-dashboard/__tests__/api.test.ts
@@ -1,4 +1,8 @@
-import { getDashboardStats } from '../utils/api';
+import {
+  getDashboardStats,
+  getInstagramBasicProfile,
+  getInstagramBasicPosts,
+} from '../utils/api';
 
 beforeEach(() => {
   global.fetch = jest.fn(() =>
@@ -14,6 +18,26 @@ test('getDashboardStats calls endpoint with auth header', async () => {
   await getDashboardStats('token123');
   expect(global.fetch).toHaveBeenCalledWith(
     expect.stringContaining('/api/dashboard/stats'),
+    expect.objectContaining({
+      headers: expect.objectContaining({ Authorization: 'Bearer token123' })
+    })
+  );
+});
+
+test('getInstagramBasicProfile adds access token query', async () => {
+  await getInstagramBasicProfile('token123', 'IGTOKEN');
+  expect(global.fetch).toHaveBeenCalledWith(
+    expect.stringContaining('/api/insta/basic-profile'),
+    expect.objectContaining({
+      headers: expect.objectContaining({ Authorization: 'Bearer token123' })
+    })
+  );
+});
+
+test('getInstagramBasicPosts adds access token and limit', async () => {
+  await getInstagramBasicPosts('token123', 'IGTOKEN', 5);
+  expect(global.fetch).toHaveBeenCalledWith(
+    expect.stringContaining('/api/insta/basic-posts'),
     expect.objectContaining({
       headers: expect.objectContaining({ Authorization: 'Bearer token123' })
     })

--- a/cicero-dashboard/app/instagram-basic/page.jsx
+++ b/cicero-dashboard/app/instagram-basic/page.jsx
@@ -1,0 +1,105 @@
+"use client";
+import { useEffect, useState } from "react";
+import useRequireAuth from "@/hooks/useRequireAuth";
+import { getInstagramBasicProfile, getInstagramBasicPosts } from "@/utils/api";
+import Loader from "@/components/Loader";
+import InstagramPostsGrid from "@/components/InstagramPostsGrid";
+
+export default function InstagramBasicPage() {
+  useRequireAuth();
+  const [accessToken, setAccessToken] = useState("");
+  const [profile, setProfile] = useState(null);
+  const [posts, setPosts] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    const stored =
+      typeof window !== "undefined" ? localStorage.getItem("ig_basic_token") : "";
+    if (stored) setAccessToken(stored);
+  }, []);
+
+  useEffect(() => {
+    if (!accessToken) return;
+    fetchData(accessToken);
+  }, [accessToken]);
+
+  async function fetchData(tokenVal) {
+    const token =
+      typeof window !== "undefined" ? localStorage.getItem("cicero_token") : null;
+    if (!token) {
+      setError("Token tidak ditemukan. Silakan login ulang.");
+      return;
+    }
+    setLoading(true);
+    setError("");
+    try {
+      const profileRes = await getInstagramBasicProfile(token, tokenVal);
+      const postsRes = await getInstagramBasicPosts(token, tokenVal, 12);
+      const postsData = postsRes.data || postsRes.posts || postsRes;
+      const mapped = Array.isArray(postsData)
+        ? postsData.map((p) => ({
+            id: p.id,
+            caption: p.caption,
+            type: p.media_type,
+            created_at: p.timestamp,
+            thumbnail: p.thumbnail_url || p.media_url,
+          }))
+        : [];
+      setProfile(profileRes.data || profileRes.profile || profileRes);
+      setPosts(mapped);
+    } catch (err) {
+      setError("Gagal mengambil data: " + (err.message || err));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function handleSubmit(e) {
+    e.preventDefault();
+    if (typeof window !== "undefined") {
+      localStorage.setItem("ig_basic_token", accessToken);
+    }
+    fetchData(accessToken);
+  }
+
+  if (loading) return <Loader />;
+  return (
+    <div className="min-h-screen bg-gray-100 flex flex-col items-center py-8">
+      <div className="w-full max-w-4xl flex flex-col gap-6">
+        <h1 className="text-2xl font-bold text-blue-700">Instagram Basic</h1>
+        <form onSubmit={handleSubmit} className="flex gap-2">
+          <input
+            type="text"
+            placeholder="Access Token"
+            value={accessToken}
+            onChange={(e) => setAccessToken(e.target.value)}
+            className="flex-1 px-3 py-2 border rounded-lg text-sm shadow focus:outline-none focus:ring-2 focus:ring-blue-300"
+          />
+          <button
+            type="submit"
+            className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg"
+          >
+            Load
+          </button>
+        </form>
+        {error && <div className="text-red-500 text-sm">{error}</div>}
+        {profile && (
+          <div className="bg-white p-4 rounded-xl shadow flex gap-4 items-center">
+            <div className="flex-1">
+              <div className="text-lg font-semibold">@{profile.username}</div>
+              <div className="text-gray-500 text-sm">
+                {profile.account_type} - {profile.media_count} posts
+              </div>
+            </div>
+          </div>
+        )}
+        {posts.length > 0 && (
+          <div className="bg-white p-4 rounded-xl shadow">
+            <InstagramPostsGrid posts={posts} />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/cicero-dashboard/components/Sidebar.jsx
+++ b/cicero-dashboard/components/Sidebar.jsx
@@ -16,6 +16,7 @@ const menu = [
   { label: "Dashboard", path: "/dashboard", icon: "🏠" },
   { label: "User Directory", path: "/users", icon: "👤" },
   { label: "Instagram Post Analysis", path: "/instagram", icon: "📸" },
+  { label: "Instagram Basic", path: "/instagram-basic", icon: "📷" },
   { label: "Instagram Likes Tracking", path: "/likes/instagram", icon: "❤️" },
   { label: "TikTok Post Analysis", path: "/tiktok", icon: "🎵" },
   { label: "TikTok Comments Tracking", path: "/comments/tiktok", icon: "💬" },

--- a/cicero-dashboard/utils/api.ts
+++ b/cicero-dashboard/utils/api.ts
@@ -176,6 +176,37 @@ export async function getInstagramInfoViaBackend(token: string, username: string
   return res.json();
 }
 
+// Fetch profile using Instagram Basic Display API via backend
+export async function getInstagramBasicProfile(
+  token: string,
+  accessToken: string,
+): Promise<any> {
+  const params = new URLSearchParams({ access_token: accessToken });
+  const url = `${API_BASE_URL}/api/insta/basic-profile?${params.toString()}`;
+  const res = await fetchWithAuth(url, token);
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Failed to fetch basic instagram profile: ${text}`);
+  }
+  return res.json();
+}
+
+// Fetch posts using Instagram Basic Display API via backend
+export async function getInstagramBasicPosts(
+  token: string,
+  accessToken: string,
+  limit: number = 10,
+): Promise<any> {
+  const params = new URLSearchParams({ access_token: accessToken, limit: String(limit) });
+  const url = `${API_BASE_URL}/api/insta/basic-posts?${params.toString()}`;
+  const res = await fetchWithAuth(url, token);
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Failed to fetch basic instagram posts: ${text}`);
+  }
+  return res.json();
+}
+
 // Fetch TikTok profile via backend using username
 export async function getTiktokProfileViaBackend(token: string, username: string): Promise<any> {
   const params = new URLSearchParams({ username });


### PR DESCRIPTION
## Summary
- fetch Instagram Basic posts and profile via backend API
- expose `getInstagramBasicProfile` and `getInstagramBasicPosts`
- add `/instagram-basic` page demonstrating the official API
- include menu item in Sidebar for the new page
- document the Instagram Basic API
- extend unit tests for the new API functions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850482df1048327a2278ba57dc6f8d1