### PR TITLE
feat: add date range support to dashboard and rekap APIs

### DIFF
--- a/cicero-dashboard/__tests__/api.test.ts
+++ b/cicero-dashboard/__tests__/api.test.ts
@@ -1,4 +1,9 @@
-import { getDashboardStats, getRekapAmplify } from '../utils/api';
+import {
+  getDashboardStats,
+  getRekapAmplify,
+  getRekapLikesIG,
+  getRekapKomentarTiktok,
+} from "../utils/api";
 
 beforeEach(() => {
   global.fetch = jest.fn(() =>
@@ -10,24 +15,58 @@ afterEach(() => {
   (global.fetch as jest.Mock).mockClear();
 });
 
-test('getDashboardStats calls endpoint with auth header', async () => {
-  await getDashboardStats('token123');
-  expect(global.fetch).toHaveBeenCalledWith(
-    expect.stringContaining('/api/dashboard/stats'),
-    expect.objectContaining({
-      headers: expect.objectContaining({ Authorization: 'Bearer token123' })
-    })
-  );
+test("getDashboardStats supports date range params", async () => {
+  await getDashboardStats("token123", undefined, undefined, "2024-01-01", "2024-01-31");
+  const call = (global.fetch as jest.Mock).mock.calls[0];
+  expect(call[0]).toContain("/api/dashboard/stats");
+  expect(call[0]).toContain("tanggal_mulai=2024-01-01");
+  expect(call[0]).toContain("tanggal_selesai=2024-01-31");
+  expect(call[1].headers.Authorization).toBe("Bearer token123");
 });
 
-test('getRekapAmplify calls endpoint with auth header', async () => {
-  await getRekapAmplify('tok', 'c1', 'harian', '2024-01-01');
-  expect(global.fetch).toHaveBeenCalledWith(
-    expect.stringContaining('/api/amplify/rekap'),
-    expect.objectContaining({
-      headers: expect.objectContaining({ Authorization: 'Bearer tok' })
-    })
+test("getRekapAmplify supports date range params", async () => {
+  await getRekapAmplify(
+    "tok",
+    "c1",
+    "harian",
+    undefined,
+    "2024-02-01",
+    "2024-02-28",
   );
+  const call = (global.fetch as jest.Mock).mock.calls[0];
+  expect(call[0]).toContain("/api/amplify/rekap");
+  expect(call[0]).toContain("tanggal_mulai=2024-02-01");
+  expect(call[0]).toContain("tanggal_selesai=2024-02-28");
+  expect(call[1].headers.Authorization).toBe("Bearer tok");
 });
 
+test("getRekapLikesIG supports date range params", async () => {
+  await getRekapLikesIG(
+    "tok",
+    "c1",
+    "harian",
+    undefined,
+    "2023-12-01",
+    "2023-12-31",
+  );
+  const url = (global.fetch as jest.Mock).mock.calls[0][0];
+  expect(url).toContain("/api/insta/rekap-likes");
+  expect(url).toContain("tanggal_mulai=2023-12-01");
+  expect(url).toContain("tanggal_selesai=2023-12-31");
+});
+
+test("getRekapKomentarTiktok supports date range params", async () => {
+  await getRekapKomentarTiktok(
+    "tok",
+    "c1",
+    "harian",
+    undefined,
+    "2024-03-01",
+    "2024-03-31",
+  );
+  const url = (global.fetch as jest.Mock).mock.calls[0][0];
+  expect(url).toContain("/api/tiktok/rekap-komentar");
+  expect(url).toContain("tanggal_mulai=2024-03-01");
+  expect(url).toContain("tanggal_selesai=2024-03-31");
+});
 

--- a/cicero-dashboard/utils/api.ts
+++ b/cicero-dashboard/utils/api.ts
@@ -40,11 +40,17 @@ async function fetchWithAuth(
 export async function getDashboardStats(
   token: string,
   periode?: string,
-  tanggal?: string
+  tanggal?: string,
+  startDate?: string,
+  endDate?: string
 ): Promise<any> {
   const params = new URLSearchParams();
   if (periode) params.append("periode", periode);
   if (tanggal) params.append("tanggal", tanggal);
+  if (startDate && endDate) {
+    params.append("tanggal_mulai", startDate);
+    params.append("tanggal_selesai", endDate);
+  }
   const url = `${API_BASE_URL}/api/dashboard/stats${
     params.toString() ? `?${params.toString()}` : ""
   }`;
@@ -58,10 +64,16 @@ export async function getRekapLikesIG(
   token: string,
   client_id: string,
   periode: string = "harian",
-  tanggal?: string
+  tanggal?: string,
+  startDate?: string,
+  endDate?: string
 ): Promise<any> {
   const params = new URLSearchParams({ client_id, periode });
   if (tanggal) params.append("tanggal", tanggal);
+  if (startDate && endDate) {
+    params.append("tanggal_mulai", startDate);
+    params.append("tanggal_selesai", endDate);
+  }
   const url = `${API_BASE_URL}/api/insta/rekap-likes?${params.toString()}`;
 
   const res = await fetchWithAuth(url, token);
@@ -141,10 +153,16 @@ export async function getRekapKomentarTiktok(
   token: string,
   client_id: string,
   periode: string = "harian",
-  tanggal?: string
+  tanggal?: string,
+  startDate?: string,
+  endDate?: string
 ): Promise<any> {
   const params = new URLSearchParams({ client_id, periode });
   if (tanggal) params.append("tanggal", tanggal);
+  if (startDate && endDate) {
+    params.append("tanggal_mulai", startDate);
+    params.append("tanggal_selesai", endDate);
+  }
   const url = `${API_BASE_URL}/api/tiktok/rekap-komentar?${params.toString()}`;
 
   const res = await fetchWithAuth(url, token);
@@ -160,10 +178,16 @@ export async function getRekapAmplify(
   token: string,
   client_id: string,
   periode: string = "harian",
-  tanggal?: string
+  tanggal?: string,
+  startDate?: string,
+  endDate?: string
 ): Promise<any> {
   const params = new URLSearchParams({ client_id, periode });
   if (tanggal) params.append("tanggal", tanggal);
+  if (startDate && endDate) {
+    params.append("tanggal_mulai", startDate);
+    params.append("tanggal_selesai", endDate);
+  }
   const url = `${API_BASE_URL}/api/amplify/rekap?${params.toString()}`;
 
   const res = await fetchWithAuth(url, token);


### PR DESCRIPTION
## Summary
- allow dashboard stats, IG likes, TikTok comments, and amplify rekap API helpers to accept start and end date
- include `tanggal_mulai` and `tanggal_selesai` in requests when a date range is provided
- expand API utility tests for new range parameters

## Testing
- `npm test`

## Coordination
- Backend must handle `tanggal_mulai` and `tanggal_selesai` query parameters for the updated endpoints


------
https://chatgpt.com/codex/tasks/task_e_6895e14186c483278659ad9191bf19de