### PR TITLE
Add server setup and deployment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This repository contains a Next.js dashboard used for visualizing data from the Cicero backend. The application resides in the `cicero-dashboard` directory.
 
+For detailed instructions on setting up a production server and deploying the dashboard, see [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md).
+
 ## Directory Overview
 
 ```

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,71 @@
+# Server Setup and Deployment Workflow
+
+This document explains how to prepare a server and deploy **Cicero_Web**.
+
+## Prerequisites
+
+- **Node.js** `>=20` and `npm`
+- **git** for cloning the repository
+- Optional: **pm2** or systemd to run the app as a service
+
+## 1. Clone the Repository
+
+```bash
+git clone <repository-url>
+cd Cicero_Web
+```
+
+## 2. Install Dependencies
+
+Navigate into the Next.js application directory and install packages:
+
+```bash
+cd cicero-dashboard
+npm install
+```
+
+## 3. Configure Environment
+
+Create a `.env.local` file inside `cicero-dashboard` and define the API URL used by the dashboard:
+
+```bash
+NEXT_PUBLIC_API_URL=<backend base url>
+```
+
+## 4. Build the Application
+
+Generate a production build with:
+
+```bash
+npm run build
+```
+
+## 5. Start the Server
+
+Launch the server on port 3000:
+
+```bash
+npm start
+```
+
+The application will be available at `http://localhost:3000`.
+
+To keep the service running in the background you can use `pm2` or create a `systemd` service pointing to `npm start`.
+
+## 6. Optional: Reverse Proxy
+
+If you want to serve the dashboard under your domain, configure a web server such as Nginx to proxy requests to `http://localhost:3000`.
+
+## 7. Running Tests
+
+To run the Jest test suite:
+
+```bash
+npm test
+```
+
+Run the tests inside `cicero-dashboard` whenever you change code.
+
+---
+
+Following this workflow will set up a production-ready environment for **Cicero_Web**.


### PR DESCRIPTION
## Summary
- add a new `DEPLOYMENT.md` with instructions for preparing a server and deploying the Next.js dashboard
- link the new documentation from the main `README.md`

## Testing
- `npm install` in `cicero-dashboard`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68561152a15c83278dc1149eb94b41d6