### PR TITLE
Support month selection

### DIFF
--- a/cicero-dashboard/app/amplify/page.jsx
+++ b/cicero-dashboard/app/amplify/page.jsx
@@ -17,6 +17,12 @@ export default function AmplifyPage() {
   const today = new Date().toISOString().split("T")[0];
   const [date, setDate] = useState(today);
 
+  useEffect(() => {
+    setDate((d) =>
+      periode === "bulanan" ? d.slice(0, 7) : d.length === 7 ? `${d}-01` : d
+    );
+  }, [periode]);
+
 
   async function handleDownload() {
     const token =
@@ -118,7 +124,7 @@ export default function AmplifyPage() {
                   {label}
                 </button>
               ))}
-              <DateSelector date={date} setDate={setDate} />
+              <DateSelector date={date} setDate={setDate} periode={periode} />
               <button
                 onClick={handleDownload}
                 className="px-3 py-1 rounded-lg text-sm font-semibold bg-blue-600 text-white"

--- a/cicero-dashboard/app/comments/tiktok/page.jsx
+++ b/cicero-dashboard/app/comments/tiktok/page.jsx
@@ -33,6 +33,12 @@ export default function TiktokKomentarTrackingPage() {
   });
 
   useEffect(() => {
+    setDate((d) =>
+      periode === "bulanan" ? d.slice(0, 7) : d.length === 7 ? `${d}-01` : d
+    );
+  }, [periode]);
+
+  useEffect(() => {
     const token =
       typeof window !== "undefined"
         ? localStorage.getItem("cicero_token")
@@ -184,7 +190,7 @@ export default function TiktokKomentarTrackingPage() {
               >
                 Bulan Ini
               </span>
-              <DateSelector date={date} setDate={setDate} />
+              <DateSelector date={date} setDate={setDate} periode={periode} />
             </div>
 
             {/* Chart per kelompok */}

--- a/cicero-dashboard/app/comments/tiktok/rekap/page.jsx
+++ b/cicero-dashboard/app/comments/tiktok/rekap/page.jsx
@@ -24,6 +24,12 @@ export default function RekapKomentarTiktokPage() {
   });
 
   useEffect(() => {
+    setDate((d) =>
+      periode === "bulanan" ? d.slice(0, 7) : d.length === 7 ? `${d}-01` : d
+    );
+  }, [periode]);
+
+  useEffect(() => {
     const token =
       typeof window !== "undefined"
         ? localStorage.getItem("cicero_token")
@@ -146,7 +152,7 @@ export default function RekapKomentarTiktokPage() {
             >
               Bulan Ini
             </span>
-            <DateSelector date={date} setDate={setDate} />
+            <DateSelector date={date} setDate={setDate} periode={periode} />
           </div>
 
           {/* Kirim data ke komponen detail rekap TikTok */}

--- a/cicero-dashboard/app/likes/instagram/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/page.jsx
@@ -27,6 +27,12 @@ export default function InstagramLikesTrackingPage() {
   const today = new Date().toISOString().split("T")[0];
   const [date, setDate] = useState(today);
 
+  useEffect(() => {
+    setDate((d) =>
+      periode === "bulanan" ? d.slice(0, 7) : d.length === 7 ? `${d}-01` : d
+    );
+  }, [periode]);
+
   // Untuk rekap likes summary (total user, sudah likes, belum likes)
   const [rekapSummary, setRekapSummary] = useState({
     totalUser: 0,
@@ -181,7 +187,7 @@ export default function InstagramLikesTrackingPage() {
               >
                 Bulan Ini
               </span>
-              <DateSelector date={date} setDate={setDate} />
+              <DateSelector date={date} setDate={setDate} periode={periode} />
             </div>
 
             {/* Chart per kelompok */}

--- a/cicero-dashboard/app/likes/instagram/rekap/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/rekap/page.jsx
@@ -24,6 +24,12 @@ export default function RekapLikesIGPage() {
   });
 
   useEffect(() => {
+    setDate((d) =>
+      periode === "bulanan" ? d.slice(0, 7) : d.length === 7 ? `${d}-01` : d
+    );
+  }, [periode]);
+
+  useEffect(() => {
     const token =
       typeof window !== "undefined"
         ? localStorage.getItem("cicero_token")
@@ -139,7 +145,7 @@ export default function RekapLikesIGPage() {
             >
               Bulan Ini
             </span>
-            <DateSelector date={date} setDate={setDate} />
+            <DateSelector date={date} setDate={setDate} periode={periode} />
           </div>
 
           {/* Kirim data dari fetch ke komponen rekap likes */}

--- a/cicero-dashboard/components/DateSelector.jsx
+++ b/cicero-dashboard/components/DateSelector.jsx
@@ -1,11 +1,15 @@
 "use client";
-export default function DateSelector({ date, setDate }) {
+export default function DateSelector({ date, setDate, periode = "harian" }) {
+  const inputType = periode === "bulanan" ? "month" : "date";
+  const label = periode === "bulanan" ? "Bulan" : "Tanggal";
+  const value = periode === "bulanan" ? (date || "").slice(0, 7) : date;
+
   return (
     <div className="flex items-center gap-1">
-      <label className="text-sm">Tanggal</label>
+      <label className="text-sm">{label}</label>
       <input
-        type="date"
-        value={date}
+        type={inputType}
+        value={value}
         onChange={(e) => setDate(e.target.value)}
         className="border rounded px-2 py-1 text-sm"
       />


### PR DESCRIPTION
## Summary
- allow choosing month in DateSelector
- preserve date format when switching between day/month modes
- hook up month selection in analytics pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68806d83a0b08327ac7bcdddc9e4b026