### PR TITLE
Display POLRES JAJARAN charts for directorate clients

### DIFF
--- a/cicero-dashboard/app/amplify/page.jsx
+++ b/cicero-dashboard/app/amplify/page.jsx
@@ -29,7 +29,6 @@ export default function DiseminasiInsightPage() {
     totalLink: 0,
   });
   const [isDirectorate, setIsDirectorate] = useState(false);
-  const [clientName, setClientName] = useState("");
 
   const viewOptions = VIEW_OPTIONS;
 
@@ -73,13 +72,6 @@ export default function DiseminasiInsightPage() {
         const dir =
           (profile.client_type || "").toUpperCase() === "DIREKTORAT";
         setIsDirectorate(dir);
-        setClientName(
-          profile.nama ||
-            profile.nama_client ||
-            profile.client_name ||
-            profile.client ||
-            ""
-        );
         let enrichedUsers = users;
         if (dir) {
           const nameMap = await getClientNames(
@@ -203,7 +195,7 @@ export default function DiseminasiInsightPage() {
             </div>
             {isDirectorate ? (
               <ChartBox
-                title={clientName || "POLRES JAJARAN"}
+                title="POLRES JAJARAN"
                 users={chartData}
                 groupBy="client_id"
                 orientation="horizontal"

--- a/cicero-dashboard/app/comments/tiktok/page.jsx
+++ b/cicero-dashboard/app/comments/tiktok/page.jsx
@@ -42,7 +42,6 @@ export default function TiktokEngagementInsightPage() {
     totalTiktokPost: 0,
   });
   const [isDirectorate, setIsDirectorate] = useState(false);
-  const [clientName, setClientName] = useState("");
 
   const viewOptions = VIEW_OPTIONS;
 
@@ -102,13 +101,6 @@ export default function TiktokEngagementInsightPage() {
         const dir =
           (profile.client_type || "").toUpperCase() === "DIREKTORAT";
         setIsDirectorate(dir);
-        setClientName(
-          profile.nama ||
-            profile.nama_client ||
-            profile.client_name ||
-            profile.client ||
-            ""
-        );
 
         let enrichedUsers = users;
         if (dir) {
@@ -247,7 +239,7 @@ export default function TiktokEngagementInsightPage() {
             {/* Chart per kelompok atau polres */}
             {isDirectorate ? (
               <ChartBox
-                title={clientName || "POLRES JAJARAN"}
+                title="POLRES JAJARAN"
                 users={chartData}
                 totalTiktokPost={rekapSummary.totalTiktokPost}
                 fieldJumlah="jumlah_komentar"

--- a/cicero-dashboard/app/likes/instagram/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/page.jsx
@@ -50,7 +50,6 @@ export default function InstagramEngagementInsightPage() {
     totalIGPost: 0,
   });
   const [isDirectorate, setIsDirectorate] = useState(false);
-  const [clientName, setClientName] = useState("");
 
   const viewOptions = VIEW_OPTIONS;
 
@@ -112,13 +111,6 @@ export default function InstagramEngagementInsightPage() {
         const dir =
           (profile.client_type || "").toUpperCase() === "DIREKTORAT";
         setIsDirectorate(dir);
-        setClientName(
-          profile.nama ||
-            profile.nama_client ||
-            profile.client_name ||
-            profile.client ||
-            ""
-        );
 
         let enrichedUsers = users;
         if (dir) {
@@ -259,7 +251,7 @@ export default function InstagramEngagementInsightPage() {
             {/* Chart per kelompok / polres */}
             {isDirectorate ? (
               <ChartBox
-                title={clientName || "POLRES JAJARAN"}
+                title="POLRES JAJARAN"
                 users={chartData}
                 totalPost={rekapSummary.totalIGPost}
                 groupBy="client_id"


### PR DESCRIPTION
## Summary
- Ensure diseminasi insight aggregates by polres when client type is DIREKTORAT
- Update Instagram and TikTok engagement insights to show POLRES JAJARAN chart titles for directorate clients

## Testing
- `npm test`
- `npm run lint` *(fails: required Next.js ESLint plugin setup prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68a056ddd4ec8327a61d88c36d67f8a5