### PR TITLE
Fix Instagram profile image selection

### DIFF
--- a/cicero-dashboard/app/dashboard/page.jsx
+++ b/cicero-dashboard/app/dashboard/page.jsx
@@ -131,12 +131,12 @@ function SocialCard({ platform, profile, posts }) {
     );
 
   const avatar =
+    profile.profile_pic_url_hd ||
+    profile.profile_pic_url ||
     profile.avatar_url ||
     profile.avatar ||
     profile.hd_profile_pic_url_info?.url ||
     profile.hd_profile_pic_versions?.[0]?.url ||
-    profile.profile_pic_url ||
-    profile.profile_pic_url_hd ||
     "";
 
   const link =

--- a/cicero-dashboard/app/posts/instagram/page.jsx
+++ b/cicero-dashboard/app/posts/instagram/page.jsx
@@ -242,9 +242,10 @@ export default function InstagramPostAnalysisPage() {
   const privacyStatus = info?.is_private ? "Privat" : "Terbuka";
 
   const profilePic =
+    profile.profile_pic_url_hd ||
+    profile.profile_pic_url ||
     profile.hd_profile_pic_url_info?.url ||
     profile.hd_profile_pic_versions?.[0]?.url ||
-    profile.profile_pic_url ||
     info?.hd_profile_pic_url_info?.url ||
     info?.hd_profile_pic_versions?.[0]?.url ||
     "";


### PR DESCRIPTION
## Summary
- prioritize profile_pic_url fields from backend when choosing profile avatar
- ensure Instagram post analysis page prefers HD profile image

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687104fb929083279ef2fca3c790cfdc