### PR TITLE
Fix recap period selection

### DIFF
--- a/cicero-dashboard/app/comments/tiktok/rekap/page.jsx
+++ b/cicero-dashboard/app/comments/tiktok/rekap/page.jsx
@@ -41,7 +41,8 @@ export default function RekapKomentarTiktokPage() {
 
     async function fetchData() {
       try {
-        const statsRes = await getDashboardStats(token);
+        const { periode, date } = getPeriodeDateForView(viewBy, customDate);
+        const statsRes = await getDashboardStats(token, periode, date);
         const statsData = statsRes.data || statsRes;
 
         const client_id =
@@ -54,7 +55,6 @@ export default function RekapKomentarTiktokPage() {
           return;
         }
 
-        const { periode, date } = getPeriodeDateForView(viewBy, customDate);
         const rekapRes = await getRekapKomentarTiktok(token, client_id, periode, date);
         const users = Array.isArray(rekapRes.data) ? rekapRes.data : [];
 

--- a/cicero-dashboard/app/likes/instagram/rekap/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/rekap/page.jsx
@@ -41,7 +41,8 @@ export default function RekapLikesIGPage() {
 
     async function fetchData() {
       try {
-        const statsRes = await getDashboardStats(token);
+        const { periode, date } = getPeriodeDateForView(viewBy, customDate);
+        const statsRes = await getDashboardStats(token, periode, date);
         const client_id =
           statsRes.data?.client_id ||
           statsRes.client_id ||
@@ -52,7 +53,6 @@ export default function RekapLikesIGPage() {
           return;
         }
 
-        const { periode, date } = getPeriodeDateForView(viewBy, customDate);
         const rekapRes = await getRekapLikesIG(token, client_id, periode, date);
         const users = Array.isArray(rekapRes.data) ? rekapRes.data : [];
 


### PR DESCRIPTION
## Summary
- ensure Instagram recap page requests dashboard stats for the selected period
- ensure TikTok comment recap page also passes period parameters

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b39a71fd883279e384c279cfde63e