### PR TITLE
Persist pagination state across refresh

### DIFF
--- a/cicero-dashboard/app/users/page.jsx
+++ b/cicero-dashboard/app/users/page.jsx
@@ -1,5 +1,6 @@
 "use client";
-import { useEffect, useState, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
+import usePersistentState from "@/hooks/usePersistentState";
 import {
   getUserDirectory,
   createUser,
@@ -19,7 +20,7 @@ export default function UserDirectoryPage() {
   const [search, setSearch] = useState("");
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
-  const [page, setPage] = useState(1);
+  const [page, setPage] = usePersistentState("users_page", 1);
 
   const [showForm, setShowForm] = useState(false);
   // state for new user form
@@ -176,7 +177,14 @@ export default function UserDirectoryPage() {
   const currentRows = filtered.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
 
   // Reset ke halaman 1 saat search berubah
-  useEffect(() => setPage(1), [search]);
+  useEffect(() => setPage(1), [search, setPage]);
+
+  // Pastikan halaman tetap valid saat totalPages berubah
+  useEffect(() => {
+    if (page > totalPages) {
+      setPage(totalPages || 1);
+    }
+  }, [page, totalPages, setPage]);
 
   if (loading) return <Loader />;
   if (error)

--- a/cicero-dashboard/components/RekapAmplifikasi.jsx
+++ b/cicero-dashboard/components/RekapAmplifikasi.jsx
@@ -1,5 +1,6 @@
 "use client";
-import { useMemo, useState, useEffect } from "react";
+import { useMemo, useEffect, useState } from "react";
+import usePersistentState from "@/hooks/usePersistentState";
 import { Link as LinkIcon, Users, Check, X } from "lucide-react";
 
 function bersihkanSatfung(divisi = "") {
@@ -46,10 +47,15 @@ export default function RekapAmplifikasi({ users = [] }) {
     });
   }, [filtered]);
 
-  const [page, setPage] = useState(1);
+  const [page, setPage] = usePersistentState("rekapAmplifikasi_page", 1);
   const totalPages = Math.ceil(sorted.length / PAGE_SIZE);
   const currentRows = sorted.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
-  useEffect(() => setPage(1), [search]);
+  useEffect(() => setPage(1), [search, setPage]);
+  useEffect(() => {
+    if (page > totalPages) {
+      setPage(totalPages || 1);
+    }
+  }, [page, totalPages, setPage]);
 
   return (
     <div className="flex flex-col gap-6 mt-8">

--- a/cicero-dashboard/components/RekapKomentarTiktok.jsx
+++ b/cicero-dashboard/components/RekapKomentarTiktok.jsx
@@ -1,5 +1,6 @@
 "use client";
-import { useMemo, useState, useEffect } from "react";
+import { useMemo, useEffect, useState } from "react";
+import usePersistentState from "@/hooks/usePersistentState";
 import { Music, Users, Check, X } from "lucide-react";
 
 function isException(val) {
@@ -79,10 +80,15 @@ export default function RekapKomentarTiktok({ users = [], totalTiktokPost = 0 })
     });
   }, [filtered, maxJumlahKomentar]);
 
-  const [page, setPage] = useState(1);
+  const [page, setPage] = usePersistentState("rekapKomentarTiktok_page", 1);
   const totalPages = Math.ceil(sorted.length / PAGE_SIZE);
   const currentRows = sorted.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
-  useEffect(() => setPage(1), [search]);
+  useEffect(() => setPage(1), [search, setPage]);
+  useEffect(() => {
+    if (page > totalPages) {
+      setPage(totalPages || 1);
+    }
+  }, [page, totalPages, setPage]);
 
   return (
     <div className="flex flex-col gap-6 mt-8">

--- a/cicero-dashboard/components/RekapLikesIG.jsx
+++ b/cicero-dashboard/components/RekapLikesIG.jsx
@@ -1,5 +1,6 @@
 "use client";
-import { useMemo, useState, useEffect } from "react";
+import { useMemo, useEffect, useState } from "react";
+import usePersistentState from "@/hooks/usePersistentState";
 import { Camera, Users, Check, X } from "lucide-react";
 
 // Utility: handle boolean/string/number for exception
@@ -98,12 +99,19 @@ export default function RekapLikesIG({ users = [], totalIGPost = 0 }) {
   }, [filtered, maxJumlahLike]);
 
   // Pagination
-  const [page, setPage] = useState(1);
+  const [page, setPage] = usePersistentState("rekapLikesIG_page", 1);
   const totalPages = Math.ceil(sorted.length / PAGE_SIZE);
   const currentRows = sorted.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
 
   // Reset ke halaman 1 jika search berubah
-  useEffect(() => setPage(1), [search]);
+  useEffect(() => setPage(1), [search, setPage]);
+
+  // Pastikan halaman tidak melebihi total yang tersedia
+  useEffect(() => {
+    if (page > totalPages) {
+      setPage(totalPages || 1);
+    }
+  }, [page, totalPages, setPage]);
 
   return (
     <div className="flex flex-col gap-6 mt-8">

--- a/cicero-dashboard/hooks/usePersistentState.ts
+++ b/cicero-dashboard/hooks/usePersistentState.ts
@@ -1,0 +1,24 @@
+import { useState, useEffect } from "react";
+
+export default function usePersistentState<T>(key: string, defaultValue: T) {
+  const [state, setState] = useState<T>(() => {
+    if (typeof window === "undefined") return defaultValue;
+    const stored = window.localStorage.getItem(key);
+    if (stored !== null) {
+      try {
+        return JSON.parse(stored) as T;
+      } catch {
+        return defaultValue;
+      }
+    }
+    return defaultValue;
+  });
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(key, JSON.stringify(state));
+    }
+  }, [key, state]);
+
+  return [state, setState] as const;
+}


### PR DESCRIPTION
## Summary
- remember last pagination page for users and rekap views
- add reusable `usePersistentState` hook backed by localStorage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a40e8ced4c8327802b651e93e3ed7f