### PR TITLE
Improve mobile sidebar and text contrast

### DIFF
--- a/cicero-dashboard/app/globals.css
+++ b/cicero-dashboard/app/globals.css
@@ -4,7 +4,7 @@
 
 :root {
   --background: #ffffff;
-  --foreground: #171717;
+  --foreground: #111827;
 }
 
 @theme inline {
@@ -31,6 +31,12 @@ body {
   color: var(--foreground);
   font-family: var(--font-geist-sans, Arial, Helvetica, sans-serif);
   line-height: 1.6;
+}
+
+@media (max-width: 640px) {
+  .text-gray-500 {
+    color: #374151 !important;
+  }
 }
 
 .container {

--- a/cicero-dashboard/components/Sidebar.jsx
+++ b/cicero-dashboard/components/Sidebar.jsx
@@ -83,9 +83,9 @@ export default function Sidebar() {
             )}
           </button>
         </SheetTrigger>
-        <SheetContent side="left" className="w-64 p-4 flex flex-col md:hidden">
+        <SheetContent side="left" className="w-20 p-4 flex flex-col md:hidden">
           <SheetTitle className="sr-only">Navigation Menu</SheetTitle>
-          {navLinks(true, false)}
+          {navLinks(true, true)}
         </SheetContent>
       </Sheet>
 


### PR DESCRIPTION
## Summary
- adjust sidebar drawer to show icons only on mobile
- darken global foreground color and override `.text-gray-500` on small screens for better contrast

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68801f92c4cc8327bb1afac25f08b38e