### PR TITLE
Fix likes tracking chart labels and total count

### DIFF
--- a/cicero-dashboard/app/likes/instagram/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/page.jsx
@@ -227,6 +227,10 @@ function ChartBox({
           title={title}
           orientation={orientation}
           totalIGPost={totalIGPost}
+          fieldJumlah="jumlah_like"
+          labelSudah="User Sudah Like"
+          labelBelum="User Belum Like"
+          labelTotal="Total Likes"
         />
       ) : (
         <div className="text-center text-gray-400 text-sm">Tidak ada data</div>

--- a/cicero-dashboard/components/ChartDivisiAbsensi.jsx
+++ b/cicero-dashboard/components/ChartDivisiAbsensi.jsx
@@ -27,7 +27,7 @@ function bersihkanSatfung(divisi = "") {
 export default function ChartDivisiAbsensi({
   users,
   title = "Absensi Komentar TikTok per Divisi/Satfung",
-  totalPost = 1, // jumlah post untuk perbandingan, generic
+  totalPost, // jumlah post untuk perbandingan, generic
   totalIGPost,   // fallback untuk instagram (kompatibilitas lama)
   totalTiktokPost, // fallback untuk tiktok (kompatibilitas lama)
   fieldJumlah = "jumlah_like", // bisa "jumlah_komentar" untuk tiktok


### PR DESCRIPTION
## Summary
- Ensure likes tracking charts use provided post count when calculating participation
- Display correct like-oriented labels in Instagram likes tracking charts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689542354fbc832790bc72907eeaba3b