### PR TITLE
Group directorate insight data by client ID

### DIFF
--- a/cicero-dashboard/app/amplify/page.jsx
+++ b/cicero-dashboard/app/amplify/page.jsx
@@ -176,7 +176,7 @@ export default function DiseminasiInsightPage() {
               />
             </div>
             {isDirectorate ? (
-              <ChartBox title="POLRES" users={chartData} />
+              <ChartBox title="POLRES" users={chartData} groupBy="client_id" />
             ) : (
               <>
                 <ChartBox title="BAG" users={kelompok.BAG} />
@@ -199,7 +199,7 @@ export default function DiseminasiInsightPage() {
   );
 }
 
-function ChartBox({ title, users }) {
+function ChartBox({ title, users, groupBy }) {
   return (
     <div className="bg-white rounded-xl shadow p-4">
       <div className="font-bold text-blue-700 mb-2 text-center">{title}</div>
@@ -212,6 +212,7 @@ function ChartBox({ title, users }) {
           labelSudah="Sudah Post"
           labelBelum="Belum Post"
           labelTotal="Total Link"
+          groupBy={groupBy}
         />
       ) : (
         <div className="text-center text-gray-400 text-sm">Tidak ada data</div>

--- a/cicero-dashboard/app/comments/tiktok/page.jsx
+++ b/cicero-dashboard/app/comments/tiktok/page.jsx
@@ -218,6 +218,7 @@ export default function TiktokEngagementInsightPage() {
                 users={chartData}
                 totalTiktokPost={rekapSummary.totalTiktokPost}
                 fieldJumlah="jumlah_komentar"
+                groupBy="client_id"
               />
             ) : (
               <div className="flex flex-col gap-6">
@@ -283,6 +284,7 @@ function ChartBox({
   totalTiktokPost,
   fieldJumlah,
   narrative,
+  groupBy,
 }) {
   return (
     <div className="bg-white rounded-xl shadow p-4">
@@ -297,6 +299,7 @@ function ChartBox({
           labelSudah="User Sudah Komentar"
           labelBelum="User Belum Komentar"
           labelTotal="Total Komentar"
+          groupBy={groupBy}
         />
       ) : (
         <div className="text-center text-gray-400 text-sm">Tidak ada data</div>

--- a/cicero-dashboard/app/likes/instagram/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/page.jsx
@@ -228,6 +228,7 @@ export default function InstagramEngagementInsightPage() {
                 title="POLRES"
                 users={chartData}
                 totalPost={rekapSummary.totalIGPost}
+                groupBy="client_id"
               />
             ) : (
               <div className="flex flex-col gap-6">
@@ -284,6 +285,7 @@ function ChartBox({
   orientation = "vertical",
   totalPost,
   narrative,
+  groupBy,
 }) {
   return (
     <div className="bg-white rounded-xl shadow p-4">
@@ -298,6 +300,7 @@ function ChartBox({
           labelSudah="User Sudah Like"
           labelBelum="User Belum Like"
           labelTotal="Total Likes"
+          groupBy={groupBy}
         />
       ) : (
         <div className="text-center text-gray-400 text-sm">Tidak ada data</div>

--- a/cicero-dashboard/app/user-insight/page.jsx
+++ b/cicero-dashboard/app/user-insight/page.jsx
@@ -81,10 +81,14 @@ export default function UserInsightPage() {
         if (dir) {
           const map = {};
           users.forEach((u) => {
-            const name =
-              (u.nama_client || u.client_name || u.client || "LAINNYA").toUpperCase();
-            if (!map[name]) {
-              map[name] = {
+            const id = String(
+              u.client_id || u.clientId || u.clientID || u.id || "LAINNYA",
+            );
+            const name = (
+              u.nama_client || u.client_name || u.client || "LAINNYA"
+            ).toUpperCase();
+            if (!map[id]) {
+              map[id] = {
                 divisi: name,
                 total: 0,
                 instagramFilled: 0,
@@ -93,13 +97,13 @@ export default function UserInsightPage() {
                 tiktokEmpty: 0,
               };
             }
-            map[name].total += 1;
+            map[id].total += 1;
             const hasIG = u.insta && String(u.insta).trim() !== "";
             const hasTT = u.tiktok && String(u.tiktok).trim() !== "";
-            if (hasIG) map[name].instagramFilled += 1;
-            else map[name].instagramEmpty += 1;
-            if (hasTT) map[name].tiktokFilled += 1;
-            else map[name].tiktokEmpty += 1;
+            if (hasIG) map[id].instagramFilled += 1;
+            else map[id].instagramEmpty += 1;
+            if (hasTT) map[id].tiktokFilled += 1;
+            else map[id].tiktokEmpty += 1;
           });
           setChartPolres(Object.values(map));
         } else {

--- a/cicero-dashboard/components/ChartDivisiAbsensi.jsx
+++ b/cicero-dashboard/components/ChartDivisiAbsensi.jsx
@@ -34,6 +34,7 @@ export default function ChartDivisiAbsensi({
   labelSudah = "User Sudah Komentar",
   labelBelum = "User Belum Komentar",
   labelTotal = "Total Komentar",
+  groupBy = "divisi",
 }) {
   // Fallback backward compatibility
   const effectiveTotal =
@@ -54,17 +55,33 @@ export default function ChartDivisiAbsensi({
       .map((u) => Number(u[fieldJumlah] || 0))
   );
 
-  // Group by divisi
+  // Group by divisi atau client_id jika diminta
   const divisiMap = {};
   users.forEach((u) => {
-    const key = bersihkanSatfung(u.divisi || "LAINNYA");
+    const idKey = String(
+      u.client_id ?? u.clientId ?? u.clientID ?? u.client ?? "LAINNYA",
+    );
+    const key =
+      groupBy === "client_id"
+        ? idKey
+        : bersihkanSatfung(u.divisi || "LAINNYA");
+    const display =
+      groupBy === "client_id"
+        ? bersihkanSatfung(
+            u.divisi ||
+              u.nama_client ||
+              u.client_name ||
+              u.client ||
+              "LAINNYA",
+          )
+        : key;
     const jumlah = Number(u[fieldJumlah] || 0);
     const sudah =
-      !isZeroPost && (jumlah >= effectiveTotal*0.5 || isException(u.exception));
+      !isZeroPost && (jumlah >= effectiveTotal * 0.5 || isException(u.exception));
     const nilai = isException(u.exception) ? maxJumlahLike : jumlah;
     if (!divisiMap[key])
       divisiMap[key] = {
-        divisi: key,
+        divisi: display,
         user_sudah: 0,
         user_belum: 0,
         total_value: 0,


### PR DESCRIPTION
## Summary
- Group insight pages by client ID when client_type is DIREKTORAT
- Allow ChartDivisiAbsensi to aggregate by client via new groupBy prop

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d737c5d5483279698169cab1e8e4f