### PR TITLE
Fix Tailwind import in globals.css

### DIFF
--- a/cicero-dashboard/app/globals.css
+++ b/cicero-dashboard/app/globals.css
@@ -1,4 +1,6 @@
-@import "tailwindcss";
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 
 :root {
   --background: #ffffff;


### PR DESCRIPTION
## Summary
- correct Tailwind import syntax in `app/globals.css`

## Testing
- `npm test`
- `npm run build` *(fails: Failed to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68515c0e513c832784a9428b07ff850c