### PR TITLE
Add terms of service and privacy docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ NEXT_PUBLIC_API_URL=<backend base url>
 - Static assets such as icons reside in `cicero-dashboard/public`.
 - The backend no longer restricts how many users can log in at once.
 - Clients may allow an unlimited number of concurrent sessions.
+- Terms of Service and Privacy Policy for Google sign-in are available at `/terms-of-service` and `/privacy-policy`. See `docs/google_auth_policies.md` for details.
 
 For more information about Next.js features, refer to the documentation inside `cicero-dashboard/README.md`.
 

--- a/cicero-dashboard/app/privacy-policy/page.jsx
+++ b/cicero-dashboard/app/privacy-policy/page.jsx
@@ -1,0 +1,26 @@
+export const metadata = {
+  title: "Kebijakan Privasi",
+  description: "Penjelasan cara kami menangani data Google Authentication."
+};
+
+export default function PrivacyPolicyPage() {
+  return (
+    <main className="max-w-3xl mx-auto p-6 prose">
+      <h1>Kebijakan Privasi</h1>
+      <p>
+        Cicero Dashboard menggunakan Google Authentication untuk proses log in.
+        Saat Anda menyetujui permintaan akses, kami hanya memperoleh nama,
+        alamat email, dan ID Google Anda.
+      </p>
+      <p>
+        Informasi tersebut tidak disimpan untuk keperluan lain selain
+        autentikasi. Kami tidak membagikan data ke pihak ketiga dan tidak
+        menggunakannya untuk iklan.
+      </p>
+      <p>
+        Anda dapat meminta penghapusan akun dengan menghubungi administrator.
+        Seluruh data Google yang tersimpan akan dihapus.
+      </p>
+    </main>
+  );
+}

--- a/cicero-dashboard/app/terms-of-service/page.jsx
+++ b/cicero-dashboard/app/terms-of-service/page.jsx
@@ -1,0 +1,24 @@
+export const metadata = {
+  title: "Ketentuan Layanan",
+  description: "Ketentuan penggunaan Cicero Dashboard dengan Google Auth."
+};
+
+export default function TermsOfServicePage() {
+  return (
+    <main className="max-w-3xl mx-auto p-6 prose">
+      <h1>Ketentuan Layanan</h1>
+      <p>
+        Cicero Dashboard menyediakan fitur masuk menggunakan akun Google. Informasi
+        yang diterima berupa nama, alamat email dan ID Google Anda. Data
+        tersebut dipakai semata-mata untuk memverifikasi identitas dan
+        memberikan akses ke dashboard.
+      </p>
+      <p>
+        Kami tidak membagikan data Google Anda ke pihak mana pun. Pengguna wajib
+        menjaga kerahasiaan kredensial. Pelanggaran atau penyalahgunaan layanan
+        dapat berakibat penghentian akses.
+      </p>
+      <p>Hubungi admin bila ada pertanyaan seputar ketentuan ini.</p>
+    </main>
+  );
+}

--- a/docs/google_auth_policies.md
+++ b/docs/google_auth_policies.md
@@ -1,0 +1,8 @@
+# Google Authentication Policies
+
+Cicero Dashboard menyediakan fitur login melalui Google. Untuk memenuhi persyaratan Google, dua halaman informasi disertakan:
+
+- **Terms of Service** – tersedia di `/terms-of-service`. Halaman ini menjelaskan ketentuan penggunaan layanan ketika pengguna masuk memakai akun Google.
+- **Privacy Policy** – tersedia di `/privacy-policy`. Menjabarkan jenis data Google yang diterima (nama, email, ID) dan cara kami memprosesnya.
+
+Kedua halaman berada di direktori `cicero-dashboard/app`. Apabila diperlukan perubahan, sunting `terms-of-service/page.jsx` atau `privacy-policy/page.jsx`.


### PR DESCRIPTION
## Summary
- create `/terms-of-service` and `/privacy-policy` pages for Google sign‑in
- document policies in `docs/google_auth_policies.md`
- mention policy pages in README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b6e2389408327add96a2fe4c505d7