### PR TITLE
fix: handle month selection properly

### DIFF
--- a/cicero-dashboard/components/ViewDataSelector.jsx
+++ b/cicero-dashboard/components/ViewDataSelector.jsx
@@ -60,7 +60,7 @@ export function getPeriodeDateForView(view, selectedDate) {
   }
   if (opt.month) {
     const d = selectedDate
-      ? new Date(`${selectedDate}-01`)
+      ? new Date(selectedDate)
       : new Date(now.getFullYear(), now.getMonth(), 1);
     return { periode: opt.periode, date: formatMonth(d) };
   }


### PR DESCRIPTION
## Summary
- avoid invalid `NaN-NaN` month strings when requesting dashboard stats

## Testing
- `cd cicero-dashboard && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896c13ef9e08327b42fd2cbdae063c8