### PR TITLE
Add custom date filter for ViewDataSelector

### DIFF
--- a/cicero-dashboard/app/amplify/page.jsx
+++ b/cicero-dashboard/app/amplify/page.jsx
@@ -16,6 +16,8 @@ export default function AmplifyPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const [viewBy, setViewBy] = useState("today");
+  const today = new Date().toISOString().split("T")[0];
+  const [customDate, setCustomDate] = useState(today);
 
 
 
@@ -30,7 +32,7 @@ export default function AmplifyPage() {
       return;
     }
 
-    const { periode, date } = getPeriodeDateForView(viewBy);
+    const { periode, date } = getPeriodeDateForView(viewBy, customDate);
 
     async function fetchData() {
       try {
@@ -44,7 +46,7 @@ export default function AmplifyPage() {
     }
 
     fetchData();
-  }, [viewBy]);
+  }, [viewBy, customDate]);
 
   if (loading) return <Loader />;
   if (error)
@@ -67,7 +69,12 @@ export default function AmplifyPage() {
               Link Amplification Report
             </h1>
             <div className="flex items-center justify-end gap-3 mb-2">
-              <ViewDataSelector value={viewBy} onChange={setViewBy} />
+              <ViewDataSelector
+                value={viewBy}
+                onChange={setViewBy}
+                date={customDate}
+                onDateChange={setCustomDate}
+              />
             </div>
             <ChartBox title="BAG" users={kelompok.BAG} />
             <ChartBox title="SAT" users={kelompok.SAT} />

--- a/cicero-dashboard/app/comments/tiktok/page.jsx
+++ b/cicero-dashboard/app/comments/tiktok/page.jsx
@@ -25,6 +25,8 @@ export default function TiktokKomentarTrackingPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const [viewBy, setViewBy] = useState("today");
+  const today = new Date().toISOString().split("T")[0];
+  const [customDate, setCustomDate] = useState(today);
   const [rekapSummary, setRekapSummary] = useState({
     totalUser: 0,
     totalSudahKomentar: 0,
@@ -58,7 +60,7 @@ export default function TiktokKomentarTrackingPage() {
           return;
         }
 
-        const { periode, date } = getPeriodeDateForView(viewBy);
+        const { periode, date } = getPeriodeDateForView(viewBy, customDate);
         const rekapRes = await getRekapKomentarTiktok(token, client_id, periode, date);
         const users = Array.isArray(rekapRes.data) ? rekapRes.data : [];
 
@@ -93,7 +95,7 @@ export default function TiktokKomentarTrackingPage() {
     }
 
     fetchData();
-  }, [viewBy]);
+  }, [viewBy, customDate]);
 
   if (loading) return <Loader />;
   if (error)
@@ -151,7 +153,12 @@ export default function TiktokKomentarTrackingPage() {
 
             {/* Switch Periode */}
             <div className="flex items-center justify-end gap-3 mb-2">
-              <ViewDataSelector value={viewBy} onChange={setViewBy} />
+              <ViewDataSelector
+                value={viewBy}
+                onChange={setViewBy}
+                date={customDate}
+                onDateChange={setCustomDate}
+              />
             </div>
 
             {/* Chart per kelompok */}

--- a/cicero-dashboard/app/likes/instagram/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/page.jsx
@@ -26,6 +26,8 @@ export default function InstagramLikesTrackingPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
   const [viewBy, setViewBy] = useState("today");
+  const today = new Date().toISOString().split("T")[0];
+  const [customDate, setCustomDate] = useState(today);
 
   // Untuk rekap likes summary (total user, sudah likes, belum likes)
   const [rekapSummary, setRekapSummary] = useState({
@@ -61,7 +63,7 @@ export default function InstagramLikesTrackingPage() {
           return;
         }
 
-        const { periode, date } = getPeriodeDateForView(viewBy);
+        const { periode, date } = getPeriodeDateForView(viewBy, customDate);
         const rekapRes = await getRekapLikesIG(token, client_id, periode, date);
         const users = Array.isArray(rekapRes.data) ? rekapRes.data : [];
 
@@ -90,7 +92,7 @@ export default function InstagramLikesTrackingPage() {
     }
 
     fetchData();
-  }, [viewBy]);
+  }, [viewBy, customDate]);
 
   if (loading) return <Loader />;
   if (error)
@@ -148,7 +150,12 @@ export default function InstagramLikesTrackingPage() {
 
             {/* Switch Periode */}
             <div className="flex items-center justify-end gap-3 mb-2">
-              <ViewDataSelector value={viewBy} onChange={setViewBy} />
+              <ViewDataSelector
+                value={viewBy}
+                onChange={setViewBy}
+                date={customDate}
+                onDateChange={setCustomDate}
+              />
             </div>
 
             {/* Chart per kelompok */}

--- a/cicero-dashboard/components/ViewDataSelector.jsx
+++ b/cicero-dashboard/components/ViewDataSelector.jsx
@@ -8,10 +8,11 @@ export const VIEW_OPTIONS = [
   { value: "last_week", label: "Minggu Sebelumnya", periode: "mingguan", weekOffset: -1 },
   { value: "this_month", label: "Bulan ini", periode: "bulanan", monthOffset: 0 },
   { value: "last_month", label: "Bulan Sebelumnya", periode: "bulanan", monthOffset: -1 },
+  { value: "date", label: "Tanggal Pilihan", periode: "harian", custom: true },
   { value: "all", label: "Seluruh Data", periode: "semua" },
 ];
 
-export function getPeriodeDateForView(view) {
+export function getPeriodeDateForView(view, selectedDate) {
   const opt = VIEW_OPTIONS.find((o) => o.value === view) || VIEW_OPTIONS[0];
   const now = new Date();
   if (opt.periode === "semua") return { periode: opt.periode, date: "" };
@@ -21,6 +22,11 @@ export function getPeriodeDateForView(view) {
   }
   function formatMonth(d) {
     return d.toISOString().split("T")[0].slice(0, 7);
+  }
+
+  if (opt.custom) {
+    const d = selectedDate ? new Date(selectedDate) : now;
+    return { periode: opt.periode, date: formatDate(d) };
   }
 
   if (Object.prototype.hasOwnProperty.call(opt, "offset")) {
@@ -41,8 +47,9 @@ export function getPeriodeDateForView(view) {
   return { periode: opt.periode, date: formatDate(now) };
 }
 
-export default function ViewDataSelector({ value, onChange }) {
+export default function ViewDataSelector({ value, onChange, date, onDateChange }) {
   const id = useId();
+  const showDateInput = value === "date";
   return (
     <div className="flex items-center gap-2">
       <label htmlFor={id} className="text-sm font-semibold">
@@ -60,6 +67,14 @@ export default function ViewDataSelector({ value, onChange }) {
           </option>
         ))}
       </select>
+      {showDateInput && (
+        <input
+          type="date"
+          className="border rounded px-2 py-1 text-sm"
+          value={date}
+          onChange={(e) => onDateChange?.(e.target.value)}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- update `ViewDataSelector` to include 'Tanggal Pilihan' option
- allow selecting a custom date via date input
- support new option in Amplify, TikTok comments and Instagram likes pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68883ac2a3f48327b2e01630dc8684e4