### PR TITLE
Use date range filter for tracking pages

### DIFF
--- a/cicero-dashboard/app/amplify/page.jsx
+++ b/cicero-dashboard/app/amplify/page.jsx
@@ -1,10 +1,7 @@
 "use client";
 import { useEffect, useState } from "react";
 import { getRekapAmplify } from "@/utils/api";
-import ViewDataSelector, {
-  getPeriodeDateForView,
-  VIEW_OPTIONS,
-} from "@/components/ViewDataSelector";
+import { getPeriodeDateForView } from "@/components/ViewDataSelector";
 import Loader from "@/components/Loader";
 import ChartDivisiAbsensi from "@/components/ChartDivisiAbsensi";
 import ChartHorizontal from "@/components/ChartHorizontal";
@@ -16,15 +13,9 @@ export default function AmplifyPage() {
   const [chartData, setChartData] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
-  const [viewBy, setViewBy] = useState("today");
   const today = new Date().toISOString().split("T")[0];
-  const [customDate, setCustomDate] = useState(today);
   const [fromDate, setFromDate] = useState(today);
   const [toDate, setToDate] = useState(today);
-
-  const viewOptions = VIEW_OPTIONS.filter(
-    (opt) => !["this_week", "last_week", "all"].includes(opt.value),
-  );
 
   useEffect(() => {
     setLoading(true);
@@ -39,13 +30,9 @@ export default function AmplifyPage() {
       return;
     }
 
-    const selectedDate =
-      viewBy === "custom_range"
-        ? { startDate: fromDate, endDate: toDate }
-        : customDate;
-    const { periode, date, startDate, endDate } = getPeriodeDateForView(
-      viewBy,
-      selectedDate,
+    const { periode, startDate, endDate } = getPeriodeDateForView(
+      "custom_range",
+      { startDate: fromDate, endDate: toDate },
     );
 
     async function fetchData() {
@@ -54,7 +41,7 @@ export default function AmplifyPage() {
           token,
           clientId,
           periode,
-          date,
+          undefined,
           startDate,
           endDate,
         );
@@ -67,7 +54,7 @@ export default function AmplifyPage() {
     }
 
     fetchData();
-  }, [viewBy, customDate, fromDate, toDate]);
+  }, [fromDate, toDate]);
 
   if (loading) return <Loader />;
   if (error)
@@ -89,23 +76,19 @@ export default function AmplifyPage() {
             <h1 className="text-2xl md:text-3xl font-bold text-blue-700 mb-2">
               Link Amplification Report
             </h1>
-            <div className="flex items-center justify-end gap-3 mb-2">
-              <ViewDataSelector
-                value={viewBy}
-                onChange={setViewBy}
-                options={viewOptions}
-                date=
-                  {viewBy === "custom_range"
-                    ? { startDate: fromDate, endDate: toDate }
-                    : customDate}
-                onDateChange={(val) => {
-                  if (viewBy === "custom_range") {
-                    setFromDate(val.startDate || "");
-                    setToDate(val.endDate || "");
-                  } else {
-                    setCustomDate(val);
-                  }
-                }}
+            <div className="flex items-center justify-end gap-2 mb-2">
+              <input
+                type="date"
+                className="border rounded px-2 py-1 text-sm"
+                value={fromDate}
+                onChange={(e) => setFromDate(e.target.value)}
+              />
+              <span className="text-sm">s/d</span>
+              <input
+                type="date"
+                className="border rounded px-2 py-1 text-sm"
+                value={toDate}
+                onChange={(e) => setToDate(e.target.value)}
               />
             </div>
             <ChartBox title="BAG" users={kelompok.BAG} />

--- a/cicero-dashboard/app/comments/tiktok/page.jsx
+++ b/cicero-dashboard/app/comments/tiktok/page.jsx
@@ -8,10 +8,7 @@ import { groupUsersByKelompok } from "@/utils/grouping";
 import Link from "next/link";
 import Narrative from "@/components/Narrative";
 import useRequireAuth from "@/hooks/useRequireAuth";
-import ViewDataSelector, {
-  getPeriodeDateForView,
-  VIEW_OPTIONS,
-} from "@/components/ViewDataSelector";
+import { getPeriodeDateForView } from "@/components/ViewDataSelector";
 import {
   Music,
   User,
@@ -25,9 +22,7 @@ export default function TiktokKomentarTrackingPage() {
   const [chartData, setChartData] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
-  const [viewBy, setViewBy] = useState("today");
   const today = new Date().toISOString().split("T")[0];
-  const [customDate, setCustomDate] = useState(today);
   const [fromDate, setFromDate] = useState(today);
   const [toDate, setToDate] = useState(today);
   const [rekapSummary, setRekapSummary] = useState({
@@ -36,10 +31,6 @@ export default function TiktokKomentarTrackingPage() {
     totalBelumKomentar: 0,
     totalTiktokPost: 0,
   });
-
-  const viewOptions = VIEW_OPTIONS.filter(
-    (opt) => !["this_week", "last_week", "all"].includes(opt.value),
-  );
 
   useEffect(() => {
     setLoading(true);
@@ -56,16 +47,14 @@ export default function TiktokKomentarTrackingPage() {
 
     async function fetchData() {
       try {
-        const selectedDate =
-          viewBy === "custom_range"
-            ? { startDate: fromDate, endDate: toDate }
-            : customDate;
-        const { periode, date, startDate, endDate } =
-          getPeriodeDateForView(viewBy, selectedDate);
+        const { periode, startDate, endDate } = getPeriodeDateForView(
+          "custom_range",
+          { startDate: fromDate, endDate: toDate },
+        );
         const statsRes = await getDashboardStats(
           token,
           periode,
-          date,
+          undefined,
           startDate,
           endDate,
         );
@@ -85,7 +74,7 @@ export default function TiktokKomentarTrackingPage() {
           token,
           client_id,
           periode,
-          date,
+          undefined,
           startDate,
           endDate,
         );
@@ -122,7 +111,7 @@ export default function TiktokKomentarTrackingPage() {
     }
 
     fetchData();
-  }, [viewBy, customDate, fromDate, toDate]);
+  }, [fromDate, toDate]);
 
   if (loading) return <Loader />;
   if (error)
@@ -178,24 +167,20 @@ export default function TiktokKomentarTrackingPage() {
               />
             </div>
 
-            {/* Switch Periode */}
-            <div className="flex items-center justify-end gap-3 mb-2">
-              <ViewDataSelector
-                value={viewBy}
-                onChange={setViewBy}
-                options={viewOptions}
-                date=
-                  {viewBy === "custom_range"
-                    ? { startDate: fromDate, endDate: toDate }
-                    : customDate}
-                onDateChange={(val) => {
-                  if (viewBy === "custom_range") {
-                    setFromDate(val.startDate || "");
-                    setToDate(val.endDate || "");
-                  } else {
-                    setCustomDate(val);
-                  }
-                }}
+            {/* Rentang Tanggal */}
+            <div className="flex items-center justify-end gap-2 mb-2">
+              <input
+                type="date"
+                className="border rounded px-2 py-1 text-sm"
+                value={fromDate}
+                onChange={(e) => setFromDate(e.target.value)}
+              />
+              <span className="text-sm">s/d</span>
+              <input
+                type="date"
+                className="border rounded px-2 py-1 text-sm"
+                value={toDate}
+                onChange={(e) => setToDate(e.target.value)}
               />
             </div>
 

--- a/cicero-dashboard/app/likes/instagram/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/page.jsx
@@ -8,10 +8,7 @@ import { groupUsersByKelompok } from "@/utils/grouping"; // pastikan path benar
 import Link from "next/link";
 import Narrative from "@/components/Narrative";
 import useRequireAuth from "@/hooks/useRequireAuth";
-import ViewDataSelector, {
-  getPeriodeDateForView,
-  VIEW_OPTIONS,
-} from "@/components/ViewDataSelector";
+import { getPeriodeDateForView } from "@/components/ViewDataSelector";
 import {
   Camera,
   User,
@@ -31,9 +28,7 @@ export default function InstagramLikesTrackingPage() {
   const [chartData, setChartData] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
-  const [viewBy, setViewBy] = useState("today");
   const today = new Date().toISOString().split("T")[0];
-  const [customDate, setCustomDate] = useState(today);
   const [fromDate, setFromDate] = useState(today);
   const [toDate, setToDate] = useState(today);
 
@@ -44,10 +39,6 @@ export default function InstagramLikesTrackingPage() {
     totalBelumLike: 0,
     totalIGPost: 0,
   });
-
-  const viewOptions = VIEW_OPTIONS.filter(
-    (opt) => !["this_week", "last_week", "all"].includes(opt.value),
-  );
 
   useEffect(() => {
     setLoading(true);
@@ -64,16 +55,14 @@ export default function InstagramLikesTrackingPage() {
 
     async function fetchData() {
       try {
-        const selectedDate =
-          viewBy === "custom_range"
-            ? { startDate: fromDate, endDate: toDate }
-            : customDate;
-        const { periode, date, startDate, endDate } =
-          getPeriodeDateForView(viewBy, selectedDate);
+        const { periode, startDate, endDate } = getPeriodeDateForView(
+          "custom_range",
+          { startDate: fromDate, endDate: toDate },
+        );
         const statsRes = await getDashboardStats(
           token,
           periode,
-          date,
+          undefined,
           startDate,
           endDate,
         );
@@ -94,7 +83,7 @@ export default function InstagramLikesTrackingPage() {
           token,
           client_id,
           periode,
-          date,
+          undefined,
           startDate,
           endDate,
         );
@@ -144,7 +133,7 @@ export default function InstagramLikesTrackingPage() {
     }
 
     fetchData();
-  }, [viewBy, customDate, fromDate, toDate]);
+  }, [fromDate, toDate]);
 
   if (loading) return <Loader />;
   if (error)
@@ -200,24 +189,20 @@ export default function InstagramLikesTrackingPage() {
               />
             </div>
 
-            {/* Switch Periode */}
-            <div className="flex items-center justify-end gap-3 mb-2">
-              <ViewDataSelector
-                value={viewBy}
-                onChange={setViewBy}
-                options={viewOptions}
-                date=
-                  {viewBy === "custom_range"
-                    ? { startDate: fromDate, endDate: toDate }
-                    : customDate}
-                onDateChange={(val) => {
-                  if (viewBy === "custom_range") {
-                    setFromDate(val.startDate || "");
-                    setToDate(val.endDate || "");
-                  } else {
-                    setCustomDate(val);
-                  }
-                }}
+            {/* Rentang Tanggal */}
+            <div className="flex items-center justify-end gap-2 mb-2">
+              <input
+                type="date"
+                className="border rounded px-2 py-1 text-sm"
+                value={fromDate}
+                onChange={(e) => setFromDate(e.target.value)}
+              />
+              <span className="text-sm">s/d</span>
+              <input
+                type="date"
+                className="border rounded px-2 py-1 text-sm"
+                value={toDate}
+                onChange={(e) => setToDate(e.target.value)}
               />
             </div>
 


### PR DESCRIPTION
## Summary
- replace "View Data By" dropdown with from/to date inputs on Instagram Likes Tracking
- remove view selector and rely on date range on Link Amplification and TikTok Comments Tracking

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689757d8a87c8327ba364f82b54031fd