### PR TITLE
Add unified data view selector

### DIFF
--- a/cicero-dashboard/app/amplify/page.jsx
+++ b/cicero-dashboard/app/amplify/page.jsx
@@ -1,7 +1,9 @@
 "use client";
 import { useEffect, useState } from "react";
 import { getRekapAmplify } from "@/utils/api";
-import DateSelector from "@/components/DateSelector";
+import ViewDataSelector, {
+  getPeriodeDateForView,
+} from "@/components/ViewDataSelector";
 import Loader from "@/components/Loader";
 import ChartDivisiAbsensi from "@/components/ChartDivisiAbsensi";
 import ChartHorizontal from "@/components/ChartHorizontal";
@@ -13,15 +15,7 @@ export default function AmplifyPage() {
   const [chartData, setChartData] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
-  const [periode, setPeriode] = useState("harian");
-  const today = new Date().toISOString().split("T")[0];
-  const [date, setDate] = useState(today);
-
-  useEffect(() => {
-    setDate((d) =>
-      periode === "bulanan" ? d.slice(0, 7) : d.length === 7 ? `${d}-01` : d
-    );
-  }, [periode]);
+  const [viewBy, setViewBy] = useState("today");
 
 
 
@@ -36,11 +30,12 @@ export default function AmplifyPage() {
       return;
     }
 
+    const { periode, date } = getPeriodeDateForView(viewBy);
+
     async function fetchData() {
       try {
         const rekapRes = await getRekapAmplify(token, clientId, periode, date);
         setChartData(Array.isArray(rekapRes.data) ? rekapRes.data : []);
-
       } catch (err) {
         setError("Gagal mengambil data: " + (err.message || err));
       } finally {
@@ -49,7 +44,7 @@ export default function AmplifyPage() {
     }
 
     fetchData();
-  }, [periode, date]);
+  }, [viewBy]);
 
   if (loading) return <Loader />;
   if (error)
