### PR TITLE
Include all users in division like totals

### DIFF
--- a/cicero-dashboard/components/ChartDivisiAbsensi.jsx
+++ b/cicero-dashboard/components/ChartDivisiAbsensi.jsx
@@ -69,10 +69,12 @@ export default function ChartDivisiAbsensi({
         user_belum: 0,
         total_value: 0,
       };
+    divisiMap[key].total_value += nilai;
     if (sudah) {
       divisiMap[key].user_sudah += 1;
-      divisiMap[key].total_value += nilai;
-    } else divisiMap[key].user_belum += 1;
+    } else {
+      divisiMap[key].user_belum += 1;
+    }
   });
 
   const dataChart = Object.values(divisiMap);


### PR DESCRIPTION
## Summary
- count likes from all users when aggregating division statistics
- keep user_sudah and user_belum counters inside conditional branches

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6895a64558788327a67af0c49a97fd6e