### PR TITLE
Fix IG post count by period

### DIFF
--- a/cicero-dashboard/app/likes/instagram/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/page.jsx
@@ -71,7 +71,10 @@ export default function InstagramLikesTrackingPage() {
 
         // Rekap summary
         const totalUser = users.length;
-        const totalIGPost = statsRes.data?.igPosts || statsRes.igPosts || 0;
+        const igPostsData = statsRes.data?.igPosts ?? statsRes.igPosts ?? 0;
+        const totalIGPost = Array.isArray(igPostsData)
+          ? igPostsData.length
+          : Number(igPostsData) || 0;
         const isZeroPost = (totalIGPost || 0) === 0;
         const totalSudahLike = isZeroPost
           ? 0

--- a/cicero-dashboard/app/likes/instagram/rekap/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/rekap/page.jsx
@@ -56,8 +56,11 @@ export default function RekapLikesIGPage() {
         const rekapRes = await getRekapLikesIG(token, client_id, periode, date);
         const users = Array.isArray(rekapRes.data) ? rekapRes.data : [];
 
-        // Sumber utama IG Post Hari Ini dari statsRes
-        const totalIGPost = statsRes.data?.igPosts || statsRes.igPosts || 0;
+        // Hitung jumlah IG post dari stats
+        const igPostsData = statsRes.data?.igPosts ?? statsRes.igPosts ?? 0;
+        const totalIGPost = Array.isArray(igPostsData)
+          ? igPostsData.length
+          : Number(igPostsData) || 0;
         const isZeroPost = (totalIGPost || 0) === 0;
         const totalUser = users.length;
         const totalSudahLike = isZeroPost


### PR DESCRIPTION
## Summary
- compute Instagram post count based on the selected time range

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b3c0eb5c08327ad84b22efaec4c2e