### PR TITLE
Hide post analysis menus for non-operator users

### DIFF
--- a/cicero-dashboard/app/login/page.jsx
+++ b/cicero-dashboard/app/login/page.jsx
@@ -49,7 +49,12 @@ export default function LoginPage() {
       if (data.success && data.token) {
         const userId = data.user?.user_id || null;
         const userClient = data.user?.client_id || null;
-        setAuth(data.token, userClient, userId);
+        const userRole =
+          data.user?.role ||
+          data.user?.user_role ||
+          data.user?.roleName ||
+          null;
+        setAuth(data.token, userClient, userId, userRole);
         router.push("/dashboard");
       } else {
         setError(data.message || "Login gagal");

--- a/cicero-dashboard/components/Header.tsx
+++ b/cicero-dashboard/components/Header.tsx
@@ -19,7 +19,7 @@ export default function Header() {
   const router = useRouter();
 
   const handleLogout = () => {
-    setAuth(null, null, null);
+    setAuth(null, null, null, null);
     router.replace("/login");
   };
 

--- a/cicero-dashboard/components/Sidebar.jsx
+++ b/cicero-dashboard/components/Sidebar.jsx
@@ -30,7 +30,7 @@ export default function Sidebar() {
   const pathname = usePathname();
   const [open, setOpen] = useState(false);
   const [collapsed, setCollapsed] = useState(false);
-  const { token, clientId } = useAuth();
+  const { token, clientId, role } = useAuth();
   const [profile, setProfile] = useState(null);
 
   useEffect(() => {
@@ -62,6 +62,7 @@ export default function Sidebar() {
   const instagramEnabled = isActive(getStatus(profile, "client_insta_status"));
   const amplifyEnabled = isActive(getStatus(profile, "client_amplify_status"));
   const tiktokEnabled = isActive(getStatus(profile, "client_tiktok_status"));
+  const isOperator = role?.toLowerCase() === "operator";
 
   const menu = [
     { label: "Dashboard", path: "/dashboard", icon: Home },
@@ -69,7 +70,13 @@ export default function Sidebar() {
     { label: "User Insight", path: "/user-insight", icon: BarChart3 },
     ...(instagramEnabled
       ? [
-          { label: "Instagram Post Analysis", path: "/instagram", icon: Instagram },
+          ...(isOperator
+            ? [{
+                label: "Instagram Post Analysis",
+                path: "/instagram",
+                icon: Instagram,
+              }]
+            : []),
           { label: "Instagram Engagement Insight", path: "/likes/instagram", icon: Heart },
         ]
       : []),
@@ -78,8 +85,18 @@ export default function Sidebar() {
       : []),
     ...(tiktokEnabled
       ? [
-          { label: "TikTok Post Analysis", path: "/tiktok", icon: Music },
-          { label: "TikTok Engagement Insight", path: "/comments/tiktok", icon: MessageCircle },
+          ...(isOperator
+            ? [{
+                label: "TikTok Post Analysis",
+                path: "/tiktok",
+                icon: Music,
+              }]
+            : []),
+          {
+            label: "TikTok Engagement Insight",
+            path: "/comments/tiktok",
+            icon: MessageCircle,
+          },
         ]
       : []),
   ];

--- a/cicero-dashboard/context/AuthContext.tsx
+++ b/cicero-dashboard/context/AuthContext.tsx
@@ -5,10 +5,12 @@ type AuthState = {
   token: string | null;
   clientId: string | null;
   userId: string | null;
+  role: string | null;
   setAuth: (
     token: string | null,
     clientId: string | null,
     userId: string | null,
+    role: string | null,
   ) => void;
 };
 
@@ -18,34 +20,41 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [token, setToken] = useState<string | null>(null);
   const [clientId, setClientId] = useState<string | null>(null);
   const [userId, setUserId] = useState<string | null>(null);
+  const [role, setRole] = useState<string | null>(null);
 
   useEffect(() => {
     const storedToken = localStorage.getItem("cicero_token");
     const storedClient = localStorage.getItem("client_id");
     const storedUser = localStorage.getItem("user_id");
+    const storedRole = localStorage.getItem("user_role");
     setToken(storedToken);
     setClientId(storedClient);
     setUserId(storedUser);
+    setRole(storedRole);
   }, []);
 
   const setAuth = (
     newToken: string | null,
     newClient: string | null,
     newUser: string | null,
+    newRole: string | null,
   ) => {
     setToken(newToken);
     setClientId(newClient);
     setUserId(newUser);
+    setRole(newRole);
     if (newToken) localStorage.setItem("cicero_token", newToken);
     else localStorage.removeItem("cicero_token");
     if (newClient) localStorage.setItem("client_id", newClient);
     else localStorage.removeItem("client_id");
     if (newUser) localStorage.setItem("user_id", newUser);
     else localStorage.removeItem("user_id");
+    if (newRole) localStorage.setItem("user_role", newRole);
+    else localStorage.removeItem("user_role");
   };
 
   return (
-    <AuthContext.Provider value={{ token, clientId, userId, setAuth }}>
+    <AuthContext.Provider value={{ token, clientId, userId, role, setAuth }}>
       {children}
     </AuthContext.Provider>
   );


### PR DESCRIPTION
## Summary
- store user role in AuthContext and persist to local storage
- hide Instagram and TikTok post analysis menus for non-operator dashboard users
- adjust login and logout flows for new role-aware auth context

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a356916cb08327a241f9bd515c2096