### PR TITLE
Fix Amplify excel export

### DIFF
--- a/cicero-dashboard/app/amplify/page.jsx
+++ b/cicero-dashboard/app/amplify/page.jsx
@@ -1,6 +1,6 @@
 "use client";
 import { useEffect, useState } from "react";
-import { getRekapAmplify } from "@/utils/api";
+import { getRekapAmplify, downloadAmplifyExcel } from "@/utils/api";
 import DateSelector from "@/components/DateSelector";
 import Loader from "@/components/Loader";
 import ChartDivisiAbsensi from "@/components/ChartDivisiAbsensi";
@@ -19,6 +19,13 @@ export default function AmplifyPage() {
 
 
   async function handleDownload() {
+    const token =
+      typeof window !== "undefined" ? localStorage.getItem("cicero_token") : null;
+    if (!token) {
+      alert("Token tidak ditemukan. Silakan login ulang.");
+      return;
+    }
+
     const rows = chartData.map((u) => ({
       date,
       pangkat_nama: `${u.title || u.pangkat || ''} ${u.nama || ''}`.trim(),
@@ -31,13 +38,11 @@ export default function AmplifyPage() {
     }));
 
     try {
-      const res = await fetch('/api/download-amplify', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ rows, fileName: 'Data Rekap Bulan Tahun' }),
-      });
-      if (!res.ok) throw new Error('Download failed');
-      const blob = await res.blob();
+      const blob = await downloadAmplifyExcel(
+        token,
+        rows,
+        'Data Rekap Bulan Tahun'
+      );
       const url = window.URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = url;

--- a/cicero-dashboard/utils/api.ts
+++ b/cicero-dashboard/utils/api.ts
@@ -401,3 +401,20 @@ export async function getTiktokPosts(token: string, client_id: string): Promise<
   if (!res.ok) throw new Error("Failed to fetch tiktok posts");
   return res.json();
 }
+
+export async function downloadAmplifyExcel(
+  token: string,
+  rows: any[],
+  fileName = 'rekap'
+): Promise<Blob> {
+  const url = `${API_BASE_URL}/api/download-amplify`;
+  const res = await fetchWithAuth(url, token, {
+    method: 'POST',
+    body: JSON.stringify({ rows, fileName }),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Failed to download excel: ${text}`);
+  }
+  return res.blob();
+}


### PR DESCRIPTION
## Summary
- connect Amplify page download to backend API
- expose `downloadAmplifyExcel` helper for API calls

## Testing
- `npm test`
- `npm run lint` *(fails: Next.js ESLint prompts for setup)*

------
https://chatgpt.com/codex/tasks/task_e_6880673b187083278a4157db0817e67c