### PR TITLE
Fix Excel download endpoint

### DIFF
--- a/cicero-dashboard/__tests__/api.test.ts
+++ b/cicero-dashboard/__tests__/api.test.ts
@@ -30,7 +30,7 @@ test('getRekapAmplify calls endpoint with auth header', async () => {
   );
 });
 
-test('downloadAmplifyExcel posts to local route', async () => {
+test('downloadAmplifyExcel posts to backend route', async () => {
   // mock blob response
   (global.fetch as jest.Mock).mockResolvedValueOnce({
     ok: true,

--- a/cicero-dashboard/utils/api.ts
+++ b/cicero-dashboard/utils/api.ts
@@ -407,11 +407,10 @@ export async function downloadAmplifyExcel(
   rows: any[],
   fileName = 'rekap'
 ): Promise<Blob> {
-  // Always hit the Next.js route for excel generation.
-  // Using API_BASE_URL here breaks when the dashboard is
-  // configured to point at a separate backend, because the
-  // backend does not expose this endpoint.
-  const url = `/api/download-amplify`;
+  // Use the backend endpoint for excel generation. The backend
+  // now exposes `/api/download-amplify`, so we can rely on
+  // `API_BASE_URL` like other API calls.
+  const url = `${API_BASE_URL}/api/download-amplify`;
   const res = await fetchWithAuth(url, token, {
     method: 'POST',
     body: JSON.stringify({ rows, fileName }),


### PR DESCRIPTION
## Summary
- use backend route for Excel download
- adjust tests for new endpoint

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68808a1d3c58832791d005c362a7dfcb