### PR TITLE
feat: enrich directorate Instagram likes with client names

### DIFF
--- a/cicero-dashboard/app/likes/instagram/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/page.jsx
@@ -178,9 +178,8 @@ export default function InstagramEngagementInsightPage() {
               ),
             ),
           );
-          enrichedUsers = users.map((u) => ({
-            ...u,
-            nama_client:
+          enrichedUsers = users.map((u) => {
+            const clientName =
               nameMap[
                 String(
                   u.client_id || u.clientId || u.clientID || u.client || "",
@@ -188,8 +187,13 @@ export default function InstagramEngagementInsightPage() {
               ] ||
               u.nama_client ||
               u.client_name ||
-              u.client,
-          }));
+              u.client;
+            return {
+              ...u,
+              nama_client: clientName,
+              client_name: clientName,
+            };
+          });
         }
 
         // Rekap summary


### PR DESCRIPTION
## Summary
- enrich Instagram likes data with client_name for directorate users to match user directory logic

## Testing
- `npm test` *(fails: /usr/bin/npm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a2f76a80cc8327875a07995eb2a9c8