### PR TITLE
Fix Instagram like tracking summary counts

### DIFF
--- a/cicero-dashboard/app/likes/instagram/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/page.jsx
@@ -117,7 +117,12 @@ export default function InstagramLikesTrackingPage() {
               (u) =>
                 Number(u.jumlah_like) >= totalIGPost || isException(u.exception)
             ).length;
-        const totalBelumLike = totalUser - totalSudahLike;
+        const totalBelumLike = isZeroPost
+          ? totalUser
+          : users.filter(
+              (u) =>
+                Number(u.jumlah_like) < totalIGPost && !isException(u.exception)
+            ).length;
 
         setRekapSummary({
           totalUser,

--- a/cicero-dashboard/app/likes/instagram/rekap/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/rekap/page.jsx
@@ -104,7 +104,12 @@ export default function RekapLikesIGPage() {
               (u) =>
                 Number(u.jumlah_like) >= totalIGPost || isException(u.exception)
             ).length;
-        const totalBelumLike = totalUser - totalSudahLike;
+        const totalBelumLike = isZeroPost
+          ? totalUser
+          : users.filter(
+              (u) =>
+                Number(u.jumlah_like) < totalIGPost && !isException(u.exception)
+            ).length;
 
         setRekapSummary({
           totalUser,

--- a/cicero-dashboard/components/RekapLikesIG.jsx
+++ b/cicero-dashboard/components/RekapLikesIG.jsx
@@ -23,7 +23,11 @@ export default function RekapLikesIG({ users = [], totalIGPost = 0 }) {
     : users.filter(u =>
         Number(u.jumlah_like) >= totalIGPost || isException(u.exception)
       ).length;
-  const totalBelumLike = totalUser - totalSudahLike;
+  const totalBelumLike = totalIGPost === 0
+    ? totalUser
+    : users.filter(u =>
+        Number(u.jumlah_like) < totalIGPost && !isException(u.exception)
+      ).length;
 
   // Hitung nilai jumlah_like tertinggi (max) di seluruh user
   const maxJumlahLike = useMemo(


### PR DESCRIPTION
## Summary
- ensure Instagram like tracking uses explicit filters to compute pending likes instead of subtracting totals
- unify summary logic so cards and tables display accurate user counts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896c49d3c4c8327871bf33cec17d9e2