### PR TITLE
Improve sidebar height

### DIFF
--- a/cicero-dashboard/components/LayoutClient.tsx
+++ b/cicero-dashboard/components/LayoutClient.tsx
@@ -19,7 +19,7 @@ export default function LayoutClient({ children }: { children: React.ReactNode }
     <>
       <Header />
       <div className="flex min-h-screen bg-gray-100 dark:bg-gray-950">
-        <aside aria-label="Sidebar navigation">
+        <aside aria-label="Sidebar navigation" className="md:min-h-screen">
           <SidebarWrapper />
         </aside>
         <main id="main-content" className="flex-1 p-4 md:p-8">

--- a/cicero-dashboard/components/Sidebar.jsx
+++ b/cicero-dashboard/components/Sidebar.jsx
@@ -98,7 +98,7 @@ export default function Sidebar() {
       </Sheet>
 
       <div
-        className={`hidden md:flex ${collapsed ? "md:w-20" : "md:w-64"} md:flex-col md:border-r md:bg-white md:shadow-sm transition-all`}
+        className={`hidden md:flex ${collapsed ? "md:w-20" : "md:w-64"} md:flex-col md:border-r md:bg-white md:shadow-sm md:min-h-screen transition-all`}
       >
         <div className="flex justify-end p-2">
           <button


### PR DESCRIPTION
## Summary
- ensure sidebar matches viewport height by adding `min-h-screen`
- keep mobile sidebar button visible

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68707be2276083279f5ecd05a1e6fbd1