### PR TITLE
Add date filter option

### DIFF
--- a/cicero-dashboard/__tests__/api.test.ts
+++ b/cicero-dashboard/__tests__/api.test.ts
@@ -21,7 +21,7 @@ test('getDashboardStats calls endpoint with auth header', async () => {
 });
 
 test('getRekapAmplify calls endpoint with auth header', async () => {
-  await getRekapAmplify('tok', 'c1', 'harian');
+  await getRekapAmplify('tok', 'c1', 'harian', '2024-01-01');
   expect(global.fetch).toHaveBeenCalledWith(
     expect.stringContaining('/api/amplify/rekap'),
     expect.objectContaining({

--- a/cicero-dashboard/app/amplify/page.jsx
+++ b/cicero-dashboard/app/amplify/page.jsx
@@ -1,6 +1,7 @@
 "use client";
 import { useEffect, useState } from "react";
 import { getRekapAmplify } from "@/utils/api";
+import DateSelector from "@/components/DateSelector";
 import Loader from "@/components/Loader";
 import ChartDivisiAbsensi from "@/components/ChartDivisiAbsensi";
 import ChartHorizontal from "@/components/ChartHorizontal";
@@ -13,6 +14,8 @@ export default function AmplifyPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const [periode, setPeriode] = useState("harian");
+  const today = new Date().toISOString().split("T")[0];
+  const [date, setDate] = useState(today);
 
   useEffect(() => {
     const token =
@@ -27,7 +30,7 @@ export default function AmplifyPage() {
 
     async function fetchData() {
       try {
-        const rekapRes = await getRekapAmplify(token, clientId, periode);
+        const rekapRes = await getRekapAmplify(token, clientId, periode, date);
         setChartData(Array.isArray(rekapRes.data) ? rekapRes.data : []);
 
       } catch (err) {
@@ -38,7 +41,7 @@ export default function AmplifyPage() {
     }
 
     fetchData();
-  }, [periode]);
+  }, [periode, date]);
 
   if (loading) return <Loader />;
   if (error)
@@ -78,6 +81,7 @@ export default function AmplifyPage() {
                   {label}
                 </button>
               ))}
+              <DateSelector date={date} setDate={setDate} />
             </div>
             <ChartBox title="BAG" users={kelompok.BAG} />
             <ChartBox title="SAT" users={kelompok.SAT} />

--- a/cicero-dashboard/app/comments/tiktok/page.jsx
+++ b/cicero-dashboard/app/comments/tiktok/page.jsx
@@ -8,6 +8,7 @@ import { groupUsersByKelompok } from "@/utils/grouping";
 import Link from "next/link";
 import Narrative from "@/components/Narrative";
 import useRequireAuth from "@/hooks/useRequireAuth";
+import DateSelector from "@/components/DateSelector";
 
 export default function TiktokKomentarTrackingPage() {
   useRequireAuth();
@@ -15,6 +16,8 @@ export default function TiktokKomentarTrackingPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const [periode, setPeriode] = useState("harian");
+  const today = new Date().toISOString().split("T")[0];
+  const [date, setDate] = useState(today);
   const [rekapSummary, setRekapSummary] = useState({
     totalUser: 0,
     totalSudahKomentar: 0,
@@ -48,7 +51,7 @@ export default function TiktokKomentarTrackingPage() {
           return;
         }
 
-        const rekapRes = await getRekapKomentarTiktok(token, client_id, periode);
+        const rekapRes = await getRekapKomentarTiktok(token, client_id, periode, date);
         const users = Array.isArray(rekapRes.data) ? rekapRes.data : [];
 
         // Ambil field TikTok Post dengan fallback urutan prioritas
@@ -82,7 +85,7 @@ export default function TiktokKomentarTrackingPage() {
     }
 
     fetchData();
-  }, [periode]);
+  }, [periode, date]);
 
   if (loading) return <Loader />;
   if (error)
@@ -190,6 +193,7 @@ export default function TiktokKomentarTrackingPage() {
               >
                 Bulan Ini
               </span>
+              <DateSelector date={date} setDate={setDate} />
             </div>
 
             {/* Chart per kelompok */}

--- a/cicero-dashboard/app/comments/tiktok/rekap/page.jsx
+++ b/cicero-dashboard/app/comments/tiktok/rekap/page.jsx
@@ -5,6 +5,7 @@ import Loader from "@/components/Loader";
 import RekapKomentarTiktok from "@/components/RekapKomentarTiktok";
 import Link from "next/link";
 import useRequireAuth from "@/hooks/useRequireAuth";
+import DateSelector from "@/components/DateSelector";
 
 export default function RekapKomentarTiktokPage() {
   useRequireAuth();
@@ -12,6 +13,8 @@ export default function RekapKomentarTiktokPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const [periode, setPeriode] = useState("harian");
+  const today = new Date().toISOString().split("T")[0];
+  const [date, setDate] = useState(today);
   const [rekapSummary, setRekapSummary] = useState({
     totalUser: 0,
     totalSudahKomentar: 0,
@@ -45,7 +48,7 @@ export default function RekapKomentarTiktokPage() {
           return;
         }
 
-        const rekapRes = await getRekapKomentarTiktok(token, client_id, periode);
+        const rekapRes = await getRekapKomentarTiktok(token, client_id, periode, date);
         const users = Array.isArray(rekapRes.data) ? rekapRes.data : [];
 
         // Sumber utama TikTok Post Hari Ini dari statsRes
@@ -79,7 +82,7 @@ export default function RekapKomentarTiktokPage() {
     }
 
     fetchData();
-  }, [periode]);
+  }, [periode, date]);
 
   if (loading) return <Loader />;
   if (error)
@@ -141,6 +144,7 @@ export default function RekapKomentarTiktokPage() {
             >
               Bulan Ini
             </span>
+            <DateSelector date={date} setDate={setDate} />
           </div>
 
           {/* Kirim data ke komponen detail rekap TikTok */}

--- a/cicero-dashboard/app/likes/instagram/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/page.jsx
@@ -8,6 +8,7 @@ import { groupUsersByKelompok } from "@/utils/grouping"; // pastikan path benar
 import Link from "next/link";
 import Narrative from "@/components/Narrative";
 import useRequireAuth from "@/hooks/useRequireAuth";
+import DateSelector from "@/components/DateSelector";
 
 export default function InstagramLikesTrackingPage() {
   useRequireAuth();
@@ -16,6 +17,8 @@ export default function InstagramLikesTrackingPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const [periode, setPeriode] = useState("harian"); // "harian" | "bulanan"
+  const today = new Date().toISOString().split("T")[0];
+  const [date, setDate] = useState(today);
 
   // Untuk rekap likes summary (total user, sudah likes, belum likes)
   const [rekapSummary, setRekapSummary] = useState({
@@ -51,7 +54,7 @@ export default function InstagramLikesTrackingPage() {
           return;
         }
 
-        const rekapRes = await getRekapLikesIG(token, client_id, periode);
+        const rekapRes = await getRekapLikesIG(token, client_id, periode, date);
         const users = Array.isArray(rekapRes.data) ? rekapRes.data : [];
 
         // Rekap summary
@@ -79,7 +82,7 @@ export default function InstagramLikesTrackingPage() {
     }
 
     fetchData();
-  }, [periode]);
+  }, [periode, date]);
 
   if (loading) return <Loader />;
   if (error)
@@ -185,6 +188,7 @@ export default function InstagramLikesTrackingPage() {
               >
                 Bulan Ini
               </span>
+              <DateSelector date={date} setDate={setDate} />
             </div>
 
             {/* Chart per kelompok */}

--- a/cicero-dashboard/app/likes/instagram/rekap/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/rekap/page.jsx
@@ -5,6 +5,7 @@ import Loader from "@/components/Loader";
 import RekapLikesIG from "@/components/RekapLikesIG";
 import Link from "next/link";
 import useRequireAuth from "@/hooks/useRequireAuth";
+import DateSelector from "@/components/DateSelector";
 
 export default function RekapLikesIGPage() {
   useRequireAuth();
@@ -12,6 +13,8 @@ export default function RekapLikesIGPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const [periode, setPeriode] = useState("harian");
+  const today = new Date().toISOString().split("T")[0];
+  const [date, setDate] = useState(today);
   const [rekapSummary, setRekapSummary] = useState({
     totalUser: 0,
     totalSudahLike: 0,
@@ -43,7 +46,7 @@ export default function RekapLikesIGPage() {
           return;
         }
 
-        const rekapRes = await getRekapLikesIG(token, client_id, periode);
+        const rekapRes = await getRekapLikesIG(token, client_id, periode, date);
         const users = Array.isArray(rekapRes.data) ? rekapRes.data : [];
 
         // Sumber utama IG Post Hari Ini dari statsRes
@@ -72,7 +75,7 @@ export default function RekapLikesIGPage() {
     }
 
     fetchData();
-  }, [periode]);
+  }, [periode, date]);
 
   if (loading) return <Loader />;
   if (error)
@@ -134,6 +137,7 @@ export default function RekapLikesIGPage() {
             >
               Bulan Ini
             </span>
+            <DateSelector date={date} setDate={setDate} />
           </div>
 
           {/* Kirim data dari fetch ke komponen rekap likes */}

--- a/cicero-dashboard/app/posts/instagram/page.jsx
+++ b/cicero-dashboard/app/posts/instagram/page.jsx
@@ -10,6 +10,7 @@ import WordCloudChart from "@/components/WordCloudChart";
 import Loader from "@/components/Loader";
 import Narrative from "@/components/Narrative";
 import PostCompareChart from "@/components/PostCompareChart";
+import FilterBar from "@/components/FilterBar";
 import useRequireAuth from "@/hooks/useRequireAuth";
 import {
   getInstagramProfileViaBackend,
@@ -29,6 +30,16 @@ export default function InstagramPostAnalysisPage() {
   const [compareStats, setCompareStats] = useState(null);
   const [compareLoading, setCompareLoading] = useState(false);
   const [compareError, setCompareError] = useState("");
+  const now = new Date();
+  const firstDay = new Date(now.getFullYear(), now.getMonth(), 1)
+    .toISOString()
+    .split("T")[0];
+  const lastDay = new Date(now.getFullYear(), now.getMonth() + 1, 0)
+    .toISOString()
+    .split("T")[0];
+  const [startDate, setStartDate] = useState(firstDay);
+  const [endDate, setEndDate] = useState(lastDay);
+  const [search, setSearch] = useState("");
   const fetchedRef = useRef(false);
 
   useEffect(() => {
@@ -158,7 +169,14 @@ export default function InstagramPostAnalysisPage() {
     );
   if (!profile) return null;
 
-  const filteredPosts = posts;
+  const filteredPosts = posts.filter((p) => {
+    const d = new Date(p.created_at);
+    if (startDate && d < new Date(startDate)) return false;
+    if (endDate && d > new Date(endDate + "T23:59:59")) return false;
+    if (search && !(p.caption || "").toLowerCase().includes(search.toLowerCase()))
+      return false;
+    return true;
+  });
 
   const sortedPosts = [...filteredPosts].sort(
     (a, b) => new Date(a.created_at) - new Date(b.created_at)
@@ -380,6 +398,14 @@ export default function InstagramPostAnalysisPage() {
           </div>
         )}
 
+        <FilterBar
+          startDate={startDate}
+          endDate={endDate}
+          search={search}
+          setStartDate={setStartDate}
+          setEndDate={setEndDate}
+          setSearch={setSearch}
+        />
 
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
           <CardStat title="Followers" value={profile.followers} />

--- a/cicero-dashboard/components/DateSelector.jsx
+++ b/cicero-dashboard/components/DateSelector.jsx
@@ -1,0 +1,14 @@
+"use client";
+export default function DateSelector({ date, setDate }) {
+  return (
+    <div className="flex items-center gap-1">
+      <label className="text-sm">Tanggal</label>
+      <input
+        type="date"
+        value={date}
+        onChange={(e) => setDate(e.target.value)}
+        className="border rounded px-2 py-1 text-sm"
+      />
+    </div>
+  );
+}

--- a/cicero-dashboard/utils/api.ts
+++ b/cicero-dashboard/utils/api.ts
@@ -50,9 +50,11 @@ export async function getDashboardStats(token: string): Promise<any> {
 export async function getRekapLikesIG(
   token: string,
   client_id: string,
-  periode: string = "harian"
+  periode: string = "harian",
+  tanggal?: string
 ): Promise<any> {
   const params = new URLSearchParams({ client_id, periode });
+  if (tanggal) params.append("tanggal", tanggal);
   const url = `${API_BASE_URL}/api/insta/rekap-likes?${params.toString()}`;
 
   const res = await fetchWithAuth(url, token);
@@ -113,9 +115,11 @@ export async function getTikTokComments(token: string): Promise<any> {
 export async function getRekapKomentarTiktok(
   token: string,
   client_id: string,
-  periode: string = "harian"
+  periode: string = "harian",
+  tanggal?: string
 ): Promise<any> {
   const params = new URLSearchParams({ client_id, periode });
+  if (tanggal) params.append("tanggal", tanggal);
   const url = `${API_BASE_URL}/api/tiktok/rekap-komentar?${params.toString()}`;
 
   const res = await fetchWithAuth(url, token);
@@ -130,9 +134,11 @@ export async function getRekapKomentarTiktok(
 export async function getRekapAmplify(
   token: string,
   client_id: string,
-  periode: string = "harian"
+  periode: string = "harian",
+  tanggal?: string
 ): Promise<any> {
   const params = new URLSearchParams({ client_id, periode });
+  if (tanggal) params.append("tanggal", tanggal);
   const url = `${API_BASE_URL}/api/amplify/rekap?${params.toString()}`;
 
   const res = await fetchWithAuth(url, token);


### PR DESCRIPTION
## Summary
- add generic `DateSelector` component
- support `tanggal` filter in API utilities
- show date selector in Amplify, Likes, Comments pages and Instagram post analytics
- expose filter to tests

## Testing
- `npm --prefix cicero-dashboard test`

------
https://chatgpt.com/codex/tasks/task_e_687066f5b9f4832780d6861d98ed7ada