### PR TITLE
Display profile image URL

### DIFF
--- a/cicero-dashboard/app/info/instagram/page.jsx
+++ b/cicero-dashboard/app/info/instagram/page.jsx
@@ -243,6 +243,11 @@ export default function InstagramInfoPage() {
             </div>
             <div className="text-gray-500">@{profile.username}</div>
             <div className="text-gray-500 text-sm">{info?.category || "-"}</div>
+            {profilePic && (
+              <div className="text-gray-400 text-xs break-all mt-1">
+                {profilePic}
+              </div>
+            )}
           </div>
         </div>
 

--- a/cicero-dashboard/app/posts/instagram/page.jsx
+++ b/cicero-dashboard/app/posts/instagram/page.jsx
@@ -351,6 +351,11 @@ export default function InstagramPostAnalysisPage() {
             {profile.category && (
               <div className="text-gray-500 text-sm">{profile.category}</div>
             )}
+            {profilePic && (
+              <div className="text-gray-400 text-xs break-all mt-1">
+                {profilePic}
+              </div>
+            )}
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- display profile image URL text on Instagram post page
- display profile image URL text on Instagram info page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68710a6e6b54832781607ae13f8caa63