### PR TITLE
Aggregate Instagram rekap for directorates

### DIFF
--- a/cicero-dashboard/app/likes/instagram/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/page.jsx
@@ -31,6 +31,11 @@ function isException(val) {
   return val === true || val === "true" || val === 1 || val === "1";
 }
 
+// Generic helper to check boolean-ish flags
+function isFlagTrue(val) {
+  return val === true || val === "true" || val === 1 || val === "1";
+}
+
 export default function InstagramEngagementInsightPage() {
   useRequireAuth();
   const [stats, setStats] = useState(null);
@@ -107,6 +112,15 @@ export default function InstagramEngagementInsightPage() {
           const clientIds = Array.from(
             new Set(
               dirData
+                .filter((u) =>
+                  isFlagTrue(
+                    u.same_role ||
+                      u.sameRole ||
+                      u.role_sama ||
+                      u.isSameRole ||
+                      u.roleSame,
+                  ),
+                )
                 .map((u) =>
                   String(
                     u.client_id ||


### PR DESCRIPTION
## Summary
- Detect directorate client type after profile lookup and expand recap scope
- Collect same-role client IDs from user directory for directorates
- Merge rekap likes across collected clients before generating summaries and charts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a2c4799a70832794565bc9632c88ed