### PR TITLE
fix: remove stray commas in rekap page

### DIFF
--- a/cicero-dashboard/app/amplify/rekap/page.jsx
+++ b/cicero-dashboard/app/amplify/rekap/page.jsx
@@ -71,9 +71,9 @@ export default function RekapAmplifikasiPage() {
                   u.clientID ||
                   u.id ||
                   u.client ||
-                  "",
-              ),
-            ),
+                  ""
+              )
+            )
           );
           users = users.map((u) => ({
             ...u,
@@ -85,8 +85,8 @@ export default function RekapAmplifikasiPage() {
                     u.clientID ||
                     u.id ||
                     u.client ||
-                    "",
-                ),
+                    ""
+                )
               ] ||
               u.nama_client ||
               u.client_name ||


### PR DESCRIPTION
## Summary
- fix nameMap indexing in RekapAmplifikasi page
- remove stray commas when fetching client names

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3b94e8c2c8327908b02b75aa7e7dc