### PR TITLE
Fix JWT constructor for Google APIs

### DIFF
--- a/cicero-dashboard/app/api/export-amplify/route.ts
+++ b/cicero-dashboard/app/api/export-amplify/route.ts
@@ -10,15 +10,14 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'Missing Google credentials' }, { status: 500 });
   }
 
-  const auth = new google.auth.JWT(
+  const auth = new google.auth.JWT({
     email,
-    undefined,
-    key.replace(/\\n/g, '\n'),
-    [
+    key: key.replace(/\\n/g, '\n'),
+    scopes: [
       'https://www.googleapis.com/auth/spreadsheets',
       'https://www.googleapis.com/auth/drive'
     ]
-  );
+  });
 
   const sheets = google.sheets({ version: 'v4', auth });
 


### PR DESCRIPTION
## Summary
- fix Google JWT auth signature for export route

## Testing
- `npm test`
- `npm run build` *(fails: Failed to fetch fonts from fonts.gstatic.com)*

------
https://chatgpt.com/codex/tasks/task_e_6880269246248327a525e5df9b2551de