### PR TITLE
Handle snake_case Instagram post stats in likes tracking

### DIFF
--- a/cicero-dashboard/app/likes/instagram/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/page.jsx
@@ -107,8 +107,12 @@ export default function InstagramLikesTrackingPage() {
         // Rekap summary
         const totalUser = users.length;
         const igPostsData =
+          statsData?.instagram_posts ??
+          statsData?.ig_posts ??
           statsData?.igPosts ??
           statsData?.instagramPosts ??
+          statsData.instagram_posts ??
+          statsData.ig_posts ??
           statsData.igPosts ??
           statsData.instagramPosts ??
           0;

--- a/cicero-dashboard/app/likes/instagram/rekap/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/rekap/page.jsx
@@ -93,8 +93,12 @@ export default function RekapLikesIGPage() {
 
         // Hitung jumlah IG post dari stats
         const igPostsData =
+          statsData?.instagram_posts ??
+          statsData?.ig_posts ??
           statsData?.igPosts ??
           statsData?.instagramPosts ??
+          statsData.instagram_posts ??
+          statsData.ig_posts ??
           statsData.igPosts ??
           statsData.instagramPosts ??
           0;


### PR DESCRIPTION
## Summary
- support new `instagram_posts` and `ig_posts` fields when calculating Instagram post counts on likes tracking pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68982ad7fa2c8327a7a1e8f15f4091ab