### PR TITLE
Use new client name key across dashboards

### DIFF
--- a/cicero-dashboard/app/amplify/page.jsx
+++ b/cicero-dashboard/app/amplify/page.jsx
@@ -74,7 +74,8 @@ export default function DiseminasiInsightPage() {
           (profile.client_type || "").toUpperCase() === "DIREKTORAT";
         setIsDirectorate(dir);
         setClientName(
-          profile.nama_client ||
+          profile.nama ||
+            profile.nama_client ||
             profile.client_name ||
             profile.client ||
             ""
@@ -96,7 +97,11 @@ export default function DiseminasiInsightPage() {
                 String(
                   u.client_id || u.clientId || u.clientID || u.client || ""
                 )
-              ] || u.nama_client || u.client_name || u.client,
+              ] ||
+              u.nama ||
+              u.nama_client ||
+              u.client_name ||
+              u.client,
           }));
         }
         const totalUser = enrichedUsers.length;

--- a/cicero-dashboard/app/comments/tiktok/page.jsx
+++ b/cicero-dashboard/app/comments/tiktok/page.jsx
@@ -103,7 +103,8 @@ export default function TiktokEngagementInsightPage() {
           (profile.client_type || "").toUpperCase() === "DIREKTORAT";
         setIsDirectorate(dir);
         setClientName(
-          profile.nama_client ||
+          profile.nama ||
+            profile.nama_client ||
             profile.client_name ||
             profile.client ||
             ""
@@ -126,7 +127,11 @@ export default function TiktokEngagementInsightPage() {
                 String(
                   u.client_id || u.clientId || u.clientID || u.client || ""
                 )
-              ] || u.nama_client || u.client_name || u.client,
+              ] ||
+              u.nama ||
+              u.nama_client ||
+              u.client_name ||
+              u.client,
           }));
         }
 

--- a/cicero-dashboard/app/likes/instagram/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/page.jsx
@@ -113,7 +113,8 @@ export default function InstagramEngagementInsightPage() {
           (profile.client_type || "").toUpperCase() === "DIREKTORAT";
         setIsDirectorate(dir);
         setClientName(
-          profile.nama_client ||
+          profile.nama ||
+            profile.nama_client ||
             profile.client_name ||
             profile.client ||
             ""
@@ -136,7 +137,11 @@ export default function InstagramEngagementInsightPage() {
                 String(
                   u.client_id || u.clientId || u.clientID || u.client || "",
                 )
-              ] || u.nama_client || u.client_name || u.client,
+              ] ||
+              u.nama ||
+              u.nama_client ||
+              u.client_name ||
+              u.client,
           }));
         }
 

--- a/cicero-dashboard/app/user-insight/page.jsx
+++ b/cicero-dashboard/app/user-insight/page.jsx
@@ -109,7 +109,11 @@ export default function UserInsightPage() {
                 String(
                   u.client_id || u.clientId || u.clientID || u.id || "",
                 )
-              ] || u.nama_client || u.client_name || u.client,
+              ] ||
+              u.nama ||
+              u.nama_client ||
+              u.client_name ||
+              u.client,
           }));
         }
 
@@ -137,7 +141,11 @@ export default function UserInsightPage() {
               u.client_id || u.clientId || u.clientID || u.id || "LAINNYA",
             );
             const name = (
-              u.nama_client || u.client_name || u.client || id
+              u.nama_client ||
+              u.nama ||
+              u.client_name ||
+              u.client ||
+              id
             ).toUpperCase();
             if (!clientMap[id]) {
               clientMap[id] = {

--- a/cicero-dashboard/app/users/page.jsx
+++ b/cicero-dashboard/app/users/page.jsx
@@ -80,7 +80,11 @@ export default function UserDirectoryPage() {
           nama_client:
             nameMap[
               String(u.client_id || u.clientId || u.clientID || u.client || "")
-            ] || u.nama_client || u.client_name || u.client,
+            ] ||
+            u.nama ||
+            u.nama_client ||
+            u.client_name ||
+            u.client,
         }));
       }
 
@@ -156,7 +160,7 @@ export default function UserDirectoryPage() {
             (u.nama || "").toLowerCase().includes(search.toLowerCase()) ||
             (u.title || "").toLowerCase().includes(search.toLowerCase()) ||
             (u.user_id || "").toLowerCase().includes(search.toLowerCase()) ||
-            (u.nama_client || u.divisi || "")
+            (u.nama_client || u.nama || u.divisi || "")
               .toLowerCase()
               .includes(search.toLowerCase()) ||
             (u.insta || "").toLowerCase().includes(search.toLowerCase()) ||
@@ -305,7 +309,7 @@ export default function UserDirectoryPage() {
                   <td className="py-1 px-2 font-mono">{u.user_id || "-"}</td>
                   <td className="py-1 px-2">
                     {isDirectorate ? (
-                      u.nama_client || "-"
+                      u.nama_client || u.nama || "-"
                     ) : editingRowId === u.user_id ? (
                       <input
                         value={editSatfung}

--- a/cicero-dashboard/components/ChartDivisiAbsensi.jsx
+++ b/cicero-dashboard/components/ChartDivisiAbsensi.jsx
@@ -49,9 +49,9 @@ export default function ChartDivisiAbsensi({
         return;
       }
 
-      const needsName = users.some(
-        (u) => !(u.nama_client || u.client_name || u.client)
-      );
+        const needsName = users.some(
+          (u) => !(u.nama_client || u.nama || u.client_name || u.client)
+        );
       if (!needsName) {
         setEnrichedUsers(users);
         return;
@@ -77,6 +77,7 @@ export default function ChartDivisiAbsensi({
           ...u,
           nama_client:
             u.nama_client ||
+            u.nama ||
             nameMap[
               String(
                 u.client_id ?? u.clientId ?? u.clientID ?? u.client ?? ""
@@ -124,10 +125,10 @@ export default function ChartDivisiAbsensi({
       groupBy === "client_id"
         ? idKey
         : bersihkanSatfung(u.divisi || "LAINNYA");
-    const display =
-      groupBy === "client_id"
-        ? u.nama_client || u.client_name || u.client || idKey
-        : key;
+      const display =
+        groupBy === "client_id"
+          ? u.nama_client || u.nama || u.client_name || u.client || idKey
+          : key;
     const jumlah = Number(u[fieldJumlah] || 0);
     const sudah =
       !isZeroPost && (jumlah >= effectiveTotal * 0.5 || isException(u.exception));

--- a/cicero-dashboard/utils/api.ts
+++ b/cicero-dashboard/utils/api.ts
@@ -121,7 +121,11 @@ export async function getClientNames(
       try {
         const profile = await getClientProfile(token, id);
         const name =
-          profile.nama_client || profile.client_name || profile.client || id;
+          profile.nama ||
+          profile.nama_client ||
+          profile.client_name ||
+          profile.client ||
+          id;
         return [id, name] as [string, string];
       } catch {
         return [id, id] as [string, string];


### PR DESCRIPTION
## Summary
- Support `nama` as client name field when fetching profiles
- Show client names in user directory, analytics and amplification charts
- Update chart component to label bars by client name

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68a051f04654832793d2c7d1a045948a