### PR TITLE
feat: add user insight page

### DIFF
--- a/cicero-dashboard/app/user-insight/page.jsx
+++ b/cicero-dashboard/app/user-insight/page.jsx
@@ -1,0 +1,83 @@
+"use client";
+import { useEffect, useState } from "react";
+import Loader from "@/components/Loader";
+import useRequireAuth from "@/hooks/useRequireAuth";
+import { useAuth } from "@/context/AuthContext";
+import { getUserDirectory } from "@/utils/api";
+import { groupUsersByKelompok } from "@/utils/grouping";
+import ChartUserFields from "@/components/ChartUserFields";
+
+export default function UserInsightPage() {
+  useRequireAuth();
+  const { token, clientId } = useAuth();
+  const [kelompok, setKelompok] = useState({
+    BAG: [],
+    SAT: [],
+    "SI & SPKT": [],
+    POLSEK: [],
+  });
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    async function fetchData() {
+      if (!token || !clientId) {
+        setError("Token / Client ID tidak ditemukan. Silakan login ulang.");
+        setLoading(false);
+        return;
+      }
+      try {
+        const res = await getUserDirectory(token, clientId);
+        const raw = res.data || res.users || res;
+        const users = Array.isArray(raw) ? raw : [];
+        setKelompok(groupUsersByKelompok(users));
+      } catch (err) {
+        setError("Gagal mengambil data: " + (err.message || err));
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchData();
+  }, [token, clientId]);
+
+  if (loading) return <Loader />;
+  if (error) {
+    return (
+      <div className="flex items-center justify-center min-h-screen bg-gray-100">
+        <div className="bg-white rounded-lg shadow-md p-6 text-red-500 font-bold">{error}</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-100 flex flex-col">
+      <div className="flex-1 flex items-start justify-center">
+        <div className="w-full max-w-5xl px-2 md:px-8 py-8">
+          <div className="flex flex-col gap-6">
+            <h1 className="text-2xl md:text-3xl font-bold text-blue-700 mb-2">
+              User Insight
+            </h1>
+            <ChartBox title="BAG" users={kelompok.BAG} />
+            <ChartBox title="SAT" users={kelompok.SAT} />
+            <ChartBox title="SI & SPKT" users={kelompok["SI & SPKT"]} />
+            <ChartBox title="POLSEK" users={kelompok.POLSEK} orientation="horizontal" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ChartBox({ title, users, orientation = "vertical" }) {
+  return (
+    <div className="bg-white rounded-xl shadow p-4">
+      <div className="font-bold text-blue-700 mb-2 text-center">{title}</div>
+      {users && users.length > 0 ? (
+        <ChartUserFields users={users} orientation={orientation} />
+      ) : (
+        <div className="text-center text-gray-400 text-sm">Tidak ada data</div>
+      )}
+    </div>
+  );
+}
+

--- a/cicero-dashboard/components/ChartUserFields.jsx
+++ b/cicero-dashboard/components/ChartUserFields.jsx
@@ -1,0 +1,143 @@
+"use client";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+  CartesianGrid,
+  LabelList,
+} from "recharts";
+
+function bersihkanSatfung(divisi = "") {
+  return divisi
+    .replace(/polsek\s*/i, "")
+    .replace(/^[0-9.\-\s]+/, "")
+    .trim();
+}
+
+export default function ChartUserFields({ users = [], orientation = "vertical" }) {
+  const divisiMap = {};
+  users.forEach((u) => {
+    const key = bersihkanSatfung(u.divisi || "LAINNYA");
+    if (!divisiMap[key]) {
+      divisiMap[key] = { divisi: key, total: 0, wa: 0, instagram: 0, tiktok: 0 };
+    }
+    divisiMap[key].total += 1;
+    if (u.whatsapp && String(u.whatsapp).trim() !== "") divisiMap[key].wa += 1;
+    if (u.insta && String(u.insta).trim() !== "") divisiMap[key].instagram += 1;
+    if (u.tiktok && String(u.tiktok).trim() !== "") divisiMap[key].tiktok += 1;
+  });
+  const dataChart = Object.values(divisiMap);
+
+  if (orientation === "horizontal") {
+    const barHeight = 32;
+    const chartHeight = Math.max(50, barHeight * dataChart.length);
+    return (
+      <div className="w-full px-2 pb-4">
+        <ResponsiveContainer width="100%" height={chartHeight}>
+          <BarChart
+            data={dataChart}
+            layout="vertical"
+            margin={{ top: 4, right: 20, left: 4, bottom: 4 }}
+            barCategoryGap="16%"
+          >
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis type="number" allowDecimals={false} />
+            <YAxis
+              dataKey="divisi"
+              type="category"
+              width={180}
+              interval={0}
+              tick={({ x, y, payload }) => (
+                <>
+                  <title>{payload.value}</title>
+                  <text
+                    x={x - 160}
+                    y={y + 10}
+                    fontSize={12}
+                    fill="#444"
+                    style={{ fontWeight: 500 }}
+                    textAnchor="start"
+                  >
+                    {payload.value}
+                  </text>
+                </>
+              )}
+            />
+            <Tooltip />
+            <Legend />
+            <Bar dataKey="total" name="Jumlah User" fill="#3b82f6" barSize={10}>
+              <LabelList dataKey="total" position="right" fontSize={10} />
+            </Bar>
+            <Bar dataKey="wa" name="No WA Terisi" fill="#10b981" barSize={10}>
+              <LabelList dataKey="wa" position="right" fontSize={10} />
+            </Bar>
+            <Bar
+              dataKey="instagram"
+              name="Username IG Terisi"
+              fill="#e1306c"
+              barSize={10}
+            >
+              <LabelList dataKey="instagram" position="right" fontSize={10} />
+            </Bar>
+            <Bar dataKey="tiktok" name="Username TikTok Terisi" fill="#000000" barSize={10}>
+              <LabelList dataKey="tiktok" position="right" fontSize={10} />
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    );
+  }
+
+  const minHeight = 220;
+  const maxHeight = 420;
+  const barHeight = 34;
+  const chartHeight = Math.min(
+    maxHeight,
+    Math.max(minHeight, barHeight * dataChart.length)
+  );
+  return (
+    <div className="w-full px-2 pb-4">
+      <ResponsiveContainer width="100%" height={chartHeight}>
+        <BarChart
+          data={dataChart}
+          margin={{ top: 4, right: 4, left: 4, bottom: 4 }}
+          barCategoryGap="16%"
+        >
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis
+            dataKey="divisi"
+            angle={-30}
+            textAnchor="end"
+            interval={0}
+            height={70}
+            tick={{ fontSize: 15, fontWeight: 700, fill: "#1e293b" }}
+          />
+          <YAxis allowDecimals={false} />
+          <Tooltip />
+          <Legend />
+          <Bar dataKey="total" name="Jumlah User" fill="#3b82f6">
+            <LabelList dataKey="total" position="top" fontSize={12} />
+          </Bar>
+          <Bar dataKey="wa" name="No WA Terisi" fill="#10b981">
+            <LabelList dataKey="wa" position="top" fontSize={12} />
+          </Bar>
+          <Bar
+            dataKey="instagram"
+            name="Username IG Terisi"
+            fill="#e1306c"
+          >
+            <LabelList dataKey="instagram" position="top" fontSize={12} />
+          </Bar>
+          <Bar dataKey="tiktok" name="Username TikTok Terisi" fill="#000000">
+            <LabelList dataKey="tiktok" position="top" fontSize={12} />
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+

--- a/cicero-dashboard/components/Sidebar.jsx
+++ b/cicero-dashboard/components/Sidebar.jsx
@@ -8,6 +8,7 @@ import {
   X as IconX,
   Home,
   Users,
+  BarChart3,
   Instagram,
   Heart,
   Music,
@@ -48,6 +49,7 @@ export default function Sidebar() {
   const menu = [
     { label: "Dashboard", path: "/dashboard", icon: Home },
     { label: "User Directory", path: "/users", icon: Users },
+    { label: "User Insight", path: "/user-insight", icon: BarChart3 },
     ...(profile?.client_insta_status
       ? [
           { label: "Instagram Post Analysis", path: "/instagram", icon: Instagram },


### PR DESCRIPTION
## Summary
- add User Insight page with per-divisi charts modeled after likes tracking
- include User Insight link in sidebar navigation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d55a16214832792e2d5c8c8905180