### PR TITLE
Improve directorate chart visuals

### DIFF
--- a/cicero-dashboard/app/user-insight/page.jsx
+++ b/cicero-dashboard/app/user-insight/page.jsx
@@ -114,10 +114,9 @@ export default function UserInsightPage() {
             const name = (
               u.nama_client || u.client_name || u.client || id
             ).toUpperCase();
-            const label = `${name} (${id})`;
             if (!clientMap[id]) {
               clientMap[id] = {
-                divisi: label,
+                divisi: name,
                 total: 0,
                 instagramFilled: 0,
                 instagramEmpty: 0,
@@ -215,6 +214,8 @@ export default function UserInsightPage() {
                 title="POLRES JAJARAN"
                 data={chartPolres}
                 orientation="horizontal"
+                minHeight={420}
+                thicknessMultiplier={3}
               />
             ) : (
               <div className="flex flex-col gap-6">
@@ -235,12 +236,23 @@ export default function UserInsightPage() {
   );
 }
 
-function ChartBox({ title, data, orientation = "vertical" }) {
+function ChartBox({
+  title,
+  data,
+  orientation = "vertical",
+  minHeight,
+  thicknessMultiplier = 1,
+}) {
   return (
     <div className="bg-white rounded-xl shadow p-4">
       <div className="font-bold text-blue-700 mb-2 text-center">{title}</div>
       {data && data.length > 0 ? (
-        <ContactChart data={data} orientation={orientation} />
+        <ContactChart
+          data={data}
+          orientation={orientation}
+          minHeight={minHeight}
+          thicknessMultiplier={thicknessMultiplier}
+        />
       ) : (
         <div className="text-center text-gray-400 text-sm">Tidak ada data</div>
       )}
@@ -248,12 +260,11 @@ function ChartBox({ title, data, orientation = "vertical" }) {
   );
 }
 
-function ContactChart({ data, orientation }) {
+function ContactChart({ data, orientation, minHeight = 50, thicknessMultiplier = 1 }) {
   const isHorizontal = orientation === "horizontal";
   const barPosition = isHorizontal ? "right" : "top";
-  const height = isHorizontal
-    ? Math.max(50, 35 * data.length)
-    : 300;
+  const perItem = 35 * thicknessMultiplier;
+  const height = isHorizontal ? Math.max(minHeight, perItem * data.length) : 300;
 
   return (
     <div className="w-full h-full">

--- a/cicero-dashboard/components/ChartDivisiAbsensi.jsx
+++ b/cicero-dashboard/components/ChartDivisiAbsensi.jsx
@@ -69,13 +69,7 @@ export default function ChartDivisiAbsensi({
         : bersihkanSatfung(u.divisi || "LAINNYA");
     const display =
       groupBy === "client_id"
-        ? bersihkanSatfung(
-            u.divisi ||
-              u.nama_client ||
-              u.client_name ||
-              u.client ||
-              "LAINNYA",
-          )
+        ? u.nama_client || u.client_name || u.client || idKey
         : key;
     const jumlah = Number(u[fieldJumlah] || 0);
     const sudah =
@@ -102,10 +96,12 @@ export default function ChartDivisiAbsensi({
 
   // Dynamic height
   const isHorizontal = orientation === "horizontal";
-  const barHeight = isHorizontal ? 40 : 34;
+  const isDirectorate = groupBy === "client_id";
+  const thicknessMultiplier = isDirectorate ? 3 : 1;
+  const barHeight = isHorizontal ? 40 * thicknessMultiplier : 34;
   // Ensure horizontal charts (used in direktorat views) remain legible
   // by providing a larger minimum height and capping extreme values.
-  const minHeight = isHorizontal ? 300 : 220;
+  const minHeight = isHorizontal ? (isDirectorate ? 420 : 300) : 220;
   const maxHeight = isHorizontal ? 900 : 420;
   const chartHeight = Math.min(
     maxHeight,
@@ -188,7 +184,7 @@ export default function ChartDivisiAbsensi({
               dataKey="user_sudah"
               fill="#22c55e"
               name={labelSudah}
-              barSize={isHorizontal ? 20 : undefined}
+              barSize={isHorizontal ? 20 * thicknessMultiplier : undefined}
             >
               <LabelList
                 dataKey="user_sudah"
@@ -200,7 +196,7 @@ export default function ChartDivisiAbsensi({
               dataKey="total_value"
               fill="#2563eb"
               name={labelTotal}
-              barSize={isHorizontal ? 20 : undefined}
+              barSize={isHorizontal ? 20 * thicknessMultiplier : undefined}
             >
               <LabelList
                 dataKey="total_value"
@@ -212,7 +208,7 @@ export default function ChartDivisiAbsensi({
               dataKey="user_belum"
               fill="#ef4444"
               name={labelBelum}
-              barSize={isHorizontal ? 20 : undefined}
+              barSize={isHorizontal ? 20 * thicknessMultiplier : undefined}
             >
               <LabelList
                 dataKey="user_belum"


### PR DESCRIPTION
## Summary
- display client charts for directorate clients using their `client_name` as labels
- enlarge horizontal bar charts with a minimum height and thicker bars for directorate views

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ee6e766d883278f3cad7566981e01