### PR TITLE
Normalize Instagram stats and simplify likes tracking pages

### DIFF
--- a/cicero-dashboard/__tests__/api.test.ts
+++ b/cicero-dashboard/__tests__/api.test.ts
@@ -7,7 +7,7 @@ import {
 
 beforeEach(() => {
   global.fetch = jest.fn(() =>
-    Promise.resolve({ ok: true, json: () => Promise.resolve({ data: 1 }) })
+    Promise.resolve({ ok: true, json: () => Promise.resolve({ data: {} }) })
   ) as any;
 });
 
@@ -68,6 +68,19 @@ test("getRekapKomentarTiktok supports date range params", async () => {
   expect(url).toContain("/api/tiktok/rekap-komentar");
   expect(url).toContain("start_date=2024-03-01");
   expect(url).toContain("end_date=2024-03-31");
+});
+
+test("getDashboardStats normalizes fields", async () => {
+  (global.fetch as jest.Mock).mockResolvedValueOnce({
+    ok: true,
+    json: () =>
+      Promise.resolve({
+        data: { clientId: "c1", instagram_posts: [1, 2, 3] },
+      }),
+  });
+  const result = await getDashboardStats("tok");
+  expect(result.client_id).toBe("c1");
+  expect(result.instagramPosts).toBe(3);
 });
 
 test("getDashboardStats handles partial date range params", async () => {

--- a/cicero-dashboard/app/likes/instagram/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/page.jsx
@@ -70,20 +70,17 @@ export default function InstagramLikesTrackingPage() {
             : customDate;
         const { periode, date, startDate, endDate } =
           getPeriodeDateForView(viewBy, selectedDate);
-        const statsRes = await getDashboardStats(
+        const statsData = await getDashboardStats(
           token,
           periode,
           date,
           startDate,
           endDate,
         );
-        const statsData = statsRes.data || statsRes;
         setStats(statsData);
 
         const client_id =
-          statsData?.client_id ||
-          statsData.client_id ||
-          localStorage.getItem("client_id");
+          statsData.client_id || localStorage.getItem("client_id");
         if (!client_id) {
           setError("Client ID tidak ditemukan.");
           setLoading(false);
@@ -106,19 +103,7 @@ export default function InstagramLikesTrackingPage() {
 
         // Rekap summary
         const totalUser = users.length;
-        const igPostsData =
-          statsData?.instagram_posts ??
-          statsData?.ig_posts ??
-          statsData?.igPosts ??
-          statsData?.instagramPosts ??
-          statsData.instagram_posts ??
-          statsData.ig_posts ??
-          statsData.igPosts ??
-          statsData.instagramPosts ??
-          0;
-        const totalIGPost = Array.isArray(igPostsData)
-          ? igPostsData.length
-          : Number(igPostsData) || 0;
+        const totalIGPost = Number(statsData.instagramPosts) || 0;
         const isZeroPost = (totalIGPost || 0) === 0;
         const totalSudahLike = isZeroPost
           ? 0

--- a/cicero-dashboard/app/likes/instagram/rekap/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/rekap/page.jsx
@@ -59,18 +59,15 @@ export default function RekapLikesIGPage() {
             : customDate;
         const { periode, date, startDate, endDate } =
           getPeriodeDateForView(viewBy, selectedDate);
-        const statsRes = await getDashboardStats(
+        const statsData = await getDashboardStats(
           token,
           periode,
           date,
           startDate,
           endDate,
         );
-        const statsData = statsRes.data || statsRes;
         const client_id =
-          statsData?.client_id ||
-          statsData.client_id ||
-          localStorage.getItem("client_id");
+          statsData.client_id || localStorage.getItem("client_id");
         if (!client_id) {
           setError("Client ID tidak ditemukan.");
           setLoading(false);
@@ -92,19 +89,7 @@ export default function RekapLikesIGPage() {
           : [];
 
         // Hitung jumlah IG post dari stats
-        const igPostsData =
-          statsData?.instagram_posts ??
-          statsData?.ig_posts ??
-          statsData?.igPosts ??
-          statsData?.instagramPosts ??
-          statsData.instagram_posts ??
-          statsData.ig_posts ??
-          statsData.igPosts ??
-          statsData.instagramPosts ??
-          0;
-        const totalIGPost = Array.isArray(igPostsData)
-          ? igPostsData.length
-          : Number(igPostsData) || 0;
+        const totalIGPost = Number(statsData.instagramPosts) || 0;
         const isZeroPost = (totalIGPost || 0) === 0;
         const totalUser = users.length;
         const totalSudahLike = isZeroPost

--- a/cicero-dashboard/utils/api.ts
+++ b/cicero-dashboard/utils/api.ts
@@ -54,7 +54,19 @@ export async function getDashboardStats(
   }`;
   const res = await fetchWithAuth(url, token);
   if (!res.ok) throw new Error("Failed to fetch stats");
-  return res.json();
+  const json = await res.json();
+  const raw: any = json.data || json;
+  const clientId = raw.client_id ?? raw.clientId ?? raw.clientID ?? null;
+  const igPostsRaw =
+    raw.instagramPosts ??
+    raw.instagram_posts ??
+    raw.igPosts ??
+    raw.ig_posts ??
+    0;
+  const instagramPosts = Array.isArray(igPostsRaw)
+    ? igPostsRaw.length
+    : Number(igPostsRaw) || 0;
+  return { ...raw, client_id: clientId, instagramPosts };
 }
 
 // Ambil rekap absensi instagram harian


### PR DESCRIPTION
## Summary
- normalize `getDashboardStats` to expose `client_id` and numeric `instagramPosts`
- update Instagram likes tracking pages to use the normalized fields
- add unit test covering dashboard stat normalization

## Testing
- `npm test`
- `npm run lint` *(fails: interactive Next.js eslint prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68982f75ac688327b5ac131028cc7e7a