### PR TITLE
Align date range params with backend

### DIFF
--- a/cicero-dashboard/__tests__/api.test.ts
+++ b/cicero-dashboard/__tests__/api.test.ts
@@ -19,8 +19,8 @@ test("getDashboardStats supports date range params", async () => {
   await getDashboardStats("token123", undefined, undefined, "2024-01-01", "2024-01-31");
   const call = (global.fetch as jest.Mock).mock.calls[0];
   expect(call[0]).toContain("/api/dashboard/stats");
-  expect(call[0]).toContain("tanggal_mulai=2024-01-01");
-  expect(call[0]).toContain("tanggal_selesai=2024-01-31");
+  expect(call[0]).toContain("start_date=2024-01-01");
+  expect(call[0]).toContain("end_date=2024-01-31");
   expect(call[1].headers.Authorization).toBe("Bearer token123");
 });
 
@@ -35,8 +35,8 @@ test("getRekapAmplify supports date range params", async () => {
   );
   const call = (global.fetch as jest.Mock).mock.calls[0];
   expect(call[0]).toContain("/api/amplify/rekap");
-  expect(call[0]).toContain("tanggal_mulai=2024-02-01");
-  expect(call[0]).toContain("tanggal_selesai=2024-02-28");
+  expect(call[0]).toContain("start_date=2024-02-01");
+  expect(call[0]).toContain("end_date=2024-02-28");
   expect(call[1].headers.Authorization).toBe("Bearer tok");
 });
 
@@ -51,8 +51,8 @@ test("getRekapLikesIG supports date range params", async () => {
   );
   const url = (global.fetch as jest.Mock).mock.calls[0][0];
   expect(url).toContain("/api/insta/rekap-likes");
-  expect(url).toContain("tanggal_mulai=2023-12-01");
-  expect(url).toContain("tanggal_selesai=2023-12-31");
+  expect(url).toContain("start_date=2023-12-01");
+  expect(url).toContain("end_date=2023-12-31");
 });
 
 test("getRekapKomentarTiktok supports date range params", async () => {
@@ -66,21 +66,21 @@ test("getRekapKomentarTiktok supports date range params", async () => {
   );
   const url = (global.fetch as jest.Mock).mock.calls[0][0];
   expect(url).toContain("/api/tiktok/rekap-komentar");
-  expect(url).toContain("tanggal_mulai=2024-03-01");
-  expect(url).toContain("tanggal_selesai=2024-03-31");
+  expect(url).toContain("start_date=2024-03-01");
+  expect(url).toContain("end_date=2024-03-31");
 });
 
 test("getDashboardStats handles partial date range params", async () => {
   await getDashboardStats("tok", undefined, undefined, "2024-06-01");
   let url = (global.fetch as jest.Mock).mock.calls[0][0];
-  expect(url).toContain("tanggal_mulai=2024-06-01");
-  expect(url).not.toContain("tanggal_selesai");
+  expect(url).toContain("start_date=2024-06-01");
+  expect(url).not.toContain("end_date");
 
   (global.fetch as jest.Mock).mockClear();
 
   await getDashboardStats("tok", undefined, undefined, undefined, "2024-06-30");
   url = (global.fetch as jest.Mock).mock.calls[0][0];
-  expect(url).toContain("tanggal_selesai=2024-06-30");
-  expect(url).not.toContain("tanggal_mulai");
+  expect(url).toContain("end_date=2024-06-30");
+  expect(url).not.toContain("start_date");
 });
 

--- a/cicero-dashboard/utils/api.ts
+++ b/cicero-dashboard/utils/api.ts
@@ -47,8 +47,8 @@ export async function getDashboardStats(
   const params = new URLSearchParams();
   if (periode) params.append("periode", periode);
   if (tanggal) params.append("tanggal", tanggal);
-  if (startDate) params.append("tanggal_mulai", startDate);
-  if (endDate) params.append("tanggal_selesai", endDate);
+  if (startDate) params.append("start_date", startDate);
+  if (endDate) params.append("end_date", endDate);
   const url = `${API_BASE_URL}/api/dashboard/stats${
     params.toString() ? `?${params.toString()}` : ""
   }`;
@@ -68,8 +68,8 @@ export async function getRekapLikesIG(
 ): Promise<any> {
   const params = new URLSearchParams({ client_id, periode });
   if (tanggal) params.append("tanggal", tanggal);
-  if (startDate) params.append("tanggal_mulai", startDate);
-  if (endDate) params.append("tanggal_selesai", endDate);
+  if (startDate) params.append("start_date", startDate);
+  if (endDate) params.append("end_date", endDate);
   const url = `${API_BASE_URL}/api/insta/rekap-likes?${params.toString()}`;
 
   const res = await fetchWithAuth(url, token);
@@ -155,8 +155,8 @@ export async function getRekapKomentarTiktok(
 ): Promise<any> {
   const params = new URLSearchParams({ client_id, periode });
   if (tanggal) params.append("tanggal", tanggal);
-  if (startDate) params.append("tanggal_mulai", startDate);
-  if (endDate) params.append("tanggal_selesai", endDate);
+  if (startDate) params.append("start_date", startDate);
+  if (endDate) params.append("end_date", endDate);
   const url = `${API_BASE_URL}/api/tiktok/rekap-komentar?${params.toString()}`;
 
   const res = await fetchWithAuth(url, token);
@@ -178,8 +178,8 @@ export async function getRekapAmplify(
 ): Promise<any> {
   const params = new URLSearchParams({ client_id, periode });
   if (tanggal) params.append("tanggal", tanggal);
-  if (startDate) params.append("tanggal_mulai", startDate);
-  if (endDate) params.append("tanggal_selesai", endDate);
+  if (startDate) params.append("start_date", startDate);
+  if (endDate) params.append("end_date", endDate);
   const url = `${API_BASE_URL}/api/amplify/rekap?${params.toString()}`;
 
   const res = await fetchWithAuth(url, token);
@@ -204,8 +204,8 @@ export async function getInstagramPostsViaBackend(
   endDate?: string
 ): Promise<any> {
   const params = new URLSearchParams({ username, limit: String(limit) });
-  if (startDate) params.append("tanggal_mulai", startDate);
-  if (endDate) params.append("tanggal_selesai", endDate);
+  if (startDate) params.append("start_date", startDate);
+  if (endDate) params.append("end_date", endDate);
   const url = `${API_BASE_URL}/api/insta/rapid-posts?${params.toString()}`;
   const res = await fetchWithAuth(url, token);
   if (!res.ok) {
@@ -352,8 +352,8 @@ export async function getTiktokPostsViaBackend(
   endDate?: string
 ): Promise<any> {
   const params = new URLSearchParams({ client_id, limit: String(limit) });
-  if (startDate) params.append("tanggal_mulai", startDate);
-  if (endDate) params.append("tanggal_selesai", endDate);
+  if (startDate) params.append("start_date", startDate);
+  if (endDate) params.append("end_date", endDate);
   const url = `${API_BASE_URL}/api/tiktok/rapid-posts?${params.toString()}`;
   const res = await fetchWithAuth(url, token);
   if (!res.ok) {


### PR DESCRIPTION
## Summary
- use `start_date`/`end_date` query params for dashboard stats and likes APIs
- update tests to cover new parameter names

## Testing
- `cd cicero-dashboard && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68980e0b0eb4832788193d23fe740e1e