### PR TITLE
Fix Instagram Likes Tracking data parsing

### DIFF
--- a/cicero-dashboard/app/likes/instagram/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/page.jsx
@@ -54,11 +54,12 @@ export default function InstagramLikesTrackingPage() {
       try {
         const { periode, date } = getPeriodeDateForView(viewBy, customDate);
         const statsRes = await getDashboardStats(token, periode, date);
-        setStats(statsRes.data || statsRes);
+        const statsData = statsRes.data || statsRes;
+        setStats(statsData);
 
         const client_id =
-          statsRes.data?.client_id ||
-          statsRes.client_id ||
+          statsData?.client_id ||
+          statsData.client_id ||
           localStorage.getItem("client_id");
         if (!client_id) {
           setError("Client ID tidak ditemukan.");
@@ -67,11 +68,20 @@ export default function InstagramLikesTrackingPage() {
         }
 
         const rekapRes = await getRekapLikesIG(token, client_id, periode, date);
-        const users = Array.isArray(rekapRes.data) ? rekapRes.data : [];
+        const users = Array.isArray(rekapRes?.data)
+          ? rekapRes.data
+          : Array.isArray(rekapRes)
+          ? rekapRes
+          : [];
 
         // Rekap summary
         const totalUser = users.length;
-        const igPostsData = statsRes.data?.igPosts ?? statsRes.igPosts ?? 0;
+        const igPostsData =
+          statsData?.igPosts ??
+          statsData?.instagramPosts ??
+          statsData.igPosts ??
+          statsData.instagramPosts ??
+          0;
         const totalIGPost = Array.isArray(igPostsData)
           ? igPostsData.length
           : Number(igPostsData) || 0;

--- a/cicero-dashboard/app/likes/instagram/rekap/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/rekap/page.jsx
@@ -43,9 +43,10 @@ export default function RekapLikesIGPage() {
       try {
         const { periode, date } = getPeriodeDateForView(viewBy, customDate);
         const statsRes = await getDashboardStats(token, periode, date);
+        const statsData = statsRes.data || statsRes;
         const client_id =
-          statsRes.data?.client_id ||
-          statsRes.client_id ||
+          statsData?.client_id ||
+          statsData.client_id ||
           localStorage.getItem("client_id");
         if (!client_id) {
           setError("Client ID tidak ditemukan.");
@@ -54,10 +55,19 @@ export default function RekapLikesIGPage() {
         }
 
         const rekapRes = await getRekapLikesIG(token, client_id, periode, date);
-        const users = Array.isArray(rekapRes.data) ? rekapRes.data : [];
+        const users = Array.isArray(rekapRes?.data)
+          ? rekapRes.data
+          : Array.isArray(rekapRes)
+          ? rekapRes
+          : [];
 
         // Hitung jumlah IG post dari stats
-        const igPostsData = statsRes.data?.igPosts ?? statsRes.igPosts ?? 0;
+        const igPostsData =
+          statsData?.igPosts ??
+          statsData?.instagramPosts ??
+          statsData.igPosts ??
+          statsData.instagramPosts ??
+          0;
         const totalIGPost = Array.isArray(igPostsData)
           ? igPostsData.length
           : Number(igPostsData) || 0;


### PR DESCRIPTION
## Summary
- handle various API response shapes in Instagram Likes Tracking to ensure charts render
- add broader fallbacks for Instagram post counts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689549bc84508327b9f608023c39c660