### PR TITLE
Group directorate insights by client

### DIFF
--- a/cicero-dashboard/app/amplify/page.jsx
+++ b/cicero-dashboard/app/amplify/page.jsx
@@ -88,13 +88,7 @@ export default function DiseminasiInsightPage() {
           totalLink,
         });
 
-        const processed = users.map((u) => ({
-          ...u,
-          divisi: dir
-            ? u.nama_client || u.client_name || u.client || u.divisi
-            : u.divisi,
-        }));
-        setChartData(processed);
+        setChartData(users);
       } catch (err) {
         setError("Gagal mengambil data: " + (err.message || err));
       } finally {
@@ -116,6 +110,21 @@ export default function DiseminasiInsightPage() {
     );
 
   const kelompok = isDirectorate ? null : groupUsersByKelompok(chartData);
+
+  const groupByClientId = (arr) => {
+    const map = {};
+    arr.forEach((u) => {
+      const id = String(
+        u.client_id || u.clientId || u.clientID || u.id || "LAINNYA",
+      );
+      const name = u.nama_client || u.client_name || u.client || id;
+      if (!map[id]) map[id] = { name, users: [] };
+      map[id].users.push(u);
+    });
+    return Object.values(map);
+  };
+
+  const clients = isDirectorate ? groupByClientId(chartData) : [];
 
   return (
     <div className="min-h-screen bg-gray-100 flex flex-col">
@@ -176,7 +185,11 @@ export default function DiseminasiInsightPage() {
               />
             </div>
             {isDirectorate ? (
-              <ChartBox title="POLRES" users={chartData} groupBy="client_id" />
+              <>
+                {clients.map((c, idx) => (
+                  <ChartBox key={idx} title={c.name} users={c.users} />
+                ))}
+              </>
             ) : (
               <>
                 <ChartBox title="BAG" users={kelompok.BAG} />

--- a/cicero-dashboard/app/comments/tiktok/page.jsx
+++ b/cicero-dashboard/app/comments/tiktok/page.jsx
@@ -119,13 +119,7 @@ export default function TiktokEngagementInsightPage() {
           totalBelumKomentar,
           totalTiktokPost,
         });
-        const processed = users.map((u) => ({
-          ...u,
-          divisi: dir
-            ? u.nama_client || u.client_name || u.client || u.divisi
-            : u.divisi,
-        }));
-        setChartData(processed);
+        setChartData(users);
       } catch (err) {
         setError("Gagal mengambil data: " + (err.message || err));
       } finally {
@@ -148,6 +142,21 @@ export default function TiktokEngagementInsightPage() {
 
   // Group chartData by kelompok jika bukan direktorat
   const kelompok = isDirectorate ? null : groupUsersByKelompok(chartData);
+
+  const groupByClientId = (arr) => {
+    const map = {};
+    arr.forEach((u) => {
+      const id = String(
+        u.client_id || u.clientId || u.clientID || u.id || "LAINNYA",
+      );
+      const name = u.nama_client || u.client_name || u.client || id;
+      if (!map[id]) map[id] = { name, users: [] };
+      map[id].users.push(u);
+    });
+    return Object.values(map);
+  };
+
+  const clients = isDirectorate ? groupByClientId(chartData) : [];
 
   return (
     <div className="min-h-screen bg-gray-100 flex flex-col">
@@ -213,13 +222,17 @@ export default function TiktokEngagementInsightPage() {
 
             {/* Chart per kelompok atau polres */}
             {isDirectorate ? (
-              <ChartBox
-                title="POLRES"
-                users={chartData}
-                totalTiktokPost={rekapSummary.totalTiktokPost}
-                fieldJumlah="jumlah_komentar"
-                groupBy="client_id"
-              />
+              <>
+                {clients.map((c, idx) => (
+                  <ChartBox
+                    key={idx}
+                    title={c.name}
+                    users={c.users}
+                    totalTiktokPost={rekapSummary.totalTiktokPost}
+                    fieldJumlah="jumlah_komentar"
+                  />
+                ))}
+              </>
             ) : (
               <div className="flex flex-col gap-6">
                 <ChartBox

--- a/cicero-dashboard/app/likes/instagram/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/page.jsx
@@ -130,13 +130,7 @@ export default function InstagramEngagementInsightPage() {
           totalBelumLike,
           totalIGPost,
         });
-        const processed = users.map((u) => ({
-          ...u,
-          divisi: dir
-            ? u.nama_client || u.client_name || u.client || u.divisi
-            : u.divisi,
-        }));
-        setChartData(processed);
+        setChartData(users);
       } catch (err) {
         setError("Gagal mengambil data: " + (err.message || err));
       } finally {
@@ -159,6 +153,21 @@ export default function InstagramEngagementInsightPage() {
 
   // Group chartData by kelompok jika bukan direktorat
   const kelompok = isDirectorate ? null : groupUsersByKelompok(chartData);
+
+  const groupByClientId = (arr) => {
+    const map = {};
+    arr.forEach((u) => {
+      const id = String(
+        u.client_id || u.clientId || u.clientID || u.id || "LAINNYA",
+      );
+      const name = u.nama_client || u.client_name || u.client || id;
+      if (!map[id]) map[id] = { name, users: [] };
+      map[id].users.push(u);
+    });
+    return Object.values(map);
+  };
+
+  const clients = isDirectorate ? groupByClientId(chartData) : [];
 
   return (
     <div className="min-h-screen bg-gray-100 flex flex-col">
@@ -224,12 +233,16 @@ export default function InstagramEngagementInsightPage() {
 
             {/* Chart per kelompok / polres */}
             {isDirectorate ? (
-              <ChartBox
-                title="POLRES"
-                users={chartData}
-                totalPost={rekapSummary.totalIGPost}
-                groupBy="client_id"
-              />
+              <>
+                {clients.map((c, idx) => (
+                  <ChartBox
+                    key={idx}
+                    title={c.name}
+                    users={c.users}
+                    totalPost={rekapSummary.totalIGPost}
+                  />
+                ))}
+              </>
             ) : (
               <div className="flex flex-col gap-6">
                 <ChartBox


### PR DESCRIPTION
## Summary
- Group User Insight data by client ID and render a chart per client name
- Split Diseminasi, Instagram, and TikTok engagement insights into separate charts for each client when viewing a directorate

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d78b1e6988327b0ca35d1765025df