### PR TITLE
Enable date range filters for TikTok comment tracking

### DIFF
--- a/cicero-dashboard/app/comments/tiktok/rekap/page.jsx
+++ b/cicero-dashboard/app/comments/tiktok/rekap/page.jsx
@@ -18,6 +18,8 @@ export default function RekapKomentarTiktokPage() {
   const [viewBy, setViewBy] = useState("today");
   const today = new Date().toISOString().split("T")[0];
   const [customDate, setCustomDate] = useState(today);
+  const [fromDate, setFromDate] = useState(today);
+  const [toDate, setToDate] = useState(today);
   const [rekapSummary, setRekapSummary] = useState({
     totalUser: 0,
     totalSudahKomentar: 0,
@@ -41,8 +43,19 @@ export default function RekapKomentarTiktokPage() {
 
     async function fetchData() {
       try {
-        const { periode, date } = getPeriodeDateForView(viewBy, customDate);
-        const statsRes = await getDashboardStats(token, periode, date);
+        const selectedDate =
+          viewBy === "custom_range"
+            ? { startDate: fromDate, endDate: toDate }
+            : customDate;
+        const { periode, date, startDate, endDate } =
+          getPeriodeDateForView(viewBy, selectedDate);
+        const statsRes = await getDashboardStats(
+          token,
+          periode,
+          date,
+          startDate,
+          endDate,
+        );
         const statsData = statsRes.data || statsRes;
 
         const client_id =
@@ -55,7 +68,14 @@ export default function RekapKomentarTiktokPage() {
           return;
         }
 
-        const rekapRes = await getRekapKomentarTiktok(token, client_id, periode, date);
+        const rekapRes = await getRekapKomentarTiktok(
+          token,
+          client_id,
+          periode,
+          date,
+          startDate,
+          endDate,
+        );
         const users = Array.isArray(rekapRes.data) ? rekapRes.data : [];
 
         // Sumber utama TikTok Post Hari Ini dari statsRes
@@ -89,7 +109,7 @@ export default function RekapKomentarTiktokPage() {
     }
 
     fetchData();
-  }, [viewBy, customDate]);
+  }, [viewBy, customDate, fromDate, toDate]);
 
   if (loading) return <Loader />;
   if (error)
@@ -121,8 +141,18 @@ export default function RekapKomentarTiktokPage() {
             <ViewDataSelector
               value={viewBy}
               onChange={setViewBy}
-              date={customDate}
-              onDateChange={setCustomDate}
+              date=
+                {viewBy === "custom_range"
+                  ? { startDate: fromDate, endDate: toDate }
+                  : customDate}
+              onDateChange={(val) => {
+                if (viewBy === "custom_range") {
+                  setFromDate(val.startDate || "");
+                  setToDate(val.endDate || "");
+                } else {
+                  setCustomDate(val);
+                }
+              }}
             />
           </div>
 


### PR DESCRIPTION
## Summary
- Support custom date ranges for TikTok comment stats
- Pass start and end dates to dashboard and rekap API calls
- Sync date range selection in detailed Rekap view

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6895e547da008327b7ad076b8bfa2def