### PR TITLE
feat: show client names on directorate charts

### DIFF
--- a/cicero-dashboard/components/ChartDivisiAbsensi.jsx
+++ b/cicero-dashboard/components/ChartDivisiAbsensi.jsx
@@ -115,7 +115,7 @@ export default function ChartDivisiAbsensi({
 
   // Group by divisi atau client_id jika diminta
   const divisiMap = {};
-  const labelKey = groupBy === "client_id" ? "client_name" : "divisi";
+  const labelKey = groupBy === "client_id" ? "nama_client" : "divisi";
   enrichedUsers.forEach((u) => {
     const idKey = String(
       u.client_id ?? u.clientId ?? u.clientID ?? u.client ?? "LAINNYA",
@@ -233,7 +233,7 @@ export default function ChartDivisiAbsensi({
                 ]
               }
               labelFormatter={(label) =>
-                `${labelKey === "client_name" ? "Client" : "Divisi"}: ${label}`
+                `${labelKey === "nama_client" ? "Client" : "Divisi"}: ${label}`
               }
             />
             <Legend />


### PR DESCRIPTION
## Summary
- ensure ChartDivisiAbsensi uses `nama_client` when grouping by client_id so directorate charts display client names on axes and tooltips

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a04f76a22c83278a06e7fdf62801ae