### PR TITLE
Align directorate charts with Polsek-style vertical view

### DIFF
--- a/cicero-dashboard/app/amplify/page.jsx
+++ b/cicero-dashboard/app/amplify/page.jsx
@@ -176,14 +176,7 @@ export default function DiseminasiInsightPage() {
               />
             </div>
             {isDirectorate ? (
-              <ChartHorizontal
-                title="POLRES"
-                users={chartData}
-                fieldJumlah="jumlah_link"
-                labelSudah="Sudah Post"
-                labelBelum="Belum Post"
-                labelTotal="Total Link"
-              />
+              <ChartBox title="POLRES" users={chartData} />
             ) : (
               <>
                 <ChartBox title="BAG" users={kelompok.BAG} />

--- a/cicero-dashboard/app/comments/tiktok/page.jsx
+++ b/cicero-dashboard/app/comments/tiktok/page.jsx
@@ -213,14 +213,11 @@ export default function TiktokEngagementInsightPage() {
 
             {/* Chart per kelompok atau polres */}
             {isDirectorate ? (
-              <ChartHorizontal
+              <ChartBox
                 title="POLRES"
                 users={chartData}
-                totalPost={rekapSummary.totalTiktokPost}
+                totalTiktokPost={rekapSummary.totalTiktokPost}
                 fieldJumlah="jumlah_komentar"
-                labelSudah="User Sudah Komentar"
-                labelBelum="User Belum Komentar"
-                labelTotal="Total Komentar"
               />
             ) : (
               <div className="flex flex-col gap-6">

--- a/cicero-dashboard/app/likes/instagram/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/page.jsx
@@ -224,7 +224,7 @@ export default function InstagramEngagementInsightPage() {
 
             {/* Chart per kelompok / polres */}
             {isDirectorate ? (
-              <ChartHorizontal
+              <ChartBox
                 title="POLRES"
                 users={chartData}
                 totalPost={rekapSummary.totalIGPost}

--- a/cicero-dashboard/app/user-insight/page.jsx
+++ b/cicero-dashboard/app/user-insight/page.jsx
@@ -207,7 +207,7 @@ export default function UserInsightPage() {
                 <ChartBox
                   title="POLRES"
                   data={chartPolres}
-                  orientation="horizontal"
+                  orientation="vertical"
                 />
               </div>
             ) : (


### PR DESCRIPTION
## Summary
- Show directorate charts with vertical orientation like Polsek view across insight pages

## Testing
- `npm test`
- `npm run lint` *(fails: requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_689d6ea4010c8327b0999aa1ea66a88b