### PR TITLE
Add edit capability in user directory

### DIFF
--- a/cicero-dashboard/utils/api.ts
+++ b/cicero-dashboard/utils/api.ts
@@ -104,6 +104,24 @@ export async function createUser(
   return res.json();
 }
 
+// Perbarui data user yang ada
+export async function updateUser(
+  token: string,
+  userId: string,
+  data: Record<string, any>,
+): Promise<any> {
+  const url = `${API_BASE_URL}/api/users/${encodeURIComponent(userId)}`;
+  const res = await fetchWithAuth(url, token, {
+    method: "PUT",
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Gagal memperbarui user: ${text}`);
+  }
+  return res.json();
+}
+
 // Ambil komentar TikTok
 export async function getTikTokComments(token: string): Promise<any> {
   const url = `${API_BASE_URL}/api/tiktok/comments`;


### PR DESCRIPTION
## Summary
- allow updating users via `updateUser` API helper
- enable editing from user directory page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687082d4cfe08327bcde2cf1e7578e38