@@ -72,24 +67,7 @@ export default function AmplifyPage() {
               Link Amplification Report
             </h1>
             <div className="flex items-center justify-end gap-3 mb-2">
-              {[
-                ["harian", "Harian"],
-                ["mingguan", "Mingguan"],
-                ["bulanan", "Bulanan"],
-              ].map(([val, label]) => (
-                <button
-                  key={val}
-                  className={`px-3 py-1 rounded-lg text-sm font-semibold border ${
-                    periode === val
-                      ? "bg-blue-600 text-white border-blue-600"
-                      : "bg-white text-blue-700"
-                  }`}
-                  onClick={() => setPeriode(val)}
-                >
-                  {label}
-                </button>
-              ))}
-              <DateSelector date={date} setDate={setDate} periode={periode} />
+              <ViewDataSelector value={viewBy} onChange={setViewBy} />
             </div>
             <ChartBox title="BAG" users={kelompok.BAG} />
             <ChartBox title="SAT" users={kelompok.SAT} />

--- a/cicero-dashboard/app/comments/tiktok/page.jsx
+++ b/cicero-dashboard/app/comments/tiktok/page.jsx
@@ -8,7 +8,9 @@ import { groupUsersByKelompok } from "@/utils/grouping";
 import Link from "next/link";
 import Narrative from "@/components/Narrative";
 import useRequireAuth from "@/hooks/useRequireAuth";
-import DateSelector from "@/components/DateSelector";
+import ViewDataSelector, {
+  getPeriodeDateForView,
+} from "@/components/ViewDataSelector";
 import {
   Music,
   User,
@@ -22,21 +24,13 @@ export default function TiktokKomentarTrackingPage() {
   const [chartData, setChartData] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
-  const [periode, setPeriode] = useState("harian");
-  const today = new Date().toISOString().split("T")[0];
-  const [date, setDate] = useState(today);
+  const [viewBy, setViewBy] = useState("today");
   const [rekapSummary, setRekapSummary] = useState({
     totalUser: 0,
     totalSudahKomentar: 0,
     totalBelumKomentar: 0,
     totalTiktokPost: 0,
   });
-
-  useEffect(() => {
-    setDate((d) =>
-      periode === "bulanan" ? d.slice(0, 7) : d.length === 7 ? `${d}-01` : d
-    );
-  }, [periode]);
 
   useEffect(() => {
     const token =
@@ -64,6 +58,7 @@ export default function TiktokKomentarTrackingPage() {
           return;
         }
 
+        const { periode, date } = getPeriodeDateForView(viewBy);
         const rekapRes = await getRekapKomentarTiktok(token, client_id, periode, date);
         const users = Array.isArray(rekapRes.data) ? rekapRes.data : [];
 
@@ -98,7 +93,7 @@ export default function TiktokKomentarTrackingPage() {
     }
 
     fetchData();
-  }, [periode, date]);
+  }, [viewBy]);
 
   if (loading) return <Loader />;
   if (error)
@@ -156,41 +151,7 @@ export default function TiktokKomentarTrackingPage() {
 
             {/* Switch Periode */}
             <div className="flex items-center justify-end gap-3 mb-2">
-              <span
-                className={
-                  periode === "harian"
-                    ? "font-semibold text-pink-700"
-                    : "text-gray-400"
-                }
-              >
-                Hari Ini
-              </span>
-              <button
-                className={`w-12 h-6 rounded-full relative transition-colors duration-200 ${
-                  periode === "bulanan" ? "bg-pink-500" : "bg-gray-300"
-                }`}
-                onClick={() =>
-                  setPeriode(periode === "harian" ? "bulanan" : "harian")
-                }
-                aria-label="Switch periode"
-                type="button"
-              >
-                <span
-                  className={`block w-6 h-6 bg-white rounded-full shadow absolute top-0 transition-all duration-200 ${
-                    periode === "bulanan" ? "left-6" : "left-0"
-                  }`}
-                />
-              </button>
-              <span
-                className={
-                  periode === "bulanan"
-                    ? "font-semibold text-pink-700"
-                    : "text-gray-400"
-                }
-              >
-                Bulan Ini
-              </span>
-              <DateSelector date={date} setDate={setDate} periode={periode} />
+              <ViewDataSelector value={viewBy} onChange={setViewBy} />
             </div>
 
             {/* Chart per kelompok */}

--- a/cicero-dashboard/app/likes/instagram/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/page.jsx
@@ -8,7 +8,9 @@ import { groupUsersByKelompok } from "@/utils/grouping"; // pastikan path benar
 import Link from "next/link";
 import Narrative from "@/components/Narrative";
 import useRequireAuth from "@/hooks/useRequireAuth";
-import DateSelector from "@/components/DateSelector";
+import ViewDataSelector, {
+  getPeriodeDateForView,
+} from "@/components/ViewDataSelector";
 import {
   Camera,
   User,
@@ -23,15 +25,7 @@ export default function InstagramLikesTrackingPage() {
   const [chartData, setChartData] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
-  const [periode, setPeriode] = useState("harian"); // "harian" | "bulanan"
-  const today = new Date().toISOString().split("T")[0];
-  const [date, setDate] = useState(today);
-
-  useEffect(() => {
-    setDate((d) =>
-      periode === "bulanan" ? d.slice(0, 7) : d.length === 7 ? `${d}-01` : d
-    );
-  }, [periode]);
+  const [viewBy, setViewBy] = useState("today");
 
   // Untuk rekap likes summary (total user, sudah likes, belum likes)
   const [rekapSummary, setRekapSummary] = useState({
@@ -67,6 +61,7 @@ export default function InstagramLikesTrackingPage() {
           return;
         }
 
+        const { periode, date } = getPeriodeDateForView(viewBy);
         const rekapRes = await getRekapLikesIG(token, client_id, periode, date);
         const users = Array.isArray(rekapRes.data) ? rekapRes.data : [];
 
@@ -95,7 +90,7 @@ export default function InstagramLikesTrackingPage() {
     }
 
     fetchData();
-  }, [periode, date]);
+  }, [viewBy]);
 
   if (loading) return <Loader />;
   if (error)
@@ -153,41 +148,7 @@ export default function InstagramLikesTrackingPage() {
 
             {/* Switch Periode */}
             <div className="flex items-center justify-end gap-3 mb-2">
-              <span
-                className={
-                  periode === "harian"
-                    ? "font-semibold text-blue-700"
-                    : "text-gray-400"
-                }
-              >
-                Hari Ini
-              </span>
-              <button
-                className={`w-12 h-6 rounded-full relative transition-colors duration-200 ${
-                  periode === "bulanan" ? "bg-blue-500" : "bg-gray-300"
-                }`}
-                onClick={() =>
-                  setPeriode(periode === "harian" ? "bulanan" : "harian")
-                }
-                aria-label="Switch periode"
-                type="button"
-              >
-                <span
-                  className={`block w-6 h-6 bg-white rounded-full shadow absolute top-0 transition-all duration-200 ${
-                    periode === "bulanan" ? "left-6" : "left-0"
-                  }`}
-                />
-              </button>
-              <span
-                className={
-                  periode === "bulanan"
-                    ? "font-semibold text-blue-700"
-                    : "text-gray-400"
-                }
-              >
-                Bulan Ini
-              </span>
-              <DateSelector date={date} setDate={setDate} periode={periode} />
+              <ViewDataSelector value={viewBy} onChange={setViewBy} />
             </div>
 
             {/* Chart per kelompok */}

--- a/cicero-dashboard/components/ViewDataSelector.jsx
+++ b/cicero-dashboard/components/ViewDataSelector.jsx
@@ -1,0 +1,65 @@
+"use client";
+import { useId } from "react";
+
+export const VIEW_OPTIONS = [
+  { value: "today", label: "Hari ini", periode: "harian", offset: 0 },
+  { value: "yesterday", label: "Hari Sebelumnya", periode: "harian", offset: -1 },
+  { value: "this_week", label: "Minggu ini", periode: "mingguan", weekOffset: 0 },
+  { value: "last_week", label: "Minggu Sebelumnya", periode: "mingguan", weekOffset: -1 },
+  { value: "this_month", label: "Bulan ini", periode: "bulanan", monthOffset: 0 },
+  { value: "last_month", label: "Bulan Sebelumnya", periode: "bulanan", monthOffset: -1 },
+  { value: "all", label: "Seluruh Data", periode: "semua" },
+];
+
+export function getPeriodeDateForView(view) {
+  const opt = VIEW_OPTIONS.find((o) => o.value === view) || VIEW_OPTIONS[0];
+  const now = new Date();
+  if (opt.periode === "semua") return { periode: opt.periode, date: "" };
+
+  function formatDate(d) {
+    return d.toISOString().split("T")[0];
+  }
+  function formatMonth(d) {
+    return d.toISOString().split("T")[0].slice(0, 7);
+  }
+
+  if (Object.prototype.hasOwnProperty.call(opt, "offset")) {
+    const d = new Date(now);
+    d.setDate(d.getDate() + (opt.offset || 0));
+    return { periode: opt.periode, date: formatDate(d) };
+  }
+  if (Object.prototype.hasOwnProperty.call(opt, "weekOffset")) {
+    const mondayOffset = (now.getDay() + 6) % 7; // monday start
+    const d = new Date(now);
+    d.setDate(d.getDate() - mondayOffset + (opt.weekOffset || 0) * 7);
+    return { periode: opt.periode, date: formatDate(d) };
+  }
+  if (Object.prototype.hasOwnProperty.call(opt, "monthOffset")) {
+    const d = new Date(now.getFullYear(), now.getMonth() + (opt.monthOffset || 0), 1);
+    return { periode: opt.periode, date: formatMonth(d) };
+  }
+  return { periode: opt.periode, date: formatDate(now) };
+}
+
+export default function ViewDataSelector({ value, onChange }) {
+  const id = useId();
+  return (
+    <div className="flex items-center gap-2">
+      <label htmlFor={id} className="text-sm font-semibold">
+        View Data By:
+      </label>
+      <select
+        id={id}
+        className="border rounded px-2 py-1 text-sm"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      >
+        {VIEW_OPTIONS.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `ViewDataSelector` component for choosing date ranges
- update Instagram Likes Tracking page to use the new selector
- update Link Amplification Report page to use the new selector
- update TikTok Comments Tracking page to use the new selector

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688835977d08832783010eb0477c9916