### PR TITLE
feat: request posts by date range

### DIFF
--- a/cicero-dashboard/app/posts/instagram/page.jsx
+++ b/cicero-dashboard/app/posts/instagram/page.jsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useState } from "react";
 import CardStat from "@/components/CardStat";
 import EngagementLineChart from "@/components/EngagementLineChart";
 import EngagementByTypeChart from "@/components/EngagementByTypeChart";
@@ -40,11 +40,8 @@ export default function InstagramPostAnalysisPage() {
   const [startDate, setStartDate] = useState(firstDay);
   const [endDate, setEndDate] = useState(lastDay);
   const [search, setSearch] = useState("");
-  const fetchedRef = useRef(false);
 
   useEffect(() => {
-    if (fetchedRef.current) return;
-    fetchedRef.current = true;
     const token =
       typeof window !== "undefined" ? localStorage.getItem("cicero_token") : null;
     const clientId =
@@ -58,6 +55,7 @@ export default function InstagramPostAnalysisPage() {
 
     async function fetchData() {
       try {
+        setLoading(true);
         const clientProfile = await getClientProfile(token, clientId);
         const username =
           clientProfile.client?.client_insta?.replace(/^@/, "") ||
@@ -72,7 +70,13 @@ export default function InstagramPostAnalysisPage() {
         const infoData = infoRes.data || infoRes.info || infoRes;
         setInfo(infoData);
 
-        const postRes = await getInstagramPostsViaBackend(token, username, 12);
+        const postRes = await getInstagramPostsViaBackend(
+          token,
+          username,
+          12,
+          startDate,
+          endDate,
+        );
         const postData = postRes.data || postRes.posts || postRes;
         setPosts(Array.isArray(postData) ? postData : []);
       } catch (err) {
@@ -83,7 +87,7 @@ export default function InstagramPostAnalysisPage() {
     }
 
     fetchData();
-  }, []);
+  }, [startDate, endDate]);
 
   function extractUsername(url) {
     if (!url) return "";

--- a/cicero-dashboard/app/posts/tiktok/page.jsx
+++ b/cicero-dashboard/app/posts/tiktok/page.jsx
@@ -56,6 +56,7 @@ export default function TiktokPostAnalysisPage() {
 
     async function fetchData() {
       try {
+        setLoading(true);
         const clientProfile = await getClientProfile(token, clientId);
         const username =
           clientProfile.client?.client_tiktok?.replace(/^@/, "") ||
@@ -70,7 +71,13 @@ export default function TiktokPostAnalysisPage() {
         const infoData = infoRes.data || infoRes.info || infoRes;
         setInfo(infoData);
 
-        const postRes = await getTiktokPostsViaBackend(token, clientId, 50);
+        const postRes = await getTiktokPostsViaBackend(
+          token,
+          clientId,
+          50,
+          startDate,
+          endDate,
+        );
         const postData = postRes.data || postRes.posts || postRes;
         setPosts(Array.isArray(postData) ? postData : []);
       } catch (err) {
@@ -81,7 +88,7 @@ export default function TiktokPostAnalysisPage() {
     }
 
     fetchData();
-  }, []);
+  }, [startDate, endDate]);
 
   function extractUsername(url) {
     if (!url) return "";

--- a/cicero-dashboard/utils/api.ts
+++ b/cicero-dashboard/utils/api.ts
@@ -199,9 +199,13 @@ export async function getInstagramPosts(token: string, client_id: string): Promi
 export async function getInstagramPostsViaBackend(
   token: string,
   username: string,
-  limit: number = 10
+  limit: number = 10,
+  startDate?: string,
+  endDate?: string
 ): Promise<any> {
   const params = new URLSearchParams({ username, limit: String(limit) });
+  if (startDate) params.append("tanggal_mulai", startDate);
+  if (endDate) params.append("tanggal_selesai", endDate);
   const url = `${API_BASE_URL}/api/insta/rapid-posts?${params.toString()}`;
   const res = await fetchWithAuth(url, token);
   if (!res.ok) {
@@ -343,9 +347,13 @@ export async function getTiktokInfoViaBackend(token: string, username: string): 
 export async function getTiktokPostsViaBackend(
   token: string,
   client_id: string,
-  limit: number = 10
+  limit: number = 10,
+  startDate?: string,
+  endDate?: string
 ): Promise<any> {
   const params = new URLSearchParams({ client_id, limit: String(limit) });
+  if (startDate) params.append("tanggal_mulai", startDate);
+  if (endDate) params.append("tanggal_selesai", endDate);
   const url = `${API_BASE_URL}/api/tiktok/rapid-posts?${params.toString()}`;
   const res = await fetchWithAuth(url, token);
   if (!res.ok) {


### PR DESCRIPTION
## Summary
- fetch Instagram and TikTok posts with optional start/end dates
- refresh posts pages when date range changes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896be6b401883279c5bb7085886c5e8