### PR TITLE
feat: show client profile based on user role

### DIFF
--- a/cicero-dashboard/app/dashboard/page.jsx
+++ b/cicero-dashboard/app/dashboard/page.jsx
@@ -15,7 +15,12 @@ import { Check, X } from "lucide-react";
 
 export default function DashboardPage() {
   useRequireAuth();
-  const { token, clientId } = useAuth();
+  const { token, clientId, role } = useAuth();
+  const specialRoles = ["ditbinmas", "ditlantas", "bidhumas"];
+  const targetClientId =
+    role && specialRoles.includes(role.toLowerCase())
+      ? role.toLowerCase()
+      : clientId;
   const [clientProfile, setClientProfile] = useState(null);
   const [igProfile, setIgProfile] = useState(null);
   const [igPosts, setIgPosts] = useState([]);
@@ -25,7 +30,7 @@ export default function DashboardPage() {
   const [error, setError] = useState("");
 
   useEffect(() => {
-    if (!token || !clientId) {
+    if (!token || !targetClientId) {
       setError("Token / Client ID tidak ditemukan. Silakan login ulang.");
       setLoading(false);
       return;
@@ -33,7 +38,7 @@ export default function DashboardPage() {
 
     async function fetchData() {
       try {
-        const profileRes = await getClientProfile(token, clientId);
+        const profileRes = await getClientProfile(token, targetClientId);
         const client = profileRes.client || profileRes.profile || profileRes;
         setClientProfile(client);
 
@@ -59,7 +64,7 @@ export default function DashboardPage() {
           try {
             const ttProf = await getTiktokProfileViaBackend(token, ttUser);
             setTiktokProfile(ttProf);
-            const ttRes = await getTiktokPostsViaBackend(token, clientId, 3);
+            const ttRes = await getTiktokPostsViaBackend(token, targetClientId, 3);
             const ttData = ttRes.data || ttRes.posts || ttRes;
             setTiktokPosts(Array.isArray(ttData) ? ttData : []);
           } catch (err) {
@@ -74,7 +79,7 @@ export default function DashboardPage() {
     }
 
     fetchData();
-  }, []);
+  }, [token, targetClientId]);
 
   if (loading) return <Loader />;
   if (error)

--- a/cicero-dashboard/app/login/page.jsx
+++ b/cicero-dashboard/app/login/page.jsx
@@ -49,7 +49,8 @@ export default function LoginPage() {
       if (data.success && data.token) {
         const userId = data.user?.user_id || null;
         const userClient = data.user?.client_id || null;
-        setAuth(data.token, userClient, userId);
+        const userRole = data.user?.role || null;
+        setAuth(data.token, userClient, userId, userRole);
         router.push("/dashboard");
       } else {
         setError(data.message || "Login gagal");

--- a/cicero-dashboard/components/ClientProfileMenu.tsx
+++ b/cicero-dashboard/components/ClientProfileMenu.tsx
@@ -4,23 +4,26 @@ import { getClientProfile } from "@/utils/api";
 import { useAuth } from "@/context/AuthContext";
 
 export default function ClientProfileMenu() {
-  const { token, clientId } = useAuth();
+  const { token, clientId, role } = useAuth();
   const [profile, setProfile] = useState<any>(null);
   const [open, setOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     async function fetchProfile() {
-      if (!token || !clientId) return;
+      const specialRoles = ["ditbinmas", "ditlantas", "bidhumas"];
+      const targetId =
+        role && specialRoles.includes(role.toLowerCase()) ? role.toLowerCase() : clientId;
+      if (!token || !targetId) return;
       try {
-        const res = await getClientProfile(token, clientId);
+        const res = await getClientProfile(token, targetId);
         setProfile(res.client || res.profile || res);
       } catch (err) {
         console.error(err);
       }
     }
     fetchProfile();
-  }, [token, clientId]);
+  }, [token, clientId, role]);
 
   useEffect(() => {
     function handleClick(e: MouseEvent) {

--- a/cicero-dashboard/components/Header.tsx
+++ b/cicero-dashboard/components/Header.tsx
@@ -19,7 +19,7 @@ export default function Header() {
   const router = useRouter();
 
   const handleLogout = () => {
-    setAuth(null, null, null);
+    setAuth(null, null, null, null);
     router.replace("/login");
   };
 

--- a/cicero-dashboard/components/Sidebar.jsx
+++ b/cicero-dashboard/components/Sidebar.jsx
@@ -30,21 +30,24 @@ export default function Sidebar() {
   const pathname = usePathname();
   const [open, setOpen] = useState(false);
   const [collapsed, setCollapsed] = useState(false);
-  const { token, clientId } = useAuth();
+  const { token, clientId, role } = useAuth();
   const [profile, setProfile] = useState(null);
 
   useEffect(() => {
     async function fetchProfile() {
-      if (!token || !clientId) return;
+      const specialRoles = ["ditbinmas", "ditlantas", "bidhumas"];
+      const targetId =
+        role && specialRoles.includes(role.toLowerCase()) ? role.toLowerCase() : clientId;
+      if (!token || !targetId) return;
       try {
-        const res = await getClientProfile(token, clientId);
+        const res = await getClientProfile(token, targetId);
         setProfile(res.client || res.profile || res);
       } catch (err) {
         console.error(err);
       }
     }
     fetchProfile();
-  }, [token, clientId]);
+  }, [token, clientId, role]);
   function isActive(val) {
     return val === true || val === "true" || val === 1 || val === "1";
   }

--- a/cicero-dashboard/context/AuthContext.tsx
+++ b/cicero-dashboard/context/AuthContext.tsx
@@ -5,10 +5,12 @@ type AuthState = {
   token: string | null;
   clientId: string | null;
   userId: string | null;
+  role: string | null;
   setAuth: (
     token: string | null,
     clientId: string | null,
     userId: string | null,
+    role: string | null,
   ) => void;
 };
 
@@ -18,34 +20,41 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [token, setToken] = useState<string | null>(null);
   const [clientId, setClientId] = useState<string | null>(null);
   const [userId, setUserId] = useState<string | null>(null);
+  const [role, setRole] = useState<string | null>(null);
 
   useEffect(() => {
     const storedToken = localStorage.getItem("cicero_token");
     const storedClient = localStorage.getItem("client_id");
     const storedUser = localStorage.getItem("user_id");
+    const storedRole = localStorage.getItem("role");
     setToken(storedToken);
     setClientId(storedClient);
     setUserId(storedUser);
+    setRole(storedRole);
   }, []);
 
   const setAuth = (
     newToken: string | null,
     newClient: string | null,
     newUser: string | null,
+    newRole: string | null,
   ) => {
     setToken(newToken);
     setClientId(newClient);
     setUserId(newUser);
+    setRole(newRole);
     if (newToken) localStorage.setItem("cicero_token", newToken);
     else localStorage.removeItem("cicero_token");
     if (newClient) localStorage.setItem("client_id", newClient);
     else localStorage.removeItem("client_id");
     if (newUser) localStorage.setItem("user_id", newUser);
     else localStorage.removeItem("user_id");
+    if (newRole) localStorage.setItem("role", newRole);
+    else localStorage.removeItem("role");
   };
 
   return (
-    <AuthContext.Provider value={{ token, clientId, userId, setAuth }}>
+    <AuthContext.Provider value={{ token, clientId, userId, role, setAuth }}>
       {children}
     </AuthContext.Provider>
   );

--- a/cicero-dashboard/hooks/useRequireAuth.ts
+++ b/cicero-dashboard/hooks/useRequireAuth.ts
@@ -5,11 +5,14 @@ import { useAuth } from "@/context/AuthContext";
 
 export default function useRequireAuth() {
   const router = useRouter();
-  const { token, clientId } = useAuth();
+  const { token, clientId, role } = useAuth();
 
   useEffect(() => {
-    if (!token || !clientId) {
+    const specialRoles = ["ditbinmas", "ditlantas", "bidhumas"];
+    const hasAccess =
+      token && (clientId || (role && specialRoles.includes(role.toLowerCase())));
+    if (!hasAccess) {
       router.replace("/");
     }
-  }, [router, token, clientId]);
+  }, [router, token, clientId, role]);
 }


### PR DESCRIPTION
## Summary
- store user role in auth context and local storage
- show client profile for ditbinmas/ditlantas/bidhumas roles on dashboard and UI
- allow special roles through auth checks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a167a5b9ac83279cc39e7ddc3a6b2d