### PR TITLE
fix: improve directorate chart readability

### DIFF
--- a/cicero-dashboard/components/ChartDivisiAbsensi.jsx
+++ b/cicero-dashboard/components/ChartDivisiAbsensi.jsx
@@ -100,7 +100,9 @@ export default function ChartDivisiAbsensi({
   // Dynamic height
   const isHorizontal = orientation === "horizontal";
   const barHeight = isHorizontal ? 32 : 34;
-  const minHeight = isHorizontal ? 50 : 220;
+  // Give horizontal charts a larger minimum height so that a small number
+  // of bars (e.g. in directorate views) remain readable.
+  const minHeight = 220;
   const maxHeight = isHorizontal ? 900 : 420;
   const chartHeight = isHorizontal
     ? Math.max(minHeight, barHeight * dataChart.length)


### PR DESCRIPTION
## Summary
- ensure horizontal charts have sufficient minimum height so directorate data remains readable

## Testing
- `npm test`
- `npm run lint` *(fails: interactive setup prompt)*

------
https://chatgpt.com/codex/tasks/task_e_689dd56c74a883278d873a56e670c25f