### PR TITLE
Fix Excel download path

### DIFF
--- a/cicero-dashboard/__tests__/api.test.ts
+++ b/cicero-dashboard/__tests__/api.test.ts
@@ -1,4 +1,4 @@
-import { getDashboardStats, getRekapAmplify } from '../utils/api';
+import { getDashboardStats, getRekapAmplify, downloadAmplifyExcel } from '../utils/api';
 
 beforeEach(() => {
   global.fetch = jest.fn(() =>
@@ -26,6 +26,22 @@ test('getRekapAmplify calls endpoint with auth header', async () => {
     expect.stringContaining('/api/amplify/rekap'),
     expect.objectContaining({
       headers: expect.objectContaining({ Authorization: 'Bearer tok' })
+    })
+  );
+});
+
+test('downloadAmplifyExcel posts to local route', async () => {
+  // mock blob response
+  (global.fetch as jest.Mock).mockResolvedValueOnce({
+    ok: true,
+    blob: () => Promise.resolve(new Blob(['data']))
+  });
+  await downloadAmplifyExcel('t1', [], 'file');
+  expect(global.fetch).toHaveBeenCalledWith(
+    expect.stringContaining('/api/download-amplify'),
+    expect.objectContaining({
+      method: 'POST',
+      headers: expect.objectContaining({ Authorization: 'Bearer t1' })
     })
   );
 });

--- a/cicero-dashboard/utils/api.ts
+++ b/cicero-dashboard/utils/api.ts
@@ -407,7 +407,11 @@ export async function downloadAmplifyExcel(
   rows: any[],
   fileName = 'rekap'
 ): Promise<Blob> {
-  const url = `${API_BASE_URL}/api/download-amplify`;
+  // Always hit the Next.js route for excel generation.
+  // Using API_BASE_URL here breaks when the dashboard is
+  // configured to point at a separate backend, because the
+  // backend does not expose this endpoint.
+  const url = `/api/download-amplify`;
   const res = await fetchWithAuth(url, token, {
     method: 'POST',
     body: JSON.stringify({ rows, fileName }),


### PR DESCRIPTION
## Summary
- always use Next.js route for Excel download
- add tests for `downloadAmplifyExcel`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68807002db548327ac53b0e1a35d1353