### PR TITLE
Update stats by view filters

### DIFF
--- a/cicero-dashboard/app/comments/tiktok/page.jsx
+++ b/cicero-dashboard/app/comments/tiktok/page.jsx
@@ -49,7 +49,8 @@ export default function TiktokKomentarTrackingPage() {
 
     async function fetchData() {
       try {
-        const statsRes = await getDashboardStats(token);
+        const { periode, date } = getPeriodeDateForView(viewBy, customDate);
+        const statsRes = await getDashboardStats(token, periode, date);
         // Gunakan semua kemungkinan key post TikTok (ttPosts/tiktokPosts)
         const statsData = statsRes.data || statsRes;
         const client_id =
@@ -62,7 +63,6 @@ export default function TiktokKomentarTrackingPage() {
           return;
         }
 
-        const { periode, date } = getPeriodeDateForView(viewBy, customDate);
         const rekapRes = await getRekapKomentarTiktok(token, client_id, periode, date);
         const users = Array.isArray(rekapRes.data) ? rekapRes.data : [];
 
@@ -125,7 +125,7 @@ export default function TiktokKomentarTrackingPage() {
             {/* Card Ringkasan */}
             <div className="bg-gradient-to-tr from-fuchsia-50 to-white rounded-2xl shadow flex flex-col md:flex-row items-stretch justify-between p-3 md:p-5 gap-2 md:gap-4 border">
               <SummaryItem
-                label="TikTok Post Hari Ini"
+                label="Jumlah TikTok Post"
                 value={rekapSummary.totalTiktokPost}
                 color="fuchsia"
                 icon={<Music className="text-fuchsia-400" />}

--- a/cicero-dashboard/app/likes/instagram/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/page.jsx
@@ -52,7 +52,8 @@ export default function InstagramLikesTrackingPage() {
 
     async function fetchData() {
       try {
-        const statsRes = await getDashboardStats(token);
+        const { periode, date } = getPeriodeDateForView(viewBy, customDate);
+        const statsRes = await getDashboardStats(token, periode, date);
         setStats(statsRes.data || statsRes);
 
         const client_id =
@@ -65,7 +66,6 @@ export default function InstagramLikesTrackingPage() {
           return;
         }
 
-        const { periode, date } = getPeriodeDateForView(viewBy, customDate);
         const rekapRes = await getRekapLikesIG(token, client_id, periode, date);
         const users = Array.isArray(rekapRes.data) ? rekapRes.data : [];
 
@@ -122,7 +122,7 @@ export default function InstagramLikesTrackingPage() {
             {/* Card Ringkasan */}
             <div className="bg-gradient-to-tr from-blue-50 to-white rounded-2xl shadow flex flex-col md:flex-row items-stretch justify-between p-3 md:p-5 gap-2 md:gap-4 border">
               <SummaryItem
-                label="IG Post Hari Ini"
+                label="Jumlah IG Post"
                 value={rekapSummary.totalIGPost}
                 color="blue"
                 icon={<Camera className="text-blue-400" />}

--- a/cicero-dashboard/utils/api.ts
+++ b/cicero-dashboard/utils/api.ts
@@ -37,11 +37,18 @@ async function fetchWithAuth(
   }
   return res;
 }
-export async function getDashboardStats(token: string): Promise<any> {
-  const res = await fetchWithAuth(
-    API_BASE_URL + "/api/dashboard/stats",
-    token
-  );
+export async function getDashboardStats(
+  token: string,
+  periode?: string,
+  tanggal?: string
+): Promise<any> {
+  const params = new URLSearchParams();
+  if (periode) params.append("periode", periode);
+  if (tanggal) params.append("tanggal", tanggal);
+  const url = `${API_BASE_URL}/api/dashboard/stats${
+    params.toString() ? `?${params.toString()}` : ""
+  }`;
+  const res = await fetchWithAuth(url, token);
   if (!res.ok) throw new Error("Failed to fetch stats");
   return res.json();
 }


### PR DESCRIPTION
## Summary
- allow passing `periode` and `tanggal` to `getDashboardStats`
- query stats by the selected `View Data By` option
- update labels to `Jumlah IG Post` and `Jumlah TikTok Post`

## Testing
- `npm install`
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_688af4edfe4c8327916a781830e03581