### PR TITLE
Group polres insights for directorate clients

### DIFF
--- a/cicero-dashboard/app/amplify/page.jsx
+++ b/cicero-dashboard/app/amplify/page.jsx
@@ -111,21 +111,6 @@ export default function DiseminasiInsightPage() {
 
   const kelompok = isDirectorate ? null : groupUsersByKelompok(chartData);
 
-  const groupByClientId = (arr) => {
-    const map = {};
-    arr.forEach((u) => {
-      const id = String(
-        u.client_id || u.clientId || u.clientID || u.id || "LAINNYA",
-      );
-      const name = u.nama_client || u.client_name || u.client || id;
-      if (!map[id]) map[id] = { name, users: [] };
-      map[id].users.push(u);
-    });
-    return Object.values(map);
-  };
-
-  const clients = isDirectorate ? groupByClientId(chartData) : [];
-
   return (
     <div className="min-h-screen bg-gray-100 flex flex-col">
       <div className="flex-1 flex items-start justify-center">
@@ -185,11 +170,11 @@ export default function DiseminasiInsightPage() {
               />
             </div>
             {isDirectorate ? (
-              <>
-                {clients.map((c, idx) => (
-                  <ChartBox key={idx} title={c.name} users={c.users} />
-                ))}
-              </>
+              <ChartBox
+                title="POLRES JAJARAN"
+                users={chartData}
+                groupBy="client_id"
+              />
             ) : (
               <>
                 <ChartBox title="BAG" users={kelompok.BAG} />

--- a/cicero-dashboard/app/comments/tiktok/page.jsx
+++ b/cicero-dashboard/app/comments/tiktok/page.jsx
@@ -143,21 +143,6 @@ export default function TiktokEngagementInsightPage() {
   // Group chartData by kelompok jika bukan direktorat
   const kelompok = isDirectorate ? null : groupUsersByKelompok(chartData);
 
-  const groupByClientId = (arr) => {
-    const map = {};
-    arr.forEach((u) => {
-      const id = String(
-        u.client_id || u.clientId || u.clientID || u.id || "LAINNYA",
-      );
-      const name = u.nama_client || u.client_name || u.client || id;
-      if (!map[id]) map[id] = { name, users: [] };
-      map[id].users.push(u);
-    });
-    return Object.values(map);
-  };
-
-  const clients = isDirectorate ? groupByClientId(chartData) : [];
-
   return (
     <div className="min-h-screen bg-gray-100 flex flex-col">
       <div className="flex-1 flex items-start justify-center">
@@ -222,17 +207,13 @@ export default function TiktokEngagementInsightPage() {
 
             {/* Chart per kelompok atau polres */}
             {isDirectorate ? (
-              <>
-                {clients.map((c, idx) => (
-                  <ChartBox
-                    key={idx}
-                    title={c.name}
-                    users={c.users}
-                    totalTiktokPost={rekapSummary.totalTiktokPost}
-                    fieldJumlah="jumlah_komentar"
-                  />
-                ))}
-              </>
+              <ChartBox
+                title="POLRES JAJARAN"
+                users={chartData}
+                totalTiktokPost={rekapSummary.totalTiktokPost}
+                fieldJumlah="jumlah_komentar"
+                groupBy="client_id"
+              />
             ) : (
               <div className="flex flex-col gap-6">
                 <ChartBox

--- a/cicero-dashboard/app/likes/instagram/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/page.jsx
@@ -154,21 +154,6 @@ export default function InstagramEngagementInsightPage() {
   // Group chartData by kelompok jika bukan direktorat
   const kelompok = isDirectorate ? null : groupUsersByKelompok(chartData);
 
-  const groupByClientId = (arr) => {
-    const map = {};
-    arr.forEach((u) => {
-      const id = String(
-        u.client_id || u.clientId || u.clientID || u.id || "LAINNYA",
-      );
-      const name = u.nama_client || u.client_name || u.client || id;
-      if (!map[id]) map[id] = { name, users: [] };
-      map[id].users.push(u);
-    });
-    return Object.values(map);
-  };
-
-  const clients = isDirectorate ? groupByClientId(chartData) : [];
-
   return (
     <div className="min-h-screen bg-gray-100 flex flex-col">
       <div className="flex-1 flex items-start justify-center">
@@ -233,16 +218,12 @@ export default function InstagramEngagementInsightPage() {
 
             {/* Chart per kelompok / polres */}
             {isDirectorate ? (
-              <>
-                {clients.map((c, idx) => (
-                  <ChartBox
-                    key={idx}
-                    title={c.name}
-                    users={c.users}
-                    totalPost={rekapSummary.totalIGPost}
-                  />
-                ))}
-              </>
+              <ChartBox
+                title="POLRES JAJARAN"
+                users={chartData}
+                totalPost={rekapSummary.totalIGPost}
+                groupBy="client_id"
+              />
             ) : (
               <div className="flex flex-col gap-6">
                 <ChartBox

--- a/cicero-dashboard/app/user-insight/page.jsx
+++ b/cicero-dashboard/app/user-insight/page.jsx
@@ -114,14 +114,25 @@ export default function UserInsightPage() {
             const name = (
               u.nama_client || u.client_name || u.client || id
             ).toUpperCase();
-            if (!clientMap[id]) clientMap[id] = { title: name, users: [] };
-            clientMap[id].users.push(u);
+            if (!clientMap[id]) {
+              clientMap[id] = {
+                divisi: name,
+                total: 0,
+                instagramFilled: 0,
+                instagramEmpty: 0,
+                tiktokFilled: 0,
+                tiktokEmpty: 0,
+              };
+            }
+            clientMap[id].total += 1;
+            const hasIG = u.insta && String(u.insta).trim() !== "";
+            const hasTT = u.tiktok && String(u.tiktok).trim() !== "";
+            if (hasIG) clientMap[id].instagramFilled += 1;
+            else clientMap[id].instagramEmpty += 1;
+            if (hasTT) clientMap[id].tiktokFilled += 1;
+            else clientMap[id].tiktokEmpty += 1;
           });
-          const charts = Object.values(clientMap).map(({ title, users }) => ({
-            title,
-            data: generateChartData(users),
-          }));
-          setChartPolres(charts);
+          setChartPolres(Object.values(clientMap));
         } else {
           const grouped = groupUsersByKelompok(users);
           setChartKelompok({
@@ -197,16 +208,11 @@ export default function UserInsightPage() {
             </div>
 
             {isDirectorate ? (
-              <div className="flex flex-col gap-6">
-                {chartPolres.map((c, idx) => (
-                  <ChartBox
-                    key={idx}
-                    title={c.title}
-                    data={c.data}
-                    orientation="vertical"
-                  />
-                ))}
-              </div>
+              <ChartBox
+                title="POLRES JAJARAN"
+                data={chartPolres}
+                orientation="horizontal"
+              />
             ) : (
               <div className="flex flex-col gap-6">
                 <ChartBox title="BAG" data={chartKelompok.BAG} />


### PR DESCRIPTION
## Summary
- Aggregate user insight metrics by client ID for directorate profiles and show a single POLRES JAJARAN chart
- Display diseminasi, Instagram, and TikTok engagement insights grouped by client ID under POLRES JAJARAN when client type is directorate

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689d7c5e167c8327bea2045305795f87