### PR TITLE
Add profile dashboard page

### DIFF
--- a/cicero-dashboard/app/profile/page.tsx
+++ b/cicero-dashboard/app/profile/page.tsx
@@ -1,0 +1,12 @@
+"use client";
+import ProfileDashboard from "@/components/ProfileDashboard";
+
+export default function ProfilePage() {
+  return (
+    <div className="min-h-screen bg-gray-100 flex flex-col items-center py-8">
+      <div className="w-full max-w-6xl">
+        <ProfileDashboard />
+      </div>
+    </div>
+  );
+}

--- a/cicero-dashboard/components/Sidebar.jsx
+++ b/cicero-dashboard/components/Sidebar.jsx
@@ -14,6 +14,7 @@ import {
 
 const menu = [
   { label: "Dashboard", path: "/dashboard", icon: "🏠" },
+  { label: "Profile", path: "/profile", icon: "🙍" },
   { label: "User Directory", path: "/users", icon: "👤" },
   { label: "Instagram Post Analysis", path: "/instagram", icon: "📸" },
   { label: "Instagram Likes Tracking", path: "/likes/instagram", icon: "❤️" },


### PR DESCRIPTION
## Summary
- add new profile route that uses the recently added `ProfileDashboard` component
- update sidebar navigation to include the profile page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68514b9621bc8327877af2cb1debfb63