### PR TITLE
Hide weekly and all-data views on tracking pages

### DIFF
--- a/cicero-dashboard/app/amplify/page.jsx
+++ b/cicero-dashboard/app/amplify/page.jsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { getRekapAmplify } from "@/utils/api";
 import ViewDataSelector, {
   getPeriodeDateForView,
+  VIEW_OPTIONS,
 } from "@/components/ViewDataSelector";
 import Loader from "@/components/Loader";
 import ChartDivisiAbsensi from "@/components/ChartDivisiAbsensi";
@@ -20,6 +21,10 @@ export default function AmplifyPage() {
   const [customDate, setCustomDate] = useState(today);
   const [fromDate, setFromDate] = useState(today);
   const [toDate, setToDate] = useState(today);
+
+  const viewOptions = VIEW_OPTIONS.filter(
+    (opt) => !["this_week", "last_week", "all"].includes(opt.value),
+  );
 
   useEffect(() => {
     setLoading(true);
@@ -88,6 +93,7 @@ export default function AmplifyPage() {
               <ViewDataSelector
                 value={viewBy}
                 onChange={setViewBy}
+                options={viewOptions}
                 date=
                   {viewBy === "custom_range"
                     ? { startDate: fromDate, endDate: toDate }

--- a/cicero-dashboard/app/comments/tiktok/page.jsx
+++ b/cicero-dashboard/app/comments/tiktok/page.jsx
@@ -10,6 +10,7 @@ import Narrative from "@/components/Narrative";
 import useRequireAuth from "@/hooks/useRequireAuth";
 import ViewDataSelector, {
   getPeriodeDateForView,
+  VIEW_OPTIONS,
 } from "@/components/ViewDataSelector";
 import {
   Music,
@@ -35,6 +36,10 @@ export default function TiktokKomentarTrackingPage() {
     totalBelumKomentar: 0,
     totalTiktokPost: 0,
   });
+
+  const viewOptions = VIEW_OPTIONS.filter(
+    (opt) => !["this_week", "last_week", "all"].includes(opt.value),
+  );
 
   useEffect(() => {
     setLoading(true);
@@ -178,6 +183,7 @@ export default function TiktokKomentarTrackingPage() {
               <ViewDataSelector
                 value={viewBy}
                 onChange={setViewBy}
+                options={viewOptions}
                 date=
                   {viewBy === "custom_range"
                     ? { startDate: fromDate, endDate: toDate }

--- a/cicero-dashboard/app/comments/tiktok/rekap/page.jsx
+++ b/cicero-dashboard/app/comments/tiktok/rekap/page.jsx
@@ -7,6 +7,7 @@ import Link from "next/link";
 import useRequireAuth from "@/hooks/useRequireAuth";
 import ViewDataSelector, {
   getPeriodeDateForView,
+  VIEW_OPTIONS,
 } from "@/components/ViewDataSelector";
 import { ArrowLeft } from "lucide-react";
 
@@ -26,6 +27,10 @@ export default function RekapKomentarTiktokPage() {
     totalBelumKomentar: 0,
     totalTiktokPost: 0,
   });
+
+  const viewOptions = VIEW_OPTIONS.filter(
+    (opt) => !["this_week", "last_week", "all"].includes(opt.value),
+  );
 
 
   useEffect(() => {
@@ -141,6 +146,7 @@ export default function RekapKomentarTiktokPage() {
             <ViewDataSelector
               value={viewBy}
               onChange={setViewBy}
+              options={viewOptions}
               date=
                 {viewBy === "custom_range"
                   ? { startDate: fromDate, endDate: toDate }

--- a/cicero-dashboard/app/likes/instagram/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/page.jsx
@@ -10,6 +10,7 @@ import Narrative from "@/components/Narrative";
 import useRequireAuth from "@/hooks/useRequireAuth";
 import ViewDataSelector, {
   getPeriodeDateForView,
+  VIEW_OPTIONS,
 } from "@/components/ViewDataSelector";
 import {
   Camera,
@@ -43,6 +44,10 @@ export default function InstagramLikesTrackingPage() {
     totalBelumLike: 0,
     totalIGPost: 0,
   });
+
+  const viewOptions = VIEW_OPTIONS.filter(
+    (opt) => !["this_week", "last_week", "all"].includes(opt.value),
+  );
 
   useEffect(() => {
     setLoading(true);
@@ -200,6 +205,7 @@ export default function InstagramLikesTrackingPage() {
               <ViewDataSelector
                 value={viewBy}
                 onChange={setViewBy}
+                options={viewOptions}
                 date=
                   {viewBy === "custom_range"
                     ? { startDate: fromDate, endDate: toDate }

--- a/cicero-dashboard/app/likes/instagram/rekap/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/rekap/page.jsx
@@ -7,6 +7,7 @@ import Link from "next/link";
 import useRequireAuth from "@/hooks/useRequireAuth";
 import ViewDataSelector, {
   getPeriodeDateForView,
+  VIEW_OPTIONS,
 } from "@/components/ViewDataSelector";
 import { ArrowLeft } from "lucide-react";
 
@@ -31,6 +32,10 @@ export default function RekapLikesIGPage() {
     totalBelumLike: 0,
     totalIGPost: 0,
   });
+
+  const viewOptions = VIEW_OPTIONS.filter(
+    (opt) => !["this_week", "last_week", "all"].includes(opt.value),
+  );
 
 
   useEffect(() => {
@@ -158,6 +163,7 @@ export default function RekapLikesIGPage() {
             <ViewDataSelector
               value={viewBy}
               onChange={setViewBy}
+              options={viewOptions}
               date=
                 {viewBy === "custom_range"
                   ? { startDate: fromDate, endDate: toDate }

--- a/cicero-dashboard/components/ViewDataSelector.jsx
+++ b/cicero-dashboard/components/ViewDataSelector.jsx
@@ -67,7 +67,13 @@ export function getPeriodeDateForView(view, selectedDate) {
   return { periode: opt.periode, date: formatDate(now) };
 }
 
-export default function ViewDataSelector({ value, onChange, date, onDateChange }) {
+export default function ViewDataSelector({
+  value,
+  onChange,
+  date,
+  onDateChange,
+  options = VIEW_OPTIONS,
+}) {
   const id = useId();
   const showDateInput = value === "date";
   const showRangeInput = value === "custom_range";
@@ -83,7 +89,7 @@ export default function ViewDataSelector({ value, onChange, date, onDateChange }
         value={value}
         onChange={(e) => onChange(e.target.value)}
       >
-        {VIEW_OPTIONS.map((opt) => (
+        {options.map((opt) => (
           <option key={opt.value} value={opt.value}>
             {opt.label}
           </option>


### PR DESCRIPTION
## Summary
- Allow `ViewDataSelector` to accept a custom options list
- Remove week/all selections from Instagram likes, link amplification, and TikTok comment tracking pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68974ccede8883278cff46f1134bbe72