### PR TITLE
Include user ID in client name lookups for amplify chart

### DIFF
--- a/cicero-dashboard/app/amplify/page.jsx
+++ b/cicero-dashboard/app/amplify/page.jsx
@@ -76,7 +76,12 @@ export default function DiseminasiInsightPage() {
             token,
             users.map((u) =>
               String(
-                u.client_id || u.clientId || u.clientID || u.client || ""
+                u.client_id ||
+                  u.clientId ||
+                  u.clientID ||
+                  u.id ||
+                  u.client ||
+                  ""
               )
             )
           );
@@ -85,7 +90,12 @@ export default function DiseminasiInsightPage() {
             nama_client:
               nameMap[
                 String(
-                  u.client_id || u.clientId || u.clientID || u.client || ""
+                  u.client_id ||
+                    u.clientId ||
+                    u.clientID ||
+                    u.id ||
+                    u.client ||
+                    ""
                 )
               ] ||
               u.nama_client ||


### PR DESCRIPTION
## Summary
- include `u.id` as candidate when fetching client names
- match `u.id` when mapping enriched users to fetched names

## Testing
- `npm test`
- `npm run lint` *(fails: interactive ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f998b2488327ac8dda6ca1af8098