### PR TITLE
feat(instagram): display like metrics in POLSEK chart

### DIFF
--- a/cicero-dashboard/app/likes/instagram/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/page.jsx
@@ -197,6 +197,10 @@ export default function InstagramLikesTrackingPage() {
                 title="POLSEK"
                 users={kelompok.POLSEK}
                 totalPost={rekapSummary.totalIGPost}
+                fieldJumlah="jumlah_like"
+                labelSudah="User Sudah Like"
+                labelBelum="User Belum Like"
+                labelTotal="Total Likes"
               />
               <Narrative>
                 Grafik POLSEK memperlihatkan jumlah like Instagram dari setiap


### PR DESCRIPTION
## Summary
- show like counts for POLSEK chart in Instagram likes tracking

## Testing
- `cd cicero-dashboard && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895810ef81c83279cbd925b6134dbb0