### PR TITLE
Prioritize nama_client over nama

### DIFF
--- a/cicero-dashboard/app/amplify/page.jsx
+++ b/cicero-dashboard/app/amplify/page.jsx
@@ -88,7 +88,6 @@ export default function DiseminasiInsightPage() {
                   u.client_id || u.clientId || u.clientID || u.client || ""
                 )
               ] ||
-              u.nama ||
               u.nama_client ||
               u.client_name ||
               u.client,

--- a/cicero-dashboard/app/comments/tiktok/page.jsx
+++ b/cicero-dashboard/app/comments/tiktok/page.jsx
@@ -112,20 +112,19 @@ export default function TiktokEngagementInsightPage() {
               )
             )
           );
-          enrichedUsers = users.map((u) => ({
-            ...u,
-            nama_client:
-              nameMap[
-                String(
-                  u.client_id || u.clientId || u.clientID || u.client || ""
-                )
-              ] ||
-              u.nama ||
-              u.nama_client ||
-              u.client_name ||
-              u.client,
-          }));
-        }
+            enrichedUsers = users.map((u) => ({
+              ...u,
+              nama_client:
+                nameMap[
+                  String(
+                    u.client_id || u.clientId || u.clientID || u.client || ""
+                  )
+                ] ||
+                u.nama_client ||
+                u.client_name ||
+                u.client,
+            }));
+          }
 
         // Ambil field TikTok Post dengan fallback urutan prioritas
         const totalTiktokPost =

--- a/cicero-dashboard/app/likes/instagram/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/page.jsx
@@ -122,20 +122,19 @@ export default function InstagramEngagementInsightPage() {
               ),
             ),
           );
-          enrichedUsers = users.map((u) => ({
-            ...u,
-            nama_client:
-              nameMap[
-                String(
-                  u.client_id || u.clientId || u.clientID || u.client || "",
-                )
-              ] ||
-              u.nama ||
-              u.nama_client ||
-              u.client_name ||
-              u.client,
-          }));
-        }
+            enrichedUsers = users.map((u) => ({
+              ...u,
+              nama_client:
+                nameMap[
+                  String(
+                    u.client_id || u.clientId || u.clientID || u.client || "",
+                  )
+                ] ||
+                u.nama_client ||
+                u.client_name ||
+                u.client,
+            }));
+          }
 
         // Rekap summary
         const totalUser = enrichedUsers.length;

--- a/cicero-dashboard/app/user-insight/page.jsx
+++ b/cicero-dashboard/app/user-insight/page.jsx
@@ -110,7 +110,6 @@ export default function UserInsightPage() {
                   u.client_id || u.clientId || u.clientID || u.id || "",
                 )
               ] ||
-              u.nama ||
               u.nama_client ||
               u.client_name ||
               u.client,
@@ -142,7 +141,6 @@ export default function UserInsightPage() {
             );
             const name = (
               u.nama_client ||
-              u.nama ||
               u.client_name ||
               u.client ||
               id

--- a/cicero-dashboard/app/users/page.jsx
+++ b/cicero-dashboard/app/users/page.jsx
@@ -81,7 +81,6 @@ export default function UserDirectoryPage() {
             nameMap[
               String(u.client_id || u.clientId || u.clientID || u.client || "")
             ] ||
-            u.nama ||
             u.nama_client ||
             u.client_name ||
             u.client,
@@ -153,22 +152,24 @@ export default function UserDirectoryPage() {
   // Filter: tidak tampilkan user dengan exception
   const filtered = useMemo(
     () =>
-      users
-        .filter((u) => !u.exception)
-        .filter(
-          (u) =>
-            (u.nama || "").toLowerCase().includes(search.toLowerCase()) ||
-            (u.title || "").toLowerCase().includes(search.toLowerCase()) ||
-            (u.user_id || "").toLowerCase().includes(search.toLowerCase()) ||
-            (u.nama_client || u.nama || u.divisi || "")
-              .toLowerCase()
-              .includes(search.toLowerCase()) ||
-            (u.insta || "").toLowerCase().includes(search.toLowerCase()) ||
-            (u.tiktok || "").toLowerCase().includes(search.toLowerCase()) ||
-            (String(u.status)).toLowerCase().includes(search.toLowerCase())
-        ),
-    [users, search]
-  );
+        users
+          .filter((u) => !u.exception)
+          .filter(
+            (u) =>
+              (u.nama_client || u.nama || "")
+                .toLowerCase()
+                .includes(search.toLowerCase()) ||
+              (u.title || "").toLowerCase().includes(search.toLowerCase()) ||
+              (u.user_id || "").toLowerCase().includes(search.toLowerCase()) ||
+              (u.divisi || "")
+                .toLowerCase()
+                .includes(search.toLowerCase()) ||
+              (u.insta || "").toLowerCase().includes(search.toLowerCase()) ||
+              (u.tiktok || "").toLowerCase().includes(search.toLowerCase()) ||
+              String(u.status).toLowerCase().includes(search.toLowerCase())
+          ),
+      [users, search]
+    );
 
   // Paging logic
   const totalPages = Math.ceil(filtered.length / PAGE_SIZE);
@@ -308,10 +309,10 @@ export default function UserDirectoryPage() {
                   </td>
                   <td className="py-1 px-2 font-mono">{u.user_id || "-"}</td>
                   <td className="py-1 px-2">
-                    {isDirectorate ? (
-                      u.nama_client || u.nama || "-"
-                    ) : editingRowId === u.user_id ? (
-                      <input
+                  {isDirectorate ? (
+                    u.nama_client || u.client_name || u.client || u.nama || "-"
+                  ) : editingRowId === u.user_id ? (
+                    <input
                         value={editSatfung}
                         onChange={(e) => setEditSatfung(e.target.value)}
                         placeholder={isDirectorate ? "Kesatuan" : "Satfung"}


### PR DESCRIPTION
## Summary
- remove `u.nama` fallback when enriching `nama_client` for directorate clients
- drop `u.nama` from `clientMap` names in user insights
- search and display client names using `nama_client` before `u.nama`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1f511865c83279aa20be9d6f6cd16