### PR TITLE
feat: refine diseminasi insight by polres

### DIFF
--- a/cicero-dashboard/app/amplify/page.jsx
+++ b/cicero-dashboard/app/amplify/page.jsx
@@ -199,12 +199,13 @@ export default function DiseminasiInsightPage() {
                 users={chartData}
                 groupBy="client_id"
                 orientation="horizontal"
+                showTotalUser
               />
             ) : (
               <>
-                <ChartBox title="BAG" users={kelompok.BAG} />
-                <ChartBox title="SAT" users={kelompok.SAT} />
-                <ChartBox title="SI & SPKT" users={kelompok["SI & SPKT"]} />
+                <ChartBox title="BAG" users={kelompok.BAG} showTotalUser />
+                <ChartBox title="SAT" users={kelompok.SAT} showTotalUser />
+                <ChartBox title="SI & SPKT" users={kelompok["SI & SPKT"]} showTotalUser />
                 <ChartHorizontal
                   title="POLSEK"
                   users={kelompok.POLSEK}
@@ -222,7 +223,13 @@ export default function DiseminasiInsightPage() {
   );
 }
 
-function ChartBox({ title, users, groupBy, orientation = "vertical" }) {
+function ChartBox({
+  title,
+  users,
+  groupBy,
+  orientation = "vertical",
+  showTotalUser = false,
+}) {
   return (
     <div className="bg-white rounded-xl shadow p-4">
       <div className="font-bold text-blue-700 mb-2 text-center">{title}</div>
@@ -237,6 +244,8 @@ function ChartBox({ title, users, groupBy, orientation = "vertical" }) {
           labelBelum="Belum Post"
           labelTotal="Total Link"
           groupBy={groupBy}
+          showTotalUser={showTotalUser}
+          labelTotalUser="Jumlah User"
         />
       ) : (
         <div className="text-center text-gray-400 text-sm">Tidak ada data</div>

--- a/cicero-dashboard/components/ChartDivisiAbsensi.jsx
+++ b/cicero-dashboard/components/ChartDivisiAbsensi.jsx
@@ -38,6 +38,8 @@ export default function ChartDivisiAbsensi({
   labelTotal = "Total Komentar",
   groupBy = "divisi",
   orientation = "vertical",
+  showTotalUser = false,
+  labelTotalUser = "Jumlah User",
 }) {
   const [enrichedUsers, setEnrichedUsers] = useState(users);
 
@@ -50,7 +52,7 @@ export default function ChartDivisiAbsensi({
       }
 
         const needsName = users.some(
-          (u) => !(u.nama_client || u.nama || u.client_name || u.client)
+          (u) => !(u.nama_client || u.client_name || u.client)
         );
       if (!needsName) {
         setEnrichedUsers(users);
@@ -77,7 +79,6 @@ export default function ChartDivisiAbsensi({
           ...u,
           nama_client:
             u.nama_client ||
-            u.nama ||
             nameMap[
               String(
                 u.client_id ?? u.clientId ?? u.clientID ?? u.client ?? ""
@@ -127,7 +128,7 @@ export default function ChartDivisiAbsensi({
         : bersihkanSatfung(u.divisi || "LAINNYA");
       const display =
         groupBy === "client_id"
-          ? u.nama_client || u.nama || u.client_name || u.client || idKey
+          ? u.nama_client || u.client_name || u.client || idKey
           : key;
     const jumlah = Number(u[fieldJumlah] || 0);
     const sudah =
@@ -136,10 +137,12 @@ export default function ChartDivisiAbsensi({
     if (!divisiMap[key])
       divisiMap[key] = {
         [labelKey]: display,
+        total_user: 0,
         user_sudah: 0,
         user_belum: 0,
         total_value: 0,
       };
+    divisiMap[key].total_user += 1;
     divisiMap[key].total_value += nilai;
     if (sudah) {
       divisiMap[key].user_sudah += 1;
@@ -224,7 +227,9 @@ export default function ChartDivisiAbsensi({
               formatter={(value, name) =>
                 [
                   value,
-                  name === "user_sudah"
+                  name === "total_user"
+                    ? labelTotalUser
+                    : name === "user_sudah"
                     ? labelSudah
                     : name === "user_belum"
                     ? labelBelum
@@ -238,6 +243,20 @@ export default function ChartDivisiAbsensi({
               }
             />
             <Legend />
+            {showTotalUser && (
+              <Bar
+                dataKey="total_user"
+                fill="#0ea5e9"
+                name={labelTotalUser}
+                barSize={isHorizontal ? 20 * thicknessMultiplier : undefined}
+              >
+                <LabelList
+                  dataKey="total_user"
+                  position={isHorizontal ? "right" : "top"}
+                  fontSize={isHorizontal ? 10 : 12}
+                />
+              </Bar>
+            )}
             <Bar
               dataKey="user_sudah"
               fill="#22c55e"
@@ -251,18 +270,6 @@ export default function ChartDivisiAbsensi({
               />
             </Bar>
             <Bar
-              dataKey="total_value"
-              fill="#2563eb"
-              name={labelTotal}
-              barSize={isHorizontal ? 20 * thicknessMultiplier : undefined}
-            >
-              <LabelList
-                dataKey="total_value"
-                position={isHorizontal ? "right" : "top"}
-                fontSize={isHorizontal ? 10 : 12}
-              />
-            </Bar>
-            <Bar
               dataKey="user_belum"
               fill="#ef4444"
               name={labelBelum}
@@ -270,6 +277,18 @@ export default function ChartDivisiAbsensi({
             >
               <LabelList
                 dataKey="user_belum"
+                position={isHorizontal ? "right" : "top"}
+                fontSize={isHorizontal ? 10 : 12}
+              />
+            </Bar>
+            <Bar
+              dataKey="total_value"
+              fill="#2563eb"
+              name={labelTotal}
+              barSize={isHorizontal ? 20 * thicknessMultiplier : undefined}
+            >
+              <LabelList
+                dataKey="total_value"
                 position={isHorizontal ? "right" : "top"}
                 fontSize={isHorizontal ? 10 : 12}
               />


### PR DESCRIPTION
## Summary
- add optional total user bar and correct client name aggregation in ChartDivisiAbsensi
- show polres comparison with user and link metrics on Diseminasi Insight page

## Testing
- `npm run lint` *(fails: interactive ESLint configuration prompt)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a06022462c83278cb042f60f20769e