### PR TITLE
feat: show user counts in like recap bars

### DIFF
--- a/cicero-dashboard/app/likes/instagram/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/page.jsx
@@ -346,6 +346,7 @@ export default function InstagramEngagementInsightPage() {
                   title="POLSEK"
                   users={kelompok.POLSEK}
                   totalPost={rekapSummary.totalIGPost}
+                  showTotalUser
                 />
                 <Narrative>
                   Grafik POLSEK memperlihatkan jumlah like Instagram dari setiap
@@ -393,6 +394,8 @@ function ChartBox({
           labelBelum="User Belum Like"
           labelTotal="Total Likes"
           groupBy={groupBy}
+          showTotalUser
+          labelTotalUser="Jumlah User"
         />
       ) : (
         <div className="text-center text-gray-400 text-sm">Tidak ada data</div>

--- a/cicero-dashboard/components/ChartHorizontal.jsx
+++ b/cicero-dashboard/components/ChartHorizontal.jsx
@@ -30,6 +30,8 @@ export default function ChartHorizontal({
   labelSudah = "User Sudah Like",
   labelBelum = "User Belum Like",
   labelTotal = "Total Likes",
+  showTotalUser = false,
+  labelTotalUser = "Jumlah User",
 }) {
   const effectiveTotal =
     typeof totalPost !== "undefined" ? totalPost : totalIGPost;
@@ -57,10 +59,12 @@ export default function ChartHorizontal({
     if (!divisiMap[key])
       divisiMap[key] = {
         divisi: key,
+        total_user: 0,
         user_sudah: 0,
         user_belum: 0,
         total_value: 0,
       };
+    divisiMap[key].total_user += 1;
     if (sudah) {
       divisiMap[key].user_sudah += 1;
       divisiMap[key].total_value += nilai;
@@ -112,7 +116,9 @@ export default function ChartHorizontal({
               formatter={(value, name) =>
                 [
                   value,
-                  name === "user_sudah"
+                  name === "total_user"
+                    ? labelTotalUser
+                    : name === "user_sudah"
                     ? labelSudah
                     : name === "user_belum"
                     ? labelBelum
@@ -124,6 +130,20 @@ export default function ChartHorizontal({
               labelFormatter={label => `Divisi: ${label}`}
             />
             <Legend />
+            {showTotalUser && (
+              <Bar
+                dataKey="total_user"
+                fill="#0ea5e9"
+                name={labelTotalUser}
+                barSize={10}
+              >
+                <LabelList
+                  dataKey="total_user"
+                  position="right"
+                  fontSize={10}
+                />
+              </Bar>
+            )}
             <Bar dataKey="user_sudah" fill="#22c55e" name={labelSudah} barSize={10}>
               <LabelList dataKey="user_sudah" position="right" fontSize={10} />
             </Bar>


### PR DESCRIPTION
## Summary
- allow ChartHorizontal to optionally render total user counts
- show user count bars in Instagram like recap charts

## Testing
- `npm test --prefix cicero-dashboard`

------
https://chatgpt.com/codex/tasks/task_e_68a41324286883279e3d49f641d64583