### PR TITLE
Update login to support dashboard-user auth

### DIFF
--- a/cicero-dashboard/components/Header.tsx
+++ b/cicero-dashboard/components/Header.tsx
@@ -19,7 +19,7 @@ export default function Header() {
   const router = useRouter();
 
   const handleLogout = () => {
-    setAuth(null, null);
+    setAuth(null, null, null);
     router.replace("/login");
   };
 

--- a/cicero-dashboard/context/AuthContext.tsx
+++ b/cicero-dashboard/context/AuthContext.tsx
@@ -4,7 +4,12 @@ import { createContext, useContext, useEffect, useState } from "react";
 type AuthState = {
   token: string | null;
   clientId: string | null;
-  setAuth: (token: string | null, clientId: string | null) => void;
+  userId: string | null;
+  setAuth: (
+    token: string | null,
+    clientId: string | null,
+    userId: string | null,
+  ) => void;
 };
 
 const AuthContext = createContext<AuthState | undefined>(undefined);
@@ -12,25 +17,35 @@ const AuthContext = createContext<AuthState | undefined>(undefined);
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [token, setToken] = useState<string | null>(null);
   const [clientId, setClientId] = useState<string | null>(null);
+  const [userId, setUserId] = useState<string | null>(null);
 
   useEffect(() => {
     const storedToken = localStorage.getItem("cicero_token");
     const storedClient = localStorage.getItem("client_id");
+    const storedUser = localStorage.getItem("user_id");
     setToken(storedToken);
     setClientId(storedClient);
+    setUserId(storedUser);
   }, []);
 
-  const setAuth = (newToken: string | null, newClient: string | null) => {
+  const setAuth = (
+    newToken: string | null,
+    newClient: string | null,
+    newUser: string | null,
+  ) => {
     setToken(newToken);
     setClientId(newClient);
+    setUserId(newUser);
     if (newToken) localStorage.setItem("cicero_token", newToken);
     else localStorage.removeItem("cicero_token");
     if (newClient) localStorage.setItem("client_id", newClient);
     else localStorage.removeItem("client_id");
+    if (newUser) localStorage.setItem("user_id", newUser);
+    else localStorage.removeItem("user_id");
   };
 
   return (
-    <AuthContext.Provider value={{ token, clientId, setAuth }}>
+    <AuthContext.Provider value={{ token, clientId, userId, setAuth }}>
       {children}
     </AuthContext.Provider>
   );


### PR DESCRIPTION
## Summary
- update auth context to store `userId`
- replace old login form with username/password based dashboard login
- add registration form on login page
- update header logout logic

## Testing
- `npm install`
- `npm test`
- `npm run lint` (no output)

------
https://chatgpt.com/codex/tasks/task_e_6879dd1c3f9c8327a8ff7e950cfda370