### PR TITLE
feat: add confirmation and WhatsApp fields to registration

### DIFF
--- a/cicero-dashboard/app/login/page.jsx
+++ b/cicero-dashboard/app/login/page.jsx
@@ -2,6 +2,7 @@
 
 import useAuthRedirect from "@/hooks/useAuthRedirect";
 import { useState } from "react";
+import { Eye, EyeOff } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/context/AuthContext";
 import DarkModeToggle from "@/components/DarkModeToggle";
@@ -9,21 +10,17 @@ import DarkModeToggle from "@/components/DarkModeToggle";
 export default function LoginPage() {
   useAuthRedirect(); // Akan redirect ke /dashboard jika sudah login
   const { setAuth } = useAuth();
+  const router = useRouter();
 
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
-  const [client_id, setClientId] = useState("");
-  const [role, setRole] = useState("");
-  const [isRegister, setIsRegister] = useState(false);
   const [error, setError] = useState("");
-  const [message, setMessage] = useState("");
   const [loading, setLoading] = useState(false);
-  const router = useRouter();
+  const [showPassword, setShowPassword] = useState(false);
 
   const handleLogin = async (e) => {
     e.preventDefault();
     setError("");
-    setMessage("");
     setLoading(true);
 
     try {
@@ -55,55 +52,17 @@ export default function LoginPage() {
     setLoading(false);
   };
 
-  const handleRegister = async (e) => {
-    e.preventDefault();
-    setError("");
-    setMessage("");
-    setLoading(true);
-
-    try {
-      const apiUrl = process.env.NEXT_PUBLIC_API_URL || "";
-      const res = await fetch(`${apiUrl}/api/auth/dashboard-register`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          username,
-          password,
-          role: role ? role.toLowerCase() : undefined,
-          client_id: client_id || undefined,
-        }),
-      });
-      const data = await res.json();
-      if (data.success) {
-        const msg = data.status === false
-          ? "Registrasi berhasil, menunggu persetujuan admin"
-          : "Registrasi berhasil, silakan login";
-        setMessage(msg);
-        setIsRegister(false);
-        setUsername("");
-        setPassword("");
-        setRole("");
-        setClientId("");
-      } else {
-        setError(data.message || "Registrasi gagal");
-      }
-    } catch (err) {
-      setError("Gagal koneksi ke server");
-    }
-    setLoading(false);
-  };
-
   return (
     <main className="min-h-screen flex items-center justify-center bg-slate-100 p-4 relative">
       <div className="absolute top-4 right-4">
         <DarkModeToggle />
       </div>
       <form
-        onSubmit={isRegister ? handleRegister : handleLogin}
+        onSubmit={handleLogin}
         className="bg-white p-8 rounded-2xl shadow-xl w-full max-w-sm"
       >
         <h2 className="mb-6 text-2xl font-bold text-blue-600 text-center">
-          {isRegister ? "Register" : "Login"} Cicero
+          Login Cicero
         </h2>
         <div className="mb-4">
           <label htmlFor="username" className="sr-only">
@@ -119,127 +78,51 @@ export default function LoginPage() {
             className="w-full px-3 py-2 rounded-md border border-gray-300 focus:outline-none focus:border-blue-400"
           />
         </div>
-        <div className="mb-4">
+        <div className="mb-4 relative">
           <label htmlFor="password" className="sr-only">
             Password
           </label>
           <input
             id="password"
-            type="password"
+            type={showPassword ? "text" : "password"}
             placeholder="Password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             required
-            className="w-full px-3 py-2 rounded-md border border-gray-300 focus:outline-none focus:border-blue-400"
+            className="w-full px-3 py-2 rounded-md border border-gray-300 focus:outline-none focus:border-blue-400 pr-10"
           />
+          <button
+            type="button"
+            onClick={() => setShowPassword((prev) => !prev)}
+            className="absolute inset-y-0 right-3 flex items-center text-gray-500"
+            tabIndex={-1}
+          >
+            {showPassword ? <EyeOff size={20} /> : <Eye size={20} />}
+          </button>
         </div>
-        {isRegister && (
-          <>
-            <div className="mb-4">
-              <label htmlFor="role" className="sr-only">
-                Role
-              </label>
-              <input
-                id="role"
-                type="text"
-                list="role-options"
-                placeholder="Role"
-                value={role}
-                onChange={(e) => setRole(e.target.value)}
-                className="w-full px-3 py-2 rounded-md border border-gray-300 focus:outline-none focus:border-blue-400"
-              />
-              <datalist id="role-options">
-                <option value="OPERATOR" />
-                <option value="DITBINMAS" />
-                <option value="DITLANTAS" />
-              </datalist>
-            </div>
-            <div className="mb-4">
-              <label htmlFor="client_id" className="sr-only">
-                Client ID
-              </label>
-              <input
-                id="client_id"
-                type="text"
-                list="client-options"
-                placeholder="Client ID"
-                value={client_id}
-                onChange={(e) => setClientId(e.target.value)}
-                className="w-full px-3 py-2 rounded-md border border-gray-300 focus:outline-none focus:border-blue-400"
-              />
-              <datalist id="client-options">
-                <option value="KEDIRI" />
-                <option value="BANGKALAN" />
-                <option value="BANYUWANGI" />
-                <option value="BATU" />
-                <option value="DITBINMAS" />
-                <option value="DITLANTAS" />
-                <option value="BLITAR" />
-                <option value="BLITAR KOTA" />
-                <option value="BOJONEGORO" />
-                <option value="BONDOWOSO" />
-                <option value="GRESIK" />
-                <option value="JEMBER" />
-                <option value="JOMBANG" />
-                <option value="KEDIRI KOTA" />
-                <option value="KP3 TANJUNG PERAK" />
-                <option value="LAMONGAN" />
-                <option value="LUMAJANG" />
-                <option value="MADIUN" />
-                <option value="MADIUN KOTA" />
-                <option value="MAGETAN" />
-                <option value="MALANG" />
-                <option value="MALANG KOTA" />
-                <option value="MOJOKERTO" />
-                <option value="MOJOKERTO KOTA" />
-                <option value="NGANJUK" />
-                <option value="NGAWI" />
-                <option value="PACITAN" />
-                <option value="PAMEKASAN" />
-                <option value="PASURUAN" />
-                <option value="PASURUAN KOTA" />
-                <option value="PONOROGO" />
-                <option value="PROBOLINGGO" />
-                <option value="PROBOLINGGO KOTA" />
-                <option value="SAMPANG" />
-                <option value="SIDOARJO" />
-                <option value="SITUBONDO" />
-                <option value="SUMENEP" />
-                <option value="SURABAYA" />
-                <option value="TRENGGALEK" />
-                <option value="TUBAN" />
-                <option value="TULUNGAGUNG" />
-              </datalist>
-            </div>
-          </>
-        )}
         {error && (
           <div className="text-red-600 text-sm mb-2 text-center">{error}</div>
-        )}
-        {message && (
-          <div className="text-green-600 text-sm mb-2 text-center">{message}</div>
         )}
         <button
           type="submit"
           disabled={loading}
-          className={`w-full py-2 rounded-lg text-white font-semibold text-lg transition
-            ${loading ? "bg-blue-300 cursor-not-allowed" : "bg-blue-600 hover:bg-blue-700"}
-          `}
+          className={`w-full py-2 rounded-lg text-white font-semibold text-lg transition ${
+            loading ? "bg-blue-300 cursor-not-allowed" : "bg-blue-600 hover:bg-blue-700"
+          }`}
         >
-          {loading ? (isRegister ? "Registering..." : "Logging in...") : isRegister ? "Register" : "Login"}
+          {loading ? "Logging in..." : "Login"}
         </button>
         <div className="text-sm text-center mt-4">
-          {isRegister ? (
-            <button type="button" onClick={() => setIsRegister(false)} className="text-blue-600 hover:underline">
-              Sudah punya akun? Login
-            </button>
-          ) : (
-            <button type="button" onClick={() => setIsRegister(true)} className="text-blue-600 hover:underline">
-              Belum punya akun? Register
-            </button>
-          )}
+          <button
+            type="button"
+            onClick={() => router.push("/register")}
+            className="text-blue-600 hover:underline"
+          >
+            Belum punya akun? Register
+          </button>
         </div>
       </form>
     </main>
   );
 }
