### PR TITLE
feat: support date range for instagram likes

### DIFF
--- a/cicero-dashboard/app/likes/instagram/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/page.jsx
@@ -33,6 +33,8 @@ export default function InstagramLikesTrackingPage() {
   const [viewBy, setViewBy] = useState("today");
   const today = new Date().toISOString().split("T")[0];
   const [customDate, setCustomDate] = useState(today);
+  const [fromDate, setFromDate] = useState(today);
+  const [toDate, setToDate] = useState(today);
 
   // Untuk rekap likes summary (total user, sudah likes, belum likes)
   const [rekapSummary, setRekapSummary] = useState({
@@ -57,8 +59,19 @@ export default function InstagramLikesTrackingPage() {
 
     async function fetchData() {
       try {
-        const { periode, date } = getPeriodeDateForView(viewBy, customDate);
-        const statsRes = await getDashboardStats(token, periode, date);
+        const selectedDate =
+          viewBy === "custom_range"
+            ? { startDate: fromDate, endDate: toDate }
+            : customDate;
+        const { periode, date, startDate, endDate } =
+          getPeriodeDateForView(viewBy, selectedDate);
+        const statsRes = await getDashboardStats(
+          token,
+          periode,
+          date,
+          startDate,
+          endDate,
+        );
         const statsData = statsRes.data || statsRes;
         setStats(statsData);
 
@@ -72,7 +85,14 @@ export default function InstagramLikesTrackingPage() {
           return;
         }
 
-        const rekapRes = await getRekapLikesIG(token, client_id, periode, date);
+        const rekapRes = await getRekapLikesIG(
+          token,
+          client_id,
+          periode,
+          date,
+          startDate,
+          endDate,
+        );
         const users = Array.isArray(rekapRes?.data)
           ? rekapRes.data
           : Array.isArray(rekapRes)
@@ -114,7 +134,7 @@ export default function InstagramLikesTrackingPage() {
     }
 
     fetchData();
-  }, [viewBy, customDate]);
+  }, [viewBy, customDate, fromDate, toDate]);
 
   if (loading) return <Loader />;
   if (error)
@@ -175,8 +195,18 @@ export default function InstagramLikesTrackingPage() {
               <ViewDataSelector
                 value={viewBy}
                 onChange={setViewBy}
-                date={customDate}
-                onDateChange={setCustomDate}
+                date=
+                  {viewBy === "custom_range"
+                    ? { startDate: fromDate, endDate: toDate }
+                    : customDate}
+                onDateChange={(val) => {
+                  if (viewBy === "custom_range") {
+                    setFromDate(val.startDate || "");
+                    setToDate(val.endDate || "");
+                  } else {
+                    setCustomDate(val);
+                  }
+                }}
               />
             </div>
 

--- a/cicero-dashboard/app/likes/instagram/rekap/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/rekap/page.jsx
@@ -23,6 +23,8 @@ export default function RekapLikesIGPage() {
   const [viewBy, setViewBy] = useState("today");
   const today = new Date().toISOString().split("T")[0];
   const [customDate, setCustomDate] = useState(today);
+  const [fromDate, setFromDate] = useState(today);
+  const [toDate, setToDate] = useState(today);
   const [rekapSummary, setRekapSummary] = useState({
     totalUser: 0,
     totalSudahLike: 0,
@@ -46,8 +48,19 @@ export default function RekapLikesIGPage() {
 
     async function fetchData() {
       try {
-        const { periode, date } = getPeriodeDateForView(viewBy, customDate);
-        const statsRes = await getDashboardStats(token, periode, date);
+        const selectedDate =
+          viewBy === "custom_range"
+            ? { startDate: fromDate, endDate: toDate }
+            : customDate;
+        const { periode, date, startDate, endDate } =
+          getPeriodeDateForView(viewBy, selectedDate);
+        const statsRes = await getDashboardStats(
+          token,
+          periode,
+          date,
+          startDate,
+          endDate,
+        );
         const statsData = statsRes.data || statsRes;
         const client_id =
           statsData?.client_id ||
@@ -59,7 +72,14 @@ export default function RekapLikesIGPage() {
           return;
         }
 
-        const rekapRes = await getRekapLikesIG(token, client_id, periode, date);
+        const rekapRes = await getRekapLikesIG(
+          token,
+          client_id,
+          periode,
+          date,
+          startDate,
+          endDate,
+        );
         const users = Array.isArray(rekapRes?.data)
           ? rekapRes.data
           : Array.isArray(rekapRes)
@@ -101,7 +121,7 @@ export default function RekapLikesIGPage() {
     }
 
     fetchData();
-  }, [viewBy, customDate]);
+  }, [viewBy, customDate, fromDate, toDate]);
 
   if (loading) return <Loader />;
   if (error)
@@ -133,8 +153,18 @@ export default function RekapLikesIGPage() {
             <ViewDataSelector
               value={viewBy}
               onChange={setViewBy}
-              date={customDate}
-              onDateChange={setCustomDate}
+              date=
+                {viewBy === "custom_range"
+                  ? { startDate: fromDate, endDate: toDate }
+                  : customDate}
+              onDateChange={(val) => {
+                if (viewBy === "custom_range") {
+                  setFromDate(val.startDate || "");
+                  setToDate(val.endDate || "");
+                } else {
+                  setCustomDate(val);
+                }
+              }}
             />
           </div>
 


### PR DESCRIPTION
## Summary
- track from and to dates for Instagram likes stats
- forward selected date range to stats and rekap APIs
- expose range picker through ViewDataSelector

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895e30c9e588327ade9ea323753fbde