### PR TITLE
Fix amplify data filter refresh

### DIFF
--- a/cicero-dashboard/app/amplify/page.jsx
+++ b/cicero-dashboard/app/amplify/page.jsx
@@ -22,6 +22,8 @@ export default function AmplifyPage() {
 
 
   useEffect(() => {
+    setLoading(true);
+    setError("");
     const token =
       typeof window !== "undefined" ? localStorage.getItem("cicero_token") : null;
     const clientId =

--- a/cicero-dashboard/app/comments/tiktok/page.jsx
+++ b/cicero-dashboard/app/comments/tiktok/page.jsx
@@ -35,6 +35,8 @@ export default function TiktokKomentarTrackingPage() {
   });
 
   useEffect(() => {
+    setLoading(true);
+    setError("");
     const token =
       typeof window !== "undefined"
         ? localStorage.getItem("cicero_token")

--- a/cicero-dashboard/app/likes/instagram/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/page.jsx
@@ -38,6 +38,8 @@ export default function InstagramLikesTrackingPage() {
   });
 
   useEffect(() => {
+    setLoading(true);
+    setError("");
     const token =
       typeof window !== "undefined"
         ? localStorage.getItem("cicero_token")

--- a/cicero-dashboard/components/ViewDataSelector.jsx
+++ b/cicero-dashboard/components/ViewDataSelector.jsx
@@ -25,8 +25,8 @@ export function getPeriodeDateForView(view, selectedDate) {
   }
 
   if (opt.custom) {
-    const d = selectedDate ? new Date(selectedDate) : now;
-    return { periode: opt.periode, date: formatDate(d) };
+    const d = selectedDate ? selectedDate : formatDate(now);
+    return { periode: opt.periode, date: d };
   }
 
   if (Object.prototype.hasOwnProperty.call(opt, "offset")) {


### PR DESCRIPTION
## Summary
- ensure charts refresh when switching data view or custom date
- avoid incorrect date formatting when using custom date filter

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68883f0757648327a87c6839b80b92c2