### PR TITLE
Limit date selector options on tracking pages

### DIFF
--- a/cicero-dashboard/app/amplify/page.jsx
+++ b/cicero-dashboard/app/amplify/page.jsx
@@ -29,9 +29,7 @@ export default function AmplifyPage() {
     totalLink: 0,
   });
 
-  const viewOptions = VIEW_OPTIONS.filter(
-    (opt) => !["this_week", "last_week", "all"].includes(opt.value),
-  );
+  const viewOptions = VIEW_OPTIONS;
 
   useEffect(() => {
     setLoading(true);

--- a/cicero-dashboard/app/comments/tiktok/page.jsx
+++ b/cicero-dashboard/app/comments/tiktok/page.jsx
@@ -37,9 +37,7 @@ export default function TiktokKomentarTrackingPage() {
     totalTiktokPost: 0,
   });
 
-  const viewOptions = VIEW_OPTIONS.filter(
-    (opt) => !["this_week", "last_week", "all"].includes(opt.value),
-  );
+  const viewOptions = VIEW_OPTIONS;
 
   useEffect(() => {
     setLoading(true);

--- a/cicero-dashboard/app/comments/tiktok/rekap/page.jsx
+++ b/cicero-dashboard/app/comments/tiktok/rekap/page.jsx
@@ -28,9 +28,7 @@ export default function RekapKomentarTiktokPage() {
     totalTiktokPost: 0,
   });
 
-  const viewOptions = VIEW_OPTIONS.filter(
-    (opt) => !["this_week", "last_week", "all"].includes(opt.value),
-  );
+  const viewOptions = VIEW_OPTIONS;
 
 
   useEffect(() => {

--- a/cicero-dashboard/app/likes/instagram/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/page.jsx
@@ -45,9 +45,7 @@ export default function InstagramLikesTrackingPage() {
     totalIGPost: 0,
   });
 
-  const viewOptions = VIEW_OPTIONS.filter(
-    (opt) => !["this_week", "last_week", "all"].includes(opt.value),
-  );
+  const viewOptions = VIEW_OPTIONS;
 
   useEffect(() => {
     setLoading(true);

--- a/cicero-dashboard/app/likes/instagram/rekap/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/rekap/page.jsx
@@ -33,9 +33,7 @@ export default function RekapLikesIGPage() {
     totalIGPost: 0,
   });
 
-  const viewOptions = VIEW_OPTIONS.filter(
-    (opt) => !["this_week", "last_week", "all"].includes(opt.value),
-  );
+  const viewOptions = VIEW_OPTIONS;
 
 
   useEffect(() => {

--- a/cicero-dashboard/components/ViewDataSelector.jsx
+++ b/cicero-dashboard/components/ViewDataSelector.jsx
@@ -2,25 +2,20 @@
 import { useId } from "react";
 
 export const VIEW_OPTIONS = [
-  { value: "today", label: "Hari ini", periode: "harian", offset: 0 },
-  { value: "yesterday", label: "Hari Sebelumnya", periode: "harian", offset: -1 },
-  { value: "this_week", label: "Minggu ini", periode: "mingguan", weekOffset: 0 },
-  { value: "last_week", label: "Minggu Sebelumnya", periode: "mingguan", weekOffset: -1 },
-  { value: "month", label: "Pilih Bulan", periode: "bulanan", month: true },
+  { value: "today", label: "Hari ini", periode: "harian" },
   { value: "date", label: "Tanggal Pilihan", periode: "harian", custom: true },
+  { value: "month", label: "Pilih Bulan", periode: "bulanan", month: true },
   {
     value: "custom_range",
     label: "Rentang Tanggal",
     periode: "harian",
     range: true,
   },
-  { value: "all", label: "Seluruh Data", periode: "semua" },
 ];
 
 export function getPeriodeDateForView(view, selectedDate) {
   const opt = VIEW_OPTIONS.find((o) => o.value === view) || VIEW_OPTIONS[0];
   const now = new Date();
-  if (opt.periode === "semua") return { periode: opt.periode, date: "" };
 
   function formatDate(d) {
     const year = d.getFullYear();
@@ -45,18 +40,6 @@ export function getPeriodeDateForView(view, selectedDate) {
   if (opt.custom) {
     const d = selectedDate ? selectedDate : formatDate(now);
     return { periode: opt.periode, date: d };
-  }
-
-  if (Object.prototype.hasOwnProperty.call(opt, "offset")) {
-    const d = new Date(now);
-    d.setDate(d.getDate() + (opt.offset || 0));
-    return { periode: opt.periode, date: formatDate(d) };
-  }
-  if (Object.prototype.hasOwnProperty.call(opt, "weekOffset")) {
-    const mondayOffset = (now.getDay() + 6) % 7; // monday start
-    const d = new Date(now);
-    d.setDate(d.getDate() - mondayOffset + (opt.weekOffset || 0) * 7);
-    return { periode: opt.periode, date: formatDate(d) };
   }
   if (opt.month) {
     const d = selectedDate


### PR DESCRIPTION
## Summary
- simplify ViewDataSelector to only offer today, date, month, and range options
- update Instagram likes, link amplification, and TikTok comment tracking pages to use the trimmed selector options

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_6899367f05008327aec347b0c79c1077