### PR TITLE
Add total user bar grouped by client

### DIFF
--- a/cicero-dashboard/app/comments/tiktok/page.jsx
+++ b/cicero-dashboard/app/comments/tiktok/page.jsx
@@ -318,6 +318,7 @@ function ChartBox({
   narrative,
   groupBy,
 }) {
+  const showTotalUser = groupBy === "client_id";
   return (
     <div className="bg-white rounded-xl shadow p-4">
       <div className="font-bold text-pink-700 mb-2 text-center">{title}</div>
@@ -332,6 +333,8 @@ function ChartBox({
           labelBelum="User Belum Komentar"
           labelTotal="Total Komentar"
           groupBy={groupBy}
+          showTotalUser={showTotalUser}
+          labelTotalUser="Jumlah User"
         />
       ) : (
         <div className="text-center text-gray-400 text-sm">Tidak ada data</div>

--- a/cicero-dashboard/app/likes/instagram/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/page.jsx
@@ -379,6 +379,7 @@ function ChartBox({
   narrative,
   groupBy,
 }) {
+  const showTotalUser = groupBy === "client_id";
   return (
     <div className="bg-white rounded-xl shadow p-4">
       <div className="font-bold text-blue-700 mb-2 text-center">{title}</div>
@@ -393,6 +394,8 @@ function ChartBox({
           labelBelum="User Belum Like"
           labelTotal="Total Likes"
           groupBy={groupBy}
+          showTotalUser={showTotalUser}
+          labelTotalUser="Jumlah User"
         />
       ) : (
         <div className="text-center text-gray-400 text-sm">Tidak ada data</div>


### PR DESCRIPTION
## Summary
- show total user count per client on Instagram likes chart
- show total user count per client on TikTok comments chart

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68a40e036f248327a81f9d5acdd51583