### PR TITLE
Improve directorate chart titles and sorting

### DIFF
--- a/cicero-dashboard/app/amplify/page.jsx
+++ b/cicero-dashboard/app/amplify/page.jsx
@@ -29,6 +29,7 @@ export default function DiseminasiInsightPage() {
     totalLink: 0,
   });
   const [isDirectorate, setIsDirectorate] = useState(false);
+  const [clientName, setClientName] = useState("");
 
   const viewOptions = VIEW_OPTIONS;
 
@@ -72,6 +73,12 @@ export default function DiseminasiInsightPage() {
         const dir =
           (profile.client_type || "").toUpperCase() === "DIREKTORAT";
         setIsDirectorate(dir);
+        setClientName(
+          profile.nama_client ||
+            profile.client_name ||
+            profile.client ||
+            ""
+        );
         const totalUser = users.length;
         const totalSudahPost = users.filter(
           (u) => Number(u.jumlah_link) > 0,
@@ -171,7 +178,7 @@ export default function DiseminasiInsightPage() {
             </div>
             {isDirectorate ? (
               <ChartBox
-                title="POLRES JAJARAN"
+                title={clientName || "POLRES JAJARAN"}
                 users={chartData}
                 groupBy="client_id"
                 orientation="horizontal"

--- a/cicero-dashboard/app/comments/tiktok/page.jsx
+++ b/cicero-dashboard/app/comments/tiktok/page.jsx
@@ -37,6 +37,7 @@ export default function TiktokEngagementInsightPage() {
     totalTiktokPost: 0,
   });
   const [isDirectorate, setIsDirectorate] = useState(false);
+  const [clientName, setClientName] = useState("");
 
   const viewOptions = VIEW_OPTIONS;
 
@@ -96,6 +97,12 @@ export default function TiktokEngagementInsightPage() {
         const dir =
           (profile.client_type || "").toUpperCase() === "DIREKTORAT";
         setIsDirectorate(dir);
+        setClientName(
+          profile.nama_client ||
+            profile.client_name ||
+            profile.client ||
+            ""
+        );
 
         // Ambil field TikTok Post dengan fallback urutan prioritas
         const totalTiktokPost =
@@ -208,7 +215,7 @@ export default function TiktokEngagementInsightPage() {
             {/* Chart per kelompok atau polres */}
             {isDirectorate ? (
               <ChartBox
-                title="POLRES JAJARAN"
+                title={clientName || "POLRES JAJARAN"}
                 users={chartData}
                 totalTiktokPost={rekapSummary.totalTiktokPost}
                 fieldJumlah="jumlah_komentar"

--- a/cicero-dashboard/app/likes/instagram/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/page.jsx
@@ -45,6 +45,7 @@ export default function InstagramEngagementInsightPage() {
     totalIGPost: 0,
   });
   const [isDirectorate, setIsDirectorate] = useState(false);
+  const [clientName, setClientName] = useState("");
 
   const viewOptions = VIEW_OPTIONS;
 
@@ -106,6 +107,12 @@ export default function InstagramEngagementInsightPage() {
         const dir =
           (profile.client_type || "").toUpperCase() === "DIREKTORAT";
         setIsDirectorate(dir);
+        setClientName(
+          profile.nama_client ||
+            profile.client_name ||
+            profile.client ||
+            ""
+        );
 
         // Rekap summary
         const totalUser = users.length;
@@ -219,7 +226,7 @@ export default function InstagramEngagementInsightPage() {
             {/* Chart per kelompok / polres */}
             {isDirectorate ? (
               <ChartBox
-                title="POLRES JAJARAN"
+                title={clientName || "POLRES JAJARAN"}
                 users={chartData}
                 totalPost={rekapSummary.totalIGPost}
                 groupBy="client_id"

--- a/cicero-dashboard/components/ChartDivisiAbsensi.jsx
+++ b/cicero-dashboard/components/ChartDivisiAbsensi.jsx
@@ -95,7 +95,9 @@ export default function ChartDivisiAbsensi({
     }
   });
 
-  const dataChart = Object.values(divisiMap);
+  const dataChart = Object.values(divisiMap).sort(
+    (a, b) => b.total_value - a.total_value
+  );
 
   // Dynamic height
   const isHorizontal = orientation === "horizontal";


### PR DESCRIPTION
## Summary
- Show client name in directorate bar charts across Instagram likes, amplification links, and TikTok comments
- Sort bar charts by total value for clearer comparisons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689de0f08af4832788e00b661759bcff