### PR TITLE
Fix Instagram like tracking counts

### DIFF
--- a/cicero-dashboard/app/likes/instagram/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/page.jsx
@@ -19,6 +19,11 @@ import {
   ArrowRight
 } from "lucide-react";
 
+// Helper: handle boolean/string/number for exception
+function isException(val) {
+  return val === true || val === "true" || val === 1 || val === "1";
+}
+
 export default function InstagramLikesTrackingPage() {
   useRequireAuth();
   const [stats, setStats] = useState(null);
@@ -88,8 +93,10 @@ export default function InstagramLikesTrackingPage() {
         const isZeroPost = (totalIGPost || 0) === 0;
         const totalSudahLike = isZeroPost
           ? 0
-          : users.filter((u) => Number(u.jumlah_like) > 0 || u.exception)
-              .length;
+          : users.filter(
+              (u) =>
+                Number(u.jumlah_like) >= totalIGPost || isException(u.exception)
+            ).length;
         const totalBelumLike = totalUser - totalSudahLike;
 
         setRekapSummary({

--- a/cicero-dashboard/app/likes/instagram/rekap/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/rekap/page.jsx
@@ -10,6 +10,11 @@ import ViewDataSelector, {
 } from "@/components/ViewDataSelector";
 import { ArrowLeft } from "lucide-react";
 
+// Helper: handle boolean/string/number for exception
+function isException(val) {
+  return val === true || val === "true" || val === 1 || val === "1";
+}
+
 export default function RekapLikesIGPage() {
   useRequireAuth();
   const [chartData, setChartData] = useState([]);
@@ -76,7 +81,8 @@ export default function RekapLikesIGPage() {
         const totalSudahLike = isZeroPost
           ? 0
           : users.filter(
-              (u) => Number(u.jumlah_like) > 0 || u.exception
+              (u) =>
+                Number(u.jumlah_like) >= totalIGPost || isException(u.exception)
             ).length;
         const totalBelumLike = totalUser - totalSudahLike;
 

--- a/cicero-dashboard/components/ChartDivisiAbsensi.jsx
+++ b/cicero-dashboard/components/ChartDivisiAbsensi.jsx
@@ -60,7 +60,7 @@ export default function ChartDivisiAbsensi({
     const key = bersihkanSatfung(u.divisi || "LAINNYA");
     const jumlah = Number(u[fieldJumlah] || 0);
     const sudah =
-      !isZeroPost && (jumlah > 0 || isException(u.exception));
+      !isZeroPost && (jumlah >= effectiveTotal || isException(u.exception));
     const nilai = isException(u.exception) ? maxJumlahLike : jumlah;
     if (!divisiMap[key])
       divisiMap[key] = {

--- a/cicero-dashboard/components/RekapLikesIG.jsx
+++ b/cicero-dashboard/components/RekapLikesIG.jsx
@@ -21,7 +21,7 @@ export default function RekapLikesIG({ users = [], totalIGPost = 0 }) {
   const totalSudahLike = totalIGPost === 0
     ? 0
     : users.filter(u =>
-        Number(u.jumlah_like) > 0 || isException(u.exception)
+        Number(u.jumlah_like) >= totalIGPost || isException(u.exception)
       ).length;
   const totalBelumLike = totalUser - totalSudahLike;
 
@@ -153,7 +153,7 @@ export default function RekapLikesIG({ users = [], totalIGPost = 0 }) {
               // LOGIC: semua user dianggap belum jika IG Post = 0
               const sudahLike = totalIGPost === 0
                 ? false
-                : Number(u.jumlah_like) > 0 || isException(u.exception);
+                : Number(u.jumlah_like) >= totalIGPost || isException(u.exception);
 
               return (
                 <tr key={u.user_id} className={sudahLike ? "bg-green-50" : "bg-red-50"}>


### PR DESCRIPTION
## Summary
- compute Instagram like summaries based on total posts instead of just any like
- ensure exception flags are parsed consistently when calculating like status
- update charts and recap table to reflect accurate counts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689585f9a8508327af948bc7b3a3afde