### PR TITLE
docs: expand README and executive summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ For detailed instructions on setting up a production server and deploying the da
 ```
 Cicero_Web/
 ├── cicero-dashboard/   # Next.js application
+├── docs/               # Supplementary documentation
 ├── LICENSE             # Project license
 └── README.md           # This file
 ```
@@ -17,8 +18,11 @@ Inside `cicero-dashboard` you will find the typical Next.js project layout:
 
 - `app/` – application pages and layouts
 - `components/` – shared React components
+- `context/` – React context providers for shared state (e.g. authentication)
 - `hooks/` – custom React hooks
+- `lib/` – small utility modules and shared assets
 - `utils/` – helper functions and API utilities
+- `__tests__/` – Jest unit tests
 
 ## Installation
 
@@ -65,6 +69,14 @@ NEXT_PUBLIC_API_URL=<backend base url>
 - Clients may allow an unlimited number of concurrent sessions.
 - Terms of Service and Privacy Policy for Google sign-in are available at `/terms-of-service` and `/privacy-policy`.
 - For Google OAuth verification, `docs/google_auth_policies.md` also includes a short description of the application.
+
+## Documentation
+
+Additional documents live under the [`docs/`](docs) directory:
+
+- [`DEPLOYMENT.md`](docs/DEPLOYMENT.md) – server setup and deployment workflow
+- [`executive_summary.md`](docs/executive_summary.md) – high-level architecture across repositories
+- [`google_auth_policies.md`](docs/google_auth_policies.md) – Google OAuth terms and privacy policy links
 
 For more information about Next.js features, refer to the documentation inside `cicero-dashboard/README.md`.
 

--- a/docs/executive_summary.md
+++ b/docs/executive_summary.md
@@ -25,7 +25,11 @@ Dokumen ini merangkum arsitektur tinggi dan alur kerja antar komponen.
 - Komunikasi dengan backend dilakukan lewat helper di `utils/api.ts` dan URL dasar
   diatur lewat variabel `NEXT_PUBLIC_API_URL`.【F:/tmp/Cicero_V2/docs/enterprise_architecture.md†L32-L39】
 - Menyajikan halaman analitik Instagram dan TikTok, direktori pengguna,
-  serta informasi client melalui folder `app/` di dalam proyek.`【F:/tmp/Cicero_V2/docs/enterprise_architecture.md†L32-L38】
+  serta informasi client melalui folder `app/` di dalam proyek. 【F:/tmp/Cicero_V2/docs/enterprise_architecture.md†L32-L38】
+- Otentikasi global dikelola oleh `AuthContext` di folder `context/` dengan hook
+  `useRequireAuth` dan `useAuthRedirect` untuk menjaga akses halaman.
+- Modul utilitas seperti `groupUsersByKelompok` di `utils/` membantu
+  normalisasi data sebelum ditampilkan.
 
 ## Aplikasi Android pegiat_medsos_apps
 


### PR DESCRIPTION
## Summary
- document `docs/` directory and additional Next.js folders in README
- outline authentication context and utilities in executive summary

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3bec60e9c83279817bb569ae5fe14