### PR TITLE
Use lucide icons everywhere

### DIFF
--- a/cicero-dashboard/app/comments/tiktok/page.jsx
+++ b/cicero-dashboard/app/comments/tiktok/page.jsx
@@ -9,6 +9,13 @@ import Link from "next/link";
 import Narrative from "@/components/Narrative";
 import useRequireAuth from "@/hooks/useRequireAuth";
 import DateSelector from "@/components/DateSelector";
+import {
+  Music,
+  User,
+  MessageCircle,
+  X,
+  ArrowRight
+} from "lucide-react";
 
 export default function TiktokKomentarTrackingPage() {
   useRequireAuth();
@@ -116,44 +123,28 @@ export default function TiktokKomentarTrackingPage() {
                 label="TikTok Post Hari Ini"
                 value={rekapSummary.totalTiktokPost}
                 color="fuchsia"
-                icon={
-                  <span className="inline-block text-fuchsia-400 text-2xl">
-                    🎵
-                  </span>
-                }
+                icon={<Music className="text-fuchsia-400" />}
               />
               <Divider />
               <SummaryItem
                 label="Total User"
                 value={rekapSummary.totalUser}
                 color="gray"
-                icon={
-                  <span className="inline-block text-gray-400 text-2xl">
-                    👤
-                  </span>
-                }
+                icon={<User className="text-gray-400" />}
               />
               <Divider />
               <SummaryItem
                 label="Sudah Komentar"
                 value={rekapSummary.totalSudahKomentar}
                 color="green"
-                icon={
-                  <span className="inline-block text-green-500 text-2xl">
-                    💬
-                  </span>
-                }
+                icon={<MessageCircle className="text-green-500" />}
               />
               <Divider />
               <SummaryItem
                 label="Belum Komentar"
                 value={rekapSummary.totalBelumKomentar}
                 color="red"
-                icon={
-                  <span className="inline-block text-red-500 text-2xl">
-                    ❌
-                  </span>
-                }
+                icon={<X className="text-red-500" />}
               />
             </div>
 
@@ -239,20 +230,7 @@ export default function TiktokKomentarTrackingPage() {
                 href="/comments/tiktok/rekap"
                 className="bg-pink-700 hover:bg-pink-800 text-white font-bold px-6 py-3 rounded-xl shadow transition-all duration-150 text-lg flex items-center gap-2"
               >
-                <svg
-                  width="20"
-                  height="20"
-                  fill="none"
-                  className="inline align-middle"
-                >
-                  <path
-                    d="M7 15l5-5-5-5"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                </svg>
+                <ArrowRight className="w-5 h-5 inline" />
                 Lihat Rekap Detail
               </Link>
             </div>

--- a/cicero-dashboard/app/comments/tiktok/rekap/page.jsx
+++ b/cicero-dashboard/app/comments/tiktok/rekap/page.jsx
@@ -6,6 +6,7 @@ import RekapKomentarTiktok from "@/components/RekapKomentarTiktok";
 import Link from "next/link";
 import useRequireAuth from "@/hooks/useRequireAuth";
 import DateSelector from "@/components/DateSelector";
+import { ArrowLeft } from "lucide-react";
 
 export default function RekapKomentarTiktokPage() {
   useRequireAuth();
@@ -104,9 +105,10 @@ export default function RekapKomentarTiktokPage() {
             </h1>
             <Link
               href="/comments/tiktok"
-              className="inline-block bg-gray-100 hover:bg-pink-50 text-pink-700 border border-pink-300 font-semibold px-4 py-2 rounded-lg transition-all duration-150 shadow"
+              className="inline-block bg-gray-100 hover:bg-pink-50 text-pink-700 border border-pink-300 font-semibold px-4 py-2 rounded-lg transition-all duration-150 shadow flex items-center gap-2"
             >
-              ← Kembali
+              <ArrowLeft className="w-4 h-4" />
+              Kembali
             </Link>
           </div>
           <div className="flex items-center justify-end gap-3 mb-2">

--- a/cicero-dashboard/app/dashboard/page.jsx
+++ b/cicero-dashboard/app/dashboard/page.jsx
@@ -11,6 +11,7 @@ import DashboardStats from "@/components/DashboardStats";
 import Loader from "@/components/Loader";
 import useRequireAuth from "@/hooks/useRequireAuth";
 import { useAuth } from "@/context/AuthContext";
+import { Check, X } from "lucide-react";
 
 export default function DashboardPage() {
   useRequireAuth();
@@ -155,13 +156,9 @@ function ClientCard({ profile }) {
         status={
           profile.client_insta_status !== undefined && (
             profile.client_insta_status ? (
-              <svg className="w-4 h-4 ml-1 text-green-600 inline" fill="none" stroke="currentColor" strokeWidth={3} viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-              </svg>
+              <Check className="w-4 h-4 ml-1 text-green-600 inline" />
             ) : (
-              <svg className="w-4 h-4 ml-1 text-red-500 inline" fill="none" stroke="currentColor" strokeWidth={3} viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-              </svg>
+              <X className="w-4 h-4 ml-1 text-red-500 inline" />
             )
           )
         }
@@ -185,13 +182,9 @@ function ClientCard({ profile }) {
         status={
           profile.client_tiktok_status !== undefined && (
             profile.client_tiktok_status ? (
-              <svg className="w-4 h-4 ml-1 text-green-600 inline" fill="none" stroke="currentColor" strokeWidth={3} viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-              </svg>
+              <Check className="w-4 h-4 ml-1 text-green-600 inline" />
             ) : (
-              <svg className="w-4 h-4 ml-1 text-red-500 inline" fill="none" stroke="currentColor" strokeWidth={3} viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-              </svg>
+              <X className="w-4 h-4 ml-1 text-red-500 inline" />
             )
           )
         }

--- a/cicero-dashboard/app/likes/instagram/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/page.jsx
@@ -9,6 +9,13 @@ import Link from "next/link";
 import Narrative from "@/components/Narrative";
 import useRequireAuth from "@/hooks/useRequireAuth";
 import DateSelector from "@/components/DateSelector";
+import {
+  Camera,
+  User,
+  ThumbsUp,
+  ThumbsDown,
+  ArrowRight
+} from "lucide-react";
 
 export default function InstagramLikesTrackingPage() {
   useRequireAuth();
@@ -113,42 +120,28 @@ export default function InstagramLikesTrackingPage() {
                 label="IG Post Hari Ini"
                 value={rekapSummary.totalIGPost}
                 color="blue"
-                icon={
-                  <span className="inline-block text-blue-400 text-2xl">
-                    📸
-                  </span>
-                }
+                icon={<Camera className="text-blue-400" />}
               />
               <Divider />
               <SummaryItem
                 label="Total User"
                 value={rekapSummary.totalUser}
                 color="gray"
-                icon={
-                  <span className="inline-block text-gray-400 text-2xl">
-                    👤
-                  </span>
-                }
+                icon={<User className="text-gray-400" />}
               />
               <Divider />
               <SummaryItem
                 label="Sudah Likes"
                 value={rekapSummary.totalSudahLike}
                 color="green"
-                icon={
-                  <span className="inline-block text-green-500 text-2xl">
-                    👍
-                  </span>
-                }
+                icon={<ThumbsUp className="text-green-500" />}
               />
               <Divider />
               <SummaryItem
                 label="Belum Likes"
                 value={rekapSummary.totalBelumLike}
                 color="red"
-                icon={
-                  <span className="inline-block text-red-500 text-2xl">👎</span>
-                }
+                icon={<ThumbsDown className="text-red-500" />}
               />
             </div>
 
@@ -227,20 +220,7 @@ export default function InstagramLikesTrackingPage() {
                 href="/likes/instagram/rekap"
                 className="bg-blue-700 hover:bg-blue-800 text-white font-bold px-6 py-3 rounded-xl shadow transition-all duration-150 text-lg flex items-center gap-2"
               >
-                <svg
-                  width="20"
-                  height="20"
-                  fill="none"
-                  className="inline align-middle"
-                >
-                  <path
-                    d="M7 15l5-5-5-5"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                </svg>
+                <ArrowRight className="w-5 h-5 inline" />
                 Lihat Rekap Detail
               </Link>
             </div>

--- a/cicero-dashboard/app/likes/instagram/rekap/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/rekap/page.jsx
@@ -6,6 +6,7 @@ import RekapLikesIG from "@/components/RekapLikesIG";
 import Link from "next/link";
 import useRequireAuth from "@/hooks/useRequireAuth";
 import DateSelector from "@/components/DateSelector";
+import { ArrowLeft } from "lucide-react";
 
 export default function RekapLikesIGPage() {
   useRequireAuth();
@@ -97,9 +98,10 @@ export default function RekapLikesIGPage() {
             </h1>
             <Link
               href="/likes/instagram"
-              className="inline-block bg-gray-100 hover:bg-blue-50 text-blue-700 border border-blue-300 font-semibold px-4 py-2 rounded-lg transition-all duration-150 shadow"
+              className="inline-block bg-gray-100 hover:bg-blue-50 text-blue-700 border border-blue-300 font-semibold px-4 py-2 rounded-lg transition-all duration-150 shadow flex items-center gap-2"
             >
-              ← Kembali
+              <ArrowLeft className="w-4 h-4" />
+              Kembali
             </Link>
           </div>
           <div className="flex items-center justify-end gap-3 mb-2">

--- a/cicero-dashboard/components/InstagramPostsGrid.jsx
+++ b/cicero-dashboard/components/InstagramPostsGrid.jsx
@@ -1,4 +1,5 @@
 "use client";
+import { Heart, MessageCircle, Eye } from "lucide-react";
 export default function InstagramPostsGrid({ posts = [] }) {
   const getThumbnailSrc = (url) => {
     if (!url) return "/file.svg";
@@ -25,9 +26,21 @@ export default function InstagramPostsGrid({ posts = [] }) {
               {post.caption || "-"}
             </p>
             <div className="text-xs text-gray-600 flex gap-4">
-              {post.like_count != null && <span>❤️ {post.like_count}</span>}
-              {post.comment_count != null && <span>💬 {post.comment_count}</span>}
-              {post.view_count != null && <span>👁️ {post.view_count}</span>}
+              {post.like_count != null && (
+                <span className="flex items-center gap-1">
+                  <Heart className="w-3 h-3" /> {post.like_count}
+                </span>
+              )}
+              {post.comment_count != null && (
+                <span className="flex items-center gap-1">
+                  <MessageCircle className="w-3 h-3" /> {post.comment_count}
+                </span>
+              )}
+              {post.view_count != null && (
+                <span className="flex items-center gap-1">
+                  <Eye className="w-3 h-3" /> {post.view_count}
+                </span>
+              )}
             </div>
           </div>
         </div>

--- a/cicero-dashboard/components/RekapKomentarTiktok.jsx
+++ b/cicero-dashboard/components/RekapKomentarTiktok.jsx
@@ -1,5 +1,6 @@
 "use client";
 import { useMemo, useState, useEffect } from "react";
+import { Music, Users, Check, X } from "lucide-react";
 
 function isException(val) {
   return val === true || val === "true" || val === 1 || val === "1";
@@ -82,25 +83,25 @@ export default function RekapKomentarTiktok({ users = [], totalTiktokPost = 0 })
           title="TikTok Post Hari Ini"
           value={totalTiktokPost}
           color="bg-gradient-to-r from-pink-400 via-fuchsia-400 to-blue-400 text-white"
-          icon={<span className="text-3xl">🎵</span>}
+          icon={<Music />}
         />
         <SummaryCard
           title="Total User"
           value={totalUser}
           color="bg-gradient-to-r from-blue-400 via-blue-500 to-sky-400 text-white"
-          icon={<svg className="w-8 h-8 text-white" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M17 20h5v-2a4 4 0 00-3-3.87M9 20h6M3 20h5m0 0v-2a4 4 0 00-3-3.87m3 3.87a9 9 0 0010 0m-10 0a9 9 0 0110 0M6 20v-2a4 4 0 013-3.87M18 20v-2a4 4 0 00-3-3.87"/></svg>}
+          icon={<Users />}
         />
         <SummaryCard
           title="Sudah Komentar"
           value={totalSudahKomentar}
           color="bg-gradient-to-r from-green-400 via-green-500 to-lime-400 text-white"
-          icon={<svg className="w-8 h-8 text-white" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7"/></svg>}
+          icon={<Check />}
         />
         <SummaryCard
           title="Belum Komentar"
           value={totalBelumKomentar}
           color="bg-gradient-to-r from-red-400 via-pink-500 to-yellow-400 text-white"
-          icon={<svg className="w-8 h-8 text-white" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>}
+          icon={<X />}
         />
       </div>
 
@@ -140,12 +141,12 @@ export default function RekapKomentarTiktok({ users = [], totalTiktokPost = 0 })
                   <td className="py-1 px-2 text-center">
                     {sudahKomentar ? (
                       <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs bg-green-500 text-white font-semibold">
-                        <svg className="w-3 h-3" fill="none" stroke="currentColor" strokeWidth={3} viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7"/></svg>
+                        <Check className="w-3 h-3" />
                         Sudah
                       </span>
                     ) : (
                       <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs bg-red-500 text-white font-semibold">
-                        <svg className="w-3 h-3" fill="none" stroke="currentColor" strokeWidth={3} viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
+                        <X className="w-3 h-3" />
                         Belum
                       </span>
                     )}

--- a/cicero-dashboard/components/RekapLikesIG.jsx
+++ b/cicero-dashboard/components/RekapLikesIG.jsx
@@ -1,5 +1,6 @@
 "use client";
 import { useMemo, useState, useEffect } from "react";
+import { Camera, Users, Check, X } from "lucide-react";
 
 // Utility: handle boolean/string/number for exception
 function isException(val) {
@@ -101,31 +102,25 @@ export default function RekapLikesIG({ users = [], totalIGPost = 0 }) {
           title="IG Post Hari Ini"
           value={totalIGPost}
           color="bg-gradient-to-r from-pink-400 via-fuchsia-400 to-blue-400 text-white"
-          icon={<span className="text-3xl">📸</span>}
+          icon={<Camera />}
         />
         <SummaryCard
           title="Total User"
           value={totalUser}
           color="bg-gradient-to-r from-blue-400 via-blue-500 to-sky-400 text-white"
-          icon={
-            <svg className="w-8 h-8 text-white" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M17 20h5v-2a4 4 0 00-3-3.87M9 20h6M3 20h5m0 0v-2a4 4 0 00-3-3.87m3 3.87a9 9 0 0010 0m-10 0a9 9 0 0110 0M6 20v-2a4 4 0 013-3.87M18 20v-2a4 4 0 00-3-3.87" /></svg>
-          }
+          icon={<Users />}
         />
         <SummaryCard
           title="Sudah Like"
           value={totalSudahLike}
           color="bg-gradient-to-r from-green-400 via-green-500 to-lime-400 text-white"
-          icon={
-            <svg className="w-8 h-8 text-white" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" /></svg>
-          }
+          icon={<Check />}
         />
         <SummaryCard
           title="Belum Like"
           value={totalBelumLike}
           color="bg-gradient-to-r from-red-400 via-pink-500 to-yellow-400 text-white"
-          icon={
-            <svg className="w-8 h-8 text-white" fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" /></svg>
-          }
+          icon={<X />}
         />
       </div>
 
@@ -175,12 +170,12 @@ export default function RekapLikesIG({ users = [], totalIGPost = 0 }) {
                   <td className="py-1 px-2 text-center">
                     {sudahLike ? (
                       <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs bg-green-500 text-white font-semibold">
-                        <svg className="w-3 h-3" fill="none" stroke="currentColor" strokeWidth={3} viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" /></svg>
+                        <Check className="w-3 h-3" />
                         Sudah
                       </span>
                     ) : (
                       <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs bg-red-500 text-white font-semibold">
-                        <svg className="w-3 h-3" fill="none" stroke="currentColor" strokeWidth={3} viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" /></svg>
+                        <X className="w-3 h-3" />
                         Belum
                       </span>
                     )}

--- a/cicero-dashboard/components/TiktokPostsGrid.jsx
+++ b/cicero-dashboard/components/TiktokPostsGrid.jsx
@@ -1,4 +1,5 @@
 "use client";
+import { Heart, MessageCircle, Eye } from "lucide-react";
 export default function TiktokPostsGrid({ posts = [] }) {
   const getThumbnailSrc = (url) => {
     if (!url) return "/file.svg";
@@ -25,9 +26,21 @@ export default function TiktokPostsGrid({ posts = [] }) {
               {post.caption || "-"}
             </p>
             <div className="text-xs text-gray-600 flex gap-4">
-              {post.like_count != null && <span>❤️ {post.like_count}</span>}
-              {post.comment_count != null && <span>💬 {post.comment_count}</span>}
-              {post.view_count != null && <span>👁️ {post.view_count}</span>}
+              {post.like_count != null && (
+                <span className="flex items-center gap-1">
+                  <Heart className="w-3 h-3" /> {post.like_count}
+                </span>
+              )}
+              {post.comment_count != null && (
+                <span className="flex items-center gap-1">
+                  <MessageCircle className="w-3 h-3" /> {post.comment_count}
+                </span>
+              )}
+              {post.view_count != null && (
+                <span className="flex items-center gap-1">
+                  <Eye className="w-3 h-3" /> {post.view_count}
+                </span>
+              )}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- replace all emoji and inline SVG with lucide-react icons on all pages except the landing page
- update imports to use lucide-react icons

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870e3293a948327a1095d8d7eae16df