+

--- a/cicero-dashboard/app/register/page.jsx
+++ b/cicero-dashboard/app/register/page.jsx
@@ -1,0 +1,254 @@
+"use client";
+
+import useAuthRedirect from "@/hooks/useAuthRedirect";
+import { useState } from "react";
+import { Eye, EyeOff } from "lucide-react";
+import { useRouter } from "next/navigation";
+import DarkModeToggle from "@/components/DarkModeToggle";
+
+export default function RegisterPage() {
+  useAuthRedirect();
+  const router = useRouter();
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [whatsapp, setWhatsapp] = useState("");
+  const [role, setRole] = useState("");
+  const [clientId, setClientId] = useState("");
+  const [error, setError] = useState("");
+  const [message, setMessage] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+
+  const handleRegister = async (e) => {
+    e.preventDefault();
+    setError("");
+    setMessage("");
+    if (password !== confirmPassword) {
+      setError("Konfirmasi password tidak sesuai");
+      return;
+    }
+    setLoading(true);
+    try {
+      const apiUrl = process.env.NEXT_PUBLIC_API_URL || "";
+      const res = await fetch(`${apiUrl}/api/auth/dashboard-register`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          username,
+          password,
+          whatsapp,
+          role: role ? role.toLowerCase() : undefined,
+          client_id: clientId || undefined,
+        }),
+      });
+      const data = await res.json();
+      if (data.success) {
+        const msg =
+          data.status === false
+            ? "Registrasi berhasil, menunggu persetujuan admin"
+            : "Registrasi berhasil, silakan login";
+        setMessage(msg);
+        setUsername("");
+        setPassword("");
+        setConfirmPassword("");
+        setWhatsapp("");
+        setRole("");
+        setClientId("");
+      } else {
+        setError(data.message || "Registrasi gagal");
+      }
+    } catch (err) {
+      setError("Gagal koneksi ke server");
+    }
+    setLoading(false);
+  };
+
+  return (
+    <main className="min-h-screen flex items-center justify-center bg-slate-100 p-4 relative">
+      <div className="absolute top-4 right-4">
+        <DarkModeToggle />
+      </div>
+      <form
+        onSubmit={handleRegister}
+        className="bg-white p-8 rounded-2xl shadow-xl w-full max-w-sm"
+      >
+        <h2 className="mb-6 text-2xl font-bold text-blue-600 text-center">
+          Register Cicero
+        </h2>
+        <div className="mb-4">
+          <label htmlFor="username" className="sr-only">
+            Username
+          </label>
+          <input
+            id="username"
+            type="text"
+            placeholder="Username"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            required
+            className="w-full px-3 py-2 rounded-md border border-gray-300 focus:outline-none focus:border-blue-400"
+          />
+        </div>
+        <div className="mb-4 relative">
+          <label htmlFor="password" className="sr-only">
+            Password
+          </label>
+          <input
+            id="password"
+            type={showPassword ? "text" : "password"}
+            placeholder="Password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            className="w-full px-3 py-2 rounded-md border border-gray-300 focus:outline-none focus:border-blue-400 pr-10"
+          />
+          <button
+            type="button"
+            onClick={() => setShowPassword((prev) => !prev)}
+            className="absolute inset-y-0 right-3 flex items-center text-gray-500"
+            tabIndex={-1}
+          >
+            {showPassword ? <EyeOff size={20} /> : <Eye size={20} />}
+          </button>
+        </div>
+        <div className="mb-4 relative">
+          <label htmlFor="confirm_password" className="sr-only">
+            Konfirmasi Password
+          </label>
+          <input
+            id="confirm_password"
+            type={showConfirmPassword ? "text" : "password"}
+            placeholder="Konfirmasi Password"
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            required
+            className="w-full px-3 py-2 rounded-md border border-gray-300 focus:outline-none focus:border-blue-400 pr-10"
+          />
+          <button
+            type="button"
+            onClick={() => setShowConfirmPassword((prev) => !prev)}
+            className="absolute inset-y-0 right-3 flex items-center text-gray-500"
+            tabIndex={-1}
+          >
+            {showConfirmPassword ? <EyeOff size={20} /> : <Eye size={20} />}
+          </button>
+        </div>
+        <div className="mb-4">
+          <label htmlFor="whatsapp" className="sr-only">
+            Nomor WhatsApp
+          </label>
+          <input
+            id="whatsapp"
+            type="tel"
+            placeholder="Nomor WhatsApp"
+            value={whatsapp}
+            onChange={(e) => setWhatsapp(e.target.value)}
+            required
+            className="w-full px-3 py-2 rounded-md border border-gray-300 focus:outline-none focus:border-blue-400"
+          />
+        </div>
+        <div className="mb-4">
+          <label htmlFor="role" className="sr-only">
+            Role
+          </label>
+          <input
+            id="role"
+            type="text"
+            list="role-options"
+            placeholder="Role"
+            value={role}
+            onChange={(e) => setRole(e.target.value)}
+            className="w-full px-3 py-2 rounded-md border border-gray-300 focus:outline-none focus:border-blue-400"
+          />
+          <datalist id="role-options">
+            <option value="OPERATOR" />
+            <option value="DITBINMAS" />
+            <option value="DITLANTAS" />
+          </datalist>
+        </div>
+        <div className="mb-4">
+          <label htmlFor="client_id" className="sr-only">
+            Client ID
+          </label>
+          <input
+            id="client_id"
+            type="text"
+            list="client-options"
+            placeholder="Client ID"
+            value={clientId}
+            onChange={(e) => setClientId(e.target.value)}
+            className="w-full px-3 py-2 rounded-md border border-gray-300 focus:outline-none focus:border-blue-400"
+          />
+          <datalist id="client-options">
+            <option value="KEDIRI" />
+            <option value="BANGKALAN" />
+            <option value="BANYUWANGI" />
+            <option value="BATU" />
+            <option value="DITBINMAS" />
+            <option value="DITLANTAS" />
+            <option value="BLITAR" />
+            <option value="BLITAR KOTA" />
+            <option value="BOJONEGORO" />
+            <option value="BONDOWOSO" />
+            <option value="GRESIK" />
+            <option value="JEMBER" />
+            <option value="JOMBANG" />
+            <option value="KEDIRI KOTA" />
+            <option value="KP3 TANJUNG PERAK" />
+            <option value="LAMONGAN" />
+            <option value="LUMAJANG" />
+            <option value="MADIUN" />
+            <option value="MADIUN KOTA" />
+            <option value="MAGETAN" />
+            <option value="MALANG" />
+            <option value="MALANG KOTA" />
+            <option value="MOJOKERTO" />
+            <option value="MOJOKERTO KOTA" />
+            <option value="NGANJUK" />
+            <option value="NGAWI" />
+            <option value="PACITAN" />
+            <option value="PAMEKASAN" />
+            <option value="PASURUAN" />
+            <option value="PASURUAN KOTA" />
+            <option value="PONOROGO" />
+            <option value="PROBOLINGGO" />
+            <option value="PROBOLINGGO KOTA" />
+            <option value="SAMPANG" />
+            <option value="SIDOARJO" />
+            <option value="SITUBONDO" />
+            <option value="SUMENEP" />
+            <option value="SURABAYA" />
+            <option value="TRENGGALEK" />
+            <option value="TUBAN" />
+            <option value="TULUNGAGUNG" />
+          </datalist>
+        </div>
+        {error && (
+          <div className="text-red-600 text-sm mb-2 text-center">{error}</div>
+        )}
+        {message && (
+          <div className="text-green-600 text-sm mb-2 text-center">{message}</div>
+        )}
+        <button
+          type="submit"
+          disabled={loading}
+          className={`w-full py-2 rounded-lg text-white font-semibold text-lg transition ${loading ? "bg-blue-300 cursor-not-allowed" : "bg-blue-600 hover:bg-blue-700"}`}
+        >
+          {loading ? "Registering..." : "Register"}
+        </button>
+        <div className="text-sm text-center mt-4">
+          <button
+            type="button"
+            onClick={() => router.push("/login")}
+            className="text-blue-600 hover:underline"
+          >
+            Sudah punya akun? Login
+          </button>
+        </div>
+      </form>
+    </main>
+  );
+}
+


### PR DESCRIPTION
## Summary
- move registration form to its own page with password confirmation, visibility toggles, and WhatsApp input
- update login page to link to registration and support password visibility toggle

## Testing
- `cd cicero-dashboard && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c0959e7e48327b1f0df7ff39befd1