### PR TITLE
Add Instagram Basic OAuth login page

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ NEXT_PUBLIC_API_URL=<backend base url>
 
 `NEXT_PUBLIC_API_URL` specifies the Cicero API endpoint that the dashboard will use.
 
+To enable Instagram OAuth login, also include:
+
+```bash
+NEXT_PUBLIC_IG_APP_ID=<instagram app id>
+NEXT_PUBLIC_IG_REDIRECT_URI=<your redirect url>
+```
+
 ## Usage Notes
 
 - The login page expects a valid API endpoint provided by `NEXT_PUBLIC_API_URL`.
@@ -99,9 +106,10 @@ that combines the info and post analytics previously found under
 ## Instagram Basic API
 
 The `/instagram-basic` page demonstrates using the official Instagram Basic
-Display API. Paste an access token in the form to load your profile and recent
-posts. Data is retrieved via `getInstagramBasicProfile` and
-`getInstagramBasicPosts` in `cicero-dashboard/utils/api.ts`.
+Display API. You can paste an access token manually or use the login helper at
+`/instagram-basic/login` to request a token via OAuth. Data is fetched via
+`getInstagramBasicProfile`, `getInstagramBasicPosts`, and
+`getInstagramBasicAccessToken` in `cicero-dashboard/utils/api.ts`.
 
 ## TikTok Post Analysis API
 

--- a/cicero-dashboard/__tests__/api.test.ts
+++ b/cicero-dashboard/__tests__/api.test.ts
@@ -2,6 +2,7 @@ import {
   getDashboardStats,
   getInstagramBasicProfile,
   getInstagramBasicPosts,
+  getInstagramBasicAccessToken,
 } from '../utils/api';
 
 beforeEach(() => {
@@ -41,5 +42,12 @@ test('getInstagramBasicPosts adds access token and limit', async () => {
     expect.objectContaining({
       headers: expect.objectContaining({ Authorization: 'Bearer token123' })
     })
+  );
+});
+
+test('getInstagramBasicAccessToken exchanges code', async () => {
+  await getInstagramBasicAccessToken('CODE123');
+  expect(global.fetch).toHaveBeenCalledWith(
+    expect.stringContaining('/api/insta/basic-token?code=CODE123')
   );
 });

--- a/cicero-dashboard/app/instagram-basic/callback/page.jsx
+++ b/cicero-dashboard/app/instagram-basic/callback/page.jsx
@@ -1,0 +1,47 @@
+"use client";
+import { useEffect, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { getInstagramBasicAccessToken } from "@/utils/api";
+
+export default function InstagramBasicCallback() {
+  const router = useRouter();
+  const params = useSearchParams();
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(true);
+  useEffect(() => {
+    const code = params.get("code");
+    if (!code) {
+      setError("Code not found");
+      setLoading(false);
+      return;
+    }
+    async function fetchToken() {
+      try {
+        const token = await getInstagramBasicAccessToken(code);
+        if (typeof window !== "undefined") {
+          localStorage.setItem("ig_basic_token", token);
+        }
+        router.replace("/instagram-basic");
+      } catch (err) {
+        setError("Gagal mengambil token");
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchToken();
+  }, [params, router]);
+
+  if (loading) {
+    return (
+      <main className="min-h-screen flex items-center justify-center">Loading...</main>
+    );
+  }
+  if (error) {
+    return (
+      <main className="min-h-screen flex items-center justify-center text-red-600">
+        {error}
+      </main>
+    );
+  }
+  return null;
+}

--- a/cicero-dashboard/app/instagram-basic/login/page.jsx
+++ b/cicero-dashboard/app/instagram-basic/login/page.jsx
@@ -1,0 +1,37 @@
+"use client";
+import Link from "next/link";
+
+export default function InstagramBasicLogin() {
+  const appId = process.env.NEXT_PUBLIC_IG_APP_ID || "";
+  const redirectUri = process.env.NEXT_PUBLIC_IG_REDIRECT_URI || "";
+  if (!appId || !redirectUri) {
+    return (
+      <main className="min-h-screen flex items-center justify-center p-4">
+        <p className="text-red-600 text-center">
+          Instagram OAuth env vars not configured
+        </p>
+      </main>
+    );
+  }
+  const authUrl =
+    "https://api.instagram.com/oauth/authorize?" +
+    new URLSearchParams({
+      client_id: appId,
+      redirect_uri: redirectUri,
+      scope: "user_profile,user_media",
+      response_type: "code",
+    }).toString();
+  return (
+    <main className="min-h-screen flex items-center justify-center bg-gray-100 p-4">
+      <div className="bg-white p-8 rounded-xl shadow w-full max-w-sm text-center">
+        <h1 className="text-xl font-bold mb-6 text-pink-600">Instagram Login</h1>
+        <Link
+          href={authUrl}
+          className="inline-block bg-pink-600 hover:bg-pink-700 text-white px-4 py-2 rounded-lg"
+        >
+          Login with Instagram
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/cicero-dashboard/app/instagram-basic/page.jsx
+++ b/cicero-dashboard/app/instagram-basic/page.jsx
@@ -4,6 +4,7 @@ import useRequireAuth from "@/hooks/useRequireAuth";
 import { getInstagramBasicProfile, getInstagramBasicPosts } from "@/utils/api";
 import Loader from "@/components/Loader";
 import InstagramPostsGrid from "@/components/InstagramPostsGrid";
+import Link from "next/link";
 
 export default function InstagramBasicPage() {
   useRequireAuth();
@@ -68,6 +69,14 @@ export default function InstagramBasicPage() {
     <div className="min-h-screen bg-gray-100 flex flex-col items-center py-8">
       <div className="w-full max-w-4xl flex flex-col gap-6">
         <h1 className="text-2xl font-bold text-blue-700">Instagram Basic</h1>
+        {!accessToken && (
+          <Link
+            href="/instagram-basic/login"
+            className="self-start bg-pink-600 hover:bg-pink-700 text-white px-4 py-2 rounded-lg"
+          >
+            Login with Instagram
+          </Link>
+        )}
         <form onSubmit={handleSubmit} className="flex gap-2">
           <input
             type="text"

--- a/cicero-dashboard/utils/api.ts
+++ b/cicero-dashboard/utils/api.ts
@@ -207,6 +207,21 @@ export async function getInstagramBasicPosts(
   return res.json();
 }
 
+// Exchange OAuth "code" for an Instagram Basic access token via backend
+export async function getInstagramBasicAccessToken(
+  code: string,
+): Promise<string> {
+  const params = new URLSearchParams({ code });
+  const url = `${API_BASE_URL}/api/insta/basic-token?${params.toString()}`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Failed to fetch basic token: ${text}`);
+  }
+  const json = await res.json();
+  return json.access_token || json.token || json;
+}
+
 // Fetch TikTok profile via backend using username
 export async function getTiktokProfileViaBackend(token: string, username: string): Promise<any> {
   const params = new URLSearchParams({ username });


### PR DESCRIPTION
## Summary
- implement Instagram Basic OAuth helper and callback pages
- add API util for exchanging OAuth code
- support OAuth link on Instagram Basic page
- document new `NEXT_PUBLIC_IG_*` env vars
- test new API util

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68504a2f66808327a59e3e282da00f51