### PR TITLE
Handle miscellaneous divisions in grouping

### DIFF
--- a/cicero-dashboard/__tests__/grouping.test.ts
+++ b/cicero-dashboard/__tests__/grouping.test.ts
@@ -7,11 +7,13 @@ describe('groupUsersByKelompok', () => {
       { name: 'B', divisi: 'Sat Reskrim' },
       { name: 'C', divisi: 'Polsek Kota' },
       { name: 'D', divisi: 'SPKT 1' },
+      { name: 'E', divisi: 'Sekretariat' },
     ];
     const result = groupUsersByKelompok(users);
     expect(result.BAG).toHaveLength(1);
     expect(result.SAT).toHaveLength(1);
     expect(result.POLSEK).toHaveLength(1);
     expect(result['SI & SPKT']).toHaveLength(1);
+    expect(result.LAINNYA).toHaveLength(1);
   });
 });

--- a/cicero-dashboard/app/amplify/page.jsx
+++ b/cicero-dashboard/app/amplify/page.jsx
@@ -209,20 +209,21 @@ export default function DiseminasiInsightPage() {
                 showTotalUser
               />
             ) : (
-              <>
-                <ChartBox title="BAG" users={kelompok.BAG} showTotalUser />
-                <ChartBox title="SAT" users={kelompok.SAT} showTotalUser />
-                <ChartBox title="SI & SPKT" users={kelompok["SI & SPKT"]} showTotalUser />
-                <ChartHorizontal
-                  title="POLSEK"
-                  users={kelompok.POLSEK}
-                  fieldJumlah="jumlah_link"
-                  labelSudah="Sudah Post"
-                  labelBelum="Belum Post"
-                  labelTotal="Total Link"
-                />
-              </>
-            )}
+            <> 
+              <ChartBox title="BAG" users={kelompok.BAG} showTotalUser />
+              <ChartBox title="SAT" users={kelompok.SAT} showTotalUser />
+              <ChartBox title="SI & SPKT" users={kelompok["SI & SPKT"]} showTotalUser />
+              <ChartBox title="LAINNYA" users={kelompok.LAINNYA} showTotalUser />
+              <ChartHorizontal
+                title="POLSEK"
+                users={kelompok.POLSEK}
+                fieldJumlah="jumlah_link"
+                labelSudah="Sudah Post"
+                labelBelum="Belum Post"
+                labelTotal="Total Link"
+              />
+            </>
+          )}
           </div>
         </div>
       </div>

--- a/cicero-dashboard/app/comments/tiktok/page.jsx
+++ b/cicero-dashboard/app/comments/tiktok/page.jsx
@@ -268,6 +268,13 @@ export default function TiktokEngagementInsightPage() {
                   fieldJumlah="jumlah_komentar"
                   narrative="Grafik ini menampilkan perbandingan jumlah komentar TikTok dari user di divisi SI & SPKT."
                 />
+                <ChartBox
+                  title="LAINNYA"
+                  users={kelompok.LAINNYA}
+                  totalTiktokPost={rekapSummary.totalTiktokPost}
+                  fieldJumlah="jumlah_komentar"
+                  narrative="Grafik ini menampilkan perbandingan jumlah komentar TikTok dari user di divisi lainnya."
+                />
                 <ChartHorizontal
                   title="POLSEK"
                   users={kelompok.POLSEK}

--- a/cicero-dashboard/app/likes/instagram/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/page.jsx
@@ -276,6 +276,12 @@ export default function InstagramEngagementInsightPage() {
                   totalPost={rekapSummary.totalIGPost}
                   narrative="Grafik ini menunjukkan perbandingan jumlah like dari user di divisi SI & SPKT."
                 />
+                <ChartBox
+                  title="LAINNYA"
+                  users={kelompok.LAINNYA}
+                  totalPost={rekapSummary.totalIGPost}
+                  narrative="Grafik ini menunjukkan perbandingan jumlah like dari user di divisi lainnya."
+                />
                 <ChartHorizontal
                   title="POLSEK"
                   users={kelompok.POLSEK}

--- a/cicero-dashboard/app/user-insight/page.jsx
+++ b/cicero-dashboard/app/user-insight/page.jsx
@@ -41,6 +41,7 @@ export default function UserInsightPage() {
     SAT: [],
     "SI & SPKT": [],
     POLSEK: [],
+    LAINNYA: [],
   });
   const [isDirectorate, setIsDirectorate] = useState(false);
   const [chartPolres, setChartPolres] = useState([]);
@@ -173,6 +174,7 @@ export default function UserInsightPage() {
             SAT: generateChartData(grouped.SAT),
             "SI & SPKT": generateChartData(grouped["SI & SPKT"]),
             POLSEK: generateChartData(grouped.POLSEK),
+            LAINNYA: generateChartData(grouped.LAINNYA),
           });
         }
       } catch (err) {
@@ -253,6 +255,7 @@ export default function UserInsightPage() {
                 <ChartBox title="BAG" data={chartKelompok.BAG} />
                 <ChartBox title="SAT" data={chartKelompok.SAT} />
                 <ChartBox title="SI & SPKT" data={chartKelompok["SI & SPKT"]} />
+                <ChartBox title="LAINNYA" data={chartKelompok.LAINNYA} />
                 <ChartBox
                   title="POLSEK"
                   data={chartKelompok.POLSEK}

--- a/cicero-dashboard/utils/grouping.ts
+++ b/cicero-dashboard/utils/grouping.ts
@@ -8,16 +8,24 @@ export interface KelompokGroups {
   SAT: User[];
   'SI & SPKT': User[];
   POLSEK: User[];
+  LAINNYA: User[];
 }
 
 export function groupUsersByKelompok(users: User[]): KelompokGroups {
-  const group: KelompokGroups = { BAG: [], SAT: [], 'SI & SPKT': [], POLSEK: [] };
+  const group: KelompokGroups = {
+    BAG: [],
+    SAT: [],
+    'SI & SPKT': [],
+    POLSEK: [],
+    LAINNYA: [],
+  };
   users.forEach((user) => {
     const div = (user.divisi || '').toUpperCase();
     if (div.startsWith('BAG')) group.BAG.push(user);
     else if (div.startsWith('SAT')) group.SAT.push(user);
     else if (div.startsWith('SI') || div.startsWith('SPKT')) group['SI & SPKT'].push(user);
     else if (div.startsWith('POLSEK')) group.POLSEK.push(user);
+    else group.LAINNYA.push(user);
   });
   return group;
 }


### PR DESCRIPTION
## Summary
- capture unclassified divisions under `LAINNYA`
- render LAINNYA charts in all dashboard views
- cover miscellaneous group in grouping tests

## Testing
- `npm test`
- `npm run lint` *(fails: interactive prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68a1faeba1e08327bd6a6a3a41a091c4