### PR TITLE
feat: support date range in API requests

### DIFF
--- a/cicero-dashboard/__tests__/api.test.ts
+++ b/cicero-dashboard/__tests__/api.test.ts
@@ -70,3 +70,17 @@ test("getRekapKomentarTiktok supports date range params", async () => {
   expect(url).toContain("tanggal_selesai=2024-03-31");
 });
 
+test("getDashboardStats handles partial date range params", async () => {
+  await getDashboardStats("tok", undefined, undefined, "2024-06-01");
+  let url = (global.fetch as jest.Mock).mock.calls[0][0];
+  expect(url).toContain("tanggal_mulai=2024-06-01");
+  expect(url).not.toContain("tanggal_selesai");
+
+  (global.fetch as jest.Mock).mockClear();
+
+  await getDashboardStats("tok", undefined, undefined, undefined, "2024-06-30");
+  url = (global.fetch as jest.Mock).mock.calls[0][0];
+  expect(url).toContain("tanggal_selesai=2024-06-30");
+  expect(url).not.toContain("tanggal_mulai");
+});
+

--- a/cicero-dashboard/utils/api.ts
+++ b/cicero-dashboard/utils/api.ts
@@ -47,10 +47,8 @@ export async function getDashboardStats(
   const params = new URLSearchParams();
   if (periode) params.append("periode", periode);
   if (tanggal) params.append("tanggal", tanggal);
-  if (startDate && endDate) {
-    params.append("tanggal_mulai", startDate);
-    params.append("tanggal_selesai", endDate);
-  }
+  if (startDate) params.append("tanggal_mulai", startDate);
+  if (endDate) params.append("tanggal_selesai", endDate);
   const url = `${API_BASE_URL}/api/dashboard/stats${
     params.toString() ? `?${params.toString()}` : ""
   }`;
@@ -70,10 +68,8 @@ export async function getRekapLikesIG(
 ): Promise<any> {
   const params = new URLSearchParams({ client_id, periode });
   if (tanggal) params.append("tanggal", tanggal);
-  if (startDate && endDate) {
-    params.append("tanggal_mulai", startDate);
-    params.append("tanggal_selesai", endDate);
-  }
+  if (startDate) params.append("tanggal_mulai", startDate);
+  if (endDate) params.append("tanggal_selesai", endDate);
   const url = `${API_BASE_URL}/api/insta/rekap-likes?${params.toString()}`;
 
   const res = await fetchWithAuth(url, token);
@@ -159,10 +155,8 @@ export async function getRekapKomentarTiktok(
 ): Promise<any> {
   const params = new URLSearchParams({ client_id, periode });
   if (tanggal) params.append("tanggal", tanggal);
-  if (startDate && endDate) {
-    params.append("tanggal_mulai", startDate);
-    params.append("tanggal_selesai", endDate);
-  }
+  if (startDate) params.append("tanggal_mulai", startDate);
+  if (endDate) params.append("tanggal_selesai", endDate);
   const url = `${API_BASE_URL}/api/tiktok/rekap-komentar?${params.toString()}`;
 
   const res = await fetchWithAuth(url, token);
@@ -184,10 +178,8 @@ export async function getRekapAmplify(
 ): Promise<any> {
   const params = new URLSearchParams({ client_id, periode });
   if (tanggal) params.append("tanggal", tanggal);
-  if (startDate && endDate) {
-    params.append("tanggal_mulai", startDate);
-    params.append("tanggal_selesai", endDate);
-  }
+  if (startDate) params.append("tanggal_mulai", startDate);
+  if (endDate) params.append("tanggal_selesai", endDate);
   const url = `${API_BASE_URL}/api/amplify/rekap?${params.toString()}`;
 
   const res = await fetchWithAuth(url, token);


### PR DESCRIPTION
## Summary
- allow dashboard and recap API helpers to send only start or end dates as needed
- test partial and full date range parameters for dashboard stats API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896a5148ed8832782f9dc5afbc41e4b