### PR TITLE
Fix user creation field

### DIFF
--- a/cicero-dashboard/app/users/page.jsx
+++ b/cicero-dashboard/app/users/page.jsx
@@ -61,7 +61,7 @@ export default function UserDirectoryPage() {
         client_id,
         nama,
         pangkat,
-        nrp_nip: nrpNip,
+        user_id: nrpNip,
         satfung,
       });
       setNama("");

--- a/cicero-dashboard/utils/api.ts
+++ b/cicero-dashboard/utils/api.ts
@@ -86,7 +86,7 @@ export async function createUser(
     client_id: string;
     nama: string;
     pangkat: string;
-    nrp_nip: string;
+    user_id: string;
     satfung: string;
   },
 ): Promise<any> {


### PR DESCRIPTION
## Summary
- use `user_id` field when calling the user creation endpoint

## Testing
- `npm test`
- `npm run build` *(fails: Failed to fetch fonts from fonts.googleapis.com)*

------
https://chatgpt.com/codex/tasks/task_e_686f6adce7988327a15849feb49a2818