### PR TITLE
Improve dashboard layout and sidebar

### DIFF
--- a/cicero-dashboard/app/dashboard/page.jsx
+++ b/cicero-dashboard/app/dashboard/page.jsx
@@ -7,6 +7,7 @@ import {
   getTiktokProfileViaBackend,
   getTiktokPostsViaBackend,
 } from "@/utils/api";
+import DashboardStats from "@/components/DashboardStats";
 import Loader from "@/components/Loader";
 import useRequireAuth from "@/hooks/useRequireAuth";
 import { useAuth } from "@/context/AuthContext";
@@ -80,7 +81,8 @@ export default function DashboardPage() {
       <div className="fixed inset-0 bg-gradient-to-br from-blue-100 via-fuchsia-50 to-white flex items-center justify-center overflow-hidden">
         <div className="bg-white rounded-2xl shadow-lg text-center text-red-500 font-bold max-w-sm w-full p-6">{error}</div>
       </div>
-    );
+    </div>
+  );
 
   if (!clientProfile)
     return (
@@ -94,10 +96,22 @@ export default function DashboardPage() {
 
   return (
     <div className="min-h-screen bg-gray-100 flex flex-col items-center py-8">
-      <div className="w-full max-w-6xl grid grid-cols-1 md:grid-cols-3 gap-4">
-        <ClientCard profile={clientProfile} />
-        <SocialCard platform="instagram" profile={igProfile} posts={igPosts} />
-        <SocialCard platform="tiktok" profile={tiktokProfile} posts={tiktokPosts} />
+      <div className="w-full max-w-6xl space-y-6">
+        <DashboardStats
+          igProfile={igProfile}
+          igPosts={igPosts}
+          tiktokProfile={tiktokProfile}
+          tiktokPosts={tiktokPosts}
+        />
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <ClientCard profile={clientProfile} />
+          <SocialCard platform="instagram" profile={igProfile} posts={igPosts} />
+          <SocialCard
+            platform="tiktok"
+            profile={tiktokProfile}
+            posts={tiktokPosts}
+          />
+        </div>
       </div>
     </div>
   );

--- a/cicero-dashboard/components/DashboardStats.jsx
+++ b/cicero-dashboard/components/DashboardStats.jsx
@@ -1,0 +1,18 @@
+import CardStat from "./CardStat";
+
+export default function DashboardStats({ igProfile, igPosts, tiktokProfile, tiktokPosts }) {
+  const stats = [
+    { title: "IG Followers", value: igProfile?.followers ?? 0 },
+    { title: "IG Posts", value: igPosts?.length ?? 0 },
+    { title: "TikTok Followers", value: tiktokProfile?.followers ?? 0 },
+    { title: "TikTok Posts", value: tiktokPosts?.length ?? 0 },
+  ];
+
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+      {stats.map((s) => (
+        <CardStat key={s.title} title={s.title} value={s.value} />
+      ))}
+    </div>
+  );
+}

--- a/cicero-dashboard/components/Sidebar.jsx
+++ b/cicero-dashboard/components/Sidebar.jsx
@@ -12,6 +12,9 @@ import {
   Heart,
   Music,
   MessageCircle,
+  ChevronLeft,
+  ChevronRight,
+  LogOut,
 } from "lucide-react";
 import {
   Sheet,
@@ -34,6 +37,7 @@ export default function Sidebar() {
   const pathname = usePathname();
   const router = useRouter();
   const [open, setOpen] = useState(false);
+  const [collapsed, setCollapsed] = useState(false);
   const { setAuth } = useAuth();
 
   const handleLogout = () => {
@@ -41,9 +45,11 @@ export default function Sidebar() {
     router.replace("/login");
   };
 
-  const navLinks = (isSheet = false) => (
+  const navLinks = (isSheet = false, isCollapsed = false) => (
     <>
-      <div className="text-2xl font-bold text-blue-700 mb-6 px-4">CICERO Dashboard</div>
+      <div className="text-2xl font-bold text-blue-700 mb-6 px-4">
+        {isCollapsed ? "C" : "CICERO Dashboard"}
+      </div>
       <nav className="flex-1 space-y-1 px-2">
         {menu.map((item) => {
           const ItemIcon = item.icon;
@@ -51,20 +57,21 @@ export default function Sidebar() {
             <Link
               key={item.path}
               href={item.path}
-              className={`flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors ${pathname.startsWith(item.path) ? "bg-blue-100 text-blue-700" : "text-gray-700 hover:bg-blue-50 hover:text-blue-700"}`}
+              className={`flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors ${pathname.startsWith(item.path) ? "bg-blue-100 text-blue-700" : "text-gray-700 hover:bg-blue-50 hover:text-blue-700"} ${isCollapsed ? "justify-center" : ""}`}
               {...(isSheet ? { onClick: () => setOpen(false) } : {})}
             >
               <ItemIcon className="w-5 h-5" />
-              <span>{item.label}</span>
+              {!isCollapsed && <span>{item.label}</span>}
             </Link>
           );
         })}
       </nav>
       <button
         onClick={handleLogout}
-        className="mt-4 mx-2 w-auto bg-red-50 hover:bg-red-100 text-red-600 font-semibold py-2 rounded-md"
+        className="mt-4 mx-2 w-auto bg-red-50 hover:bg-red-100 text-red-600 font-semibold py-2 rounded-md flex items-center justify-center gap-2"
       >
-        Logout
+        <LogOut className="w-5 h-5" />
+        {!isCollapsed && <span>Logout</span>}
       </button>
     </>
   );
@@ -86,12 +93,27 @@ export default function Sidebar() {
         </SheetTrigger>
         <SheetContent side="left" className="w-64 p-4 flex flex-col md:hidden">
           <SheetTitle className="sr-only">Navigation Menu</SheetTitle>
-          {navLinks(true)}
+          {navLinks(true, false)}
         </SheetContent>
       </Sheet>
 
-      <div className="hidden md:flex md:w-64 md:flex-col md:border-r md:bg-white md:shadow-sm">
-        {navLinks(false)}
+      <div
+        className={`hidden md:flex ${collapsed ? "md:w-20" : "md:w-64"} md:flex-col md:border-r md:bg-white md:shadow-sm transition-all`}
+      >
+        <div className="flex justify-end p-2">
+          <button
+            onClick={() => setCollapsed(!collapsed)}
+            className="text-gray-500 hover:text-gray-700"
+            aria-label="Toggle Sidebar"
+          >
+            {collapsed ? (
+              <ChevronRight size={20} />
+            ) : (
+              <ChevronLeft size={20} />
+            )}
+          </button>
+        </div>
+        {navLinks(false, collapsed)}
       </div>
     </>
   );


### PR DESCRIPTION
## Summary
- redesign sidebar with collapse toggle and logout icon
- add a new `DashboardStats` component to show key metrics
- integrate stats and responsive layout on dashboard

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687076cb101c8327a9e21de33ef7178a