### PR TITLE
feat: expand panduan sop page

### DIFF
--- a/cicero-dashboard/app/panduan-sop/page.jsx
+++ b/cicero-dashboard/app/panduan-sop/page.jsx
@@ -6,7 +6,7 @@ export const metadata = {
 export default function PanduanSOPPage() {
   const sections = [
     {
-      title: "Panduan Frontend",
+      title: "Panduan Pengembangan Frontend",
       content: (
         <div className="space-y-2">
           <p>
@@ -18,14 +18,14 @@ npm run dev</code></pre>
           <p>Dokumentasi:</p>
           <ul className="list-disc pl-5 space-y-1">
             <li><a href="https://github.com/cicero78M/Cicero_Web/blob/main/docs/DEPLOYMENT.md" target="_blank" rel="noopener noreferrer" className="text-blue-600 underline">Panduan Deployment</a></li>
-            <li><a href="https://github.com/cicero78M/Cicero_Web/blob/main/docs/executive_summary.md" target="_blank" rel="noopener noreferrer" className="text-blue-600 underline">Executive Summary</a></li>
-            <li><a href="https://github.com/cicero78M/Cicero_Web/blob/main/docs/google_auth_policies.md" target="_blank" rel="noopener noreferrer" className="text-blue-600 underline">Kebijakan Google Auth</a></li>
+            <li><a href="https://github.com/cicero78M/Cicero_Web/blob/main/docs/executive_summary.md" target="_blank" rel="noopener noreferrer" className="text-blue-600 underline">Panduan Ringkasan Eksekutif</a></li>
+            <li><a href="https://github.com/cicero78M/Cicero_Web/blob/main/docs/google_auth_policies.md" target="_blank" rel="noopener noreferrer" className="text-blue-600 underline">Panduan Kebijakan Google Auth</a></li>
           </ul>
         </div>
       ),
     },
     {
-      title: "Panduan Backend",
+      title: "Panduan Pengembangan Backend",
       content: (
         <div className="space-y-2">
           <p>
@@ -37,10 +37,62 @@ npm run dev</code></pre>
 npm start</code></pre>
           <p>Dokumentasi terkait:</p>
           <ul className="list-disc pl-5 space-y-1">
-            <li><a href="https://github.com/cicero78M/Cicero_V2/blob/main/docs/combined_overview.md" target="_blank" rel="noopener noreferrer" className="text-blue-600 underline">Gambaran Kombinasi</a></li>
-            <li><a href="https://github.com/cicero78M/Cicero_V2/blob/main/docs/enterprise_architecture.md" target="_blank" rel="noopener noreferrer" className="text-blue-600 underline">Arsitektur Enterprise</a></li>
+            <li><a href="https://github.com/cicero78M/Cicero_V2/blob/main/docs/combined_overview.md" target="_blank" rel="noopener noreferrer" className="text-blue-600 underline">Panduan Gambaran Kombinasi</a></li>
+            <li><a href="https://github.com/cicero78M/Cicero_V2/blob/main/docs/enterprise_architecture.md" target="_blank" rel="noopener noreferrer" className="text-blue-600 underline">Panduan Arsitektur Enterprise</a></li>
             <li><a href="https://github.com/cicero78M/Cicero_V2/blob/main/docs/workflow_usage_guide.md" target="_blank" rel="noopener noreferrer" className="text-blue-600 underline">Panduan Alur Kerja</a></li>
           </ul>
+        </div>
+      ),
+    },
+    {
+      title: "Panduan Registrasi User Dashboard",
+      content: (
+        <div className="space-y-2">
+          <p>Langkah registrasi pengguna untuk mengakses dashboard:</p>
+          <ol className="list-decimal pl-5 space-y-1">
+            <li>Buka halaman dashboard dan pilih "Daftar".</li>
+            <li>Isi formulir registrasi dengan data yang diperlukan.</li>
+            <li>Verifikasi akun melalui tautan yang dikirimkan ke email.</li>
+          </ol>
+        </div>
+      ),
+    },
+    {
+      title: "Panduan Update Data via WA Bot",
+      content: (
+        <div className="space-y-2">
+          <p>Petunjuk memperbarui data menggunakan bot WhatsApp:</p>
+          <ol className="list-decimal pl-5 space-y-1">
+            <li>Simpan nomor bot WA ke kontak.</li>
+            <li>Kirim pesan dengan format yang telah ditentukan.</li>
+            <li>Tunggu konfirmasi bahwa data berhasil diperbarui.</li>
+          </ol>
+        </div>
+      ),
+    },
+    {
+      title: "Panduan Operator Update, Rekap, dan Absensi",
+      content: (
+        <div className="space-y-2">
+          <p>Langkah bagi operator untuk memperbarui, merekap, dan mencatat absensi:</p>
+          <ol className="list-decimal pl-5 space-y-1">
+            <li>Masuk ke dashboard operator.</li>
+            <li>Lakukan pembaruan data dan rekap sesuai periode.</li>
+            <li>Catat absensi harian pada menu yang tersedia.</li>
+          </ol>
+        </div>
+      ),
+    },
+    {
+      title: "Panduan Penggunaan Chart Visualisasi Data",
+      content: (
+        <div className="space-y-2">
+          <p>Cara membaca dan memanfaatkan chart visualisasi:</p>
+          <ol className="list-decimal pl-5 space-y-1">
+            <li>Pilih jenis chart pada menu analitik.</li>
+            <li>Gunakan filter untuk menyesuaikan data yang ditampilkan.</li>
+            <li>Unduh chart bila diperlukan untuk laporan.</li>
+          </ol>
         </div>
       ),
     },


### PR DESCRIPTION
## Summary
- rename existing links to follow panduan naming
- add guides for dashboard registration, WA bot updates, operator tasks, and chart visualizations

## Testing
- `npm test`
- `npm run lint` *(fails: requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a3e9d3992483278f0930fd93a3d9d0