### PR TITLE
Rename insight menu labels and page titles

### DIFF
--- a/cicero-dashboard/app/amplify/page.jsx
+++ b/cicero-dashboard/app/amplify/page.jsx
@@ -12,7 +12,7 @@ import { groupUsersByKelompok } from "@/utils/grouping";
 import useRequireAuth from "@/hooks/useRequireAuth";
 import { Link as LinkIcon, User, Check, X } from "lucide-react";
 
-export default function AmplifyPage() {
+export default function DiseminasiInsightPage() {
   useRequireAuth();
   const [chartData, setChartData] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -108,7 +108,7 @@ export default function AmplifyPage() {
         <div className="w-full max-w-6xl px-2 md:px-8 py-8">
           <div className="flex flex-col gap-8">
             <h1 className="text-2xl md:text-3xl font-bold text-blue-700 mb-2">
-              Link Amplification Report
+              Diseminasi Insight Report
             </h1>
 
             <div className="bg-gradient-to-tr from-indigo-50 to-white rounded-2xl shadow flex flex-col md:flex-row items-stretch justify-between p-3 md:p-5 gap-2 md:gap-4 border">

--- a/cicero-dashboard/app/comments/tiktok/page.jsx
+++ b/cicero-dashboard/app/comments/tiktok/page.jsx
@@ -20,7 +20,7 @@ import {
   ArrowRight
 } from "lucide-react";
 
-export default function TiktokKomentarTrackingPage() {
+export default function TiktokEngagementInsightPage() {
   useRequireAuth();
   const [chartData, setChartData] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -142,7 +142,7 @@ export default function TiktokKomentarTrackingPage() {
           <div className="flex flex-col gap-8">
             {/* Header */}
             <h1 className="text-2xl md:text-3xl font-bold text-pink-700 mb-2">
-              TikTok Comments Tracking
+              TikTok Engagement Insight
             </h1>
 
             {/* Card Ringkasan */}

--- a/cicero-dashboard/app/likes/instagram/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/page.jsx
@@ -25,7 +25,7 @@ function isException(val) {
   return val === true || val === "true" || val === 1 || val === "1";
 }
 
-export default function InstagramLikesTrackingPage() {
+export default function InstagramEngagementInsightPage() {
   useRequireAuth();
   const [stats, setStats] = useState(null);
   const [chartData, setChartData] = useState([]);
@@ -153,7 +153,7 @@ export default function InstagramLikesTrackingPage() {
           <div className="flex flex-col gap-8">
             {/* Header */}
             <h1 className="text-2xl md:text-3xl font-bold text-blue-700 mb-2">
-              Instagram Likes Tracking
+              Instagram Engagement Insight
             </h1>
 
             {/* Card Ringkasan */}

--- a/cicero-dashboard/components/Sidebar.jsx
+++ b/cicero-dashboard/components/Sidebar.jsx
@@ -53,16 +53,16 @@ export default function Sidebar() {
     ...(profile?.client_insta_status
       ? [
           { label: "Instagram Post Analysis", path: "/instagram", icon: Instagram },
-          { label: "Instagram Likes Tracking", path: "/likes/instagram", icon: Heart },
+          { label: "Instagram Engagement Insight", path: "/likes/instagram", icon: Heart },
         ]
       : []),
     ...(profile?.client_amplify_status
-      ? [{ label: "Link Amplification", path: "/amplify", icon: LinkIcon }]
+      ? [{ label: "Diseminasi Insight", path: "/amplify", icon: LinkIcon }]
       : []),
     ...(profile?.client_tiktok_status
       ? [
           { label: "TikTok Post Analysis", path: "/tiktok", icon: Music },
-          { label: "TikTok Comments Tracking", path: "/comments/tiktok", icon: MessageCircle },
+          { label: "TikTok Engagement Insight", path: "/comments/tiktok", icon: MessageCircle },
         ]
       : []),
   ];


### PR DESCRIPTION
## Summary
- rename Link Amplification, Instagram Likes Tracking, and TikTok Comments Tracking to new Insight labels in sidebar
- update corresponding page components and headings

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689d62e96a0883279d02fa1f4928bc06