### PR TITLE
Support Ditbinmas role in IG engagement insight

### DIFF
--- a/cicero-dashboard/__tests__/api.test.ts
+++ b/cicero-dashboard/__tests__/api.test.ts
@@ -97,3 +97,10 @@ test("getDashboardStats handles partial date range params", async () => {
   expect(url).not.toContain("start_date");
 });
 
+test("getDashboardStats includes client_id when provided", async () => {
+  await getDashboardStats("tok", undefined, undefined, undefined, undefined, "DITBINMAS");
+  const url = (global.fetch as jest.Mock).mock.calls[0][0];
+  expect(url).toContain("/api/dashboard/stats");
+  expect(url).toContain("client_id=DITBINMAS");
+});
+

--- a/cicero-dashboard/app/likes/instagram/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/page.jsx
@@ -61,11 +61,22 @@ export default function InstagramEngagementInsightPage() {
       typeof window !== "undefined"
         ? localStorage.getItem("cicero_token")
         : null;
-    if (!token) {
-      setError("Token tidak ditemukan. Silakan login ulang.");
+    const userClientId =
+      typeof window !== "undefined"
+        ? localStorage.getItem("client_id")
+        : null;
+    const role =
+      typeof window !== "undefined"
+        ? localStorage.getItem("user_role")
+        : null;
+    if (!token || !userClientId) {
+      setError("Token / Client ID tidak ditemukan. Silakan login ulang.");
       setLoading(false);
       return;
     }
+
+    const isDitbinmas = String(role).toLowerCase() === "ditbinmas";
+    const taskClientId = isDitbinmas ? "DITBINMAS" : userClientId;
 
     async function fetchData() {
       try {
@@ -81,16 +92,12 @@ export default function InstagramEngagementInsightPage() {
           date,
           startDate,
           endDate,
+          taskClientId,
         );
         setStats(statsData);
 
-        const client_id =
-          statsData.client_id || localStorage.getItem("client_id");
-        if (!client_id) {
-          setError("Client ID tidak ditemukan.");
-          setLoading(false);
-          return;
-        }
+        const client_id = userClientId;
+
 
         const profileRes = await getClientProfile(token, client_id);
         const profile =

--- a/cicero-dashboard/app/likes/instagram/rekap/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/rekap/page.jsx
@@ -49,11 +49,22 @@ export default function RekapLikesIGPage() {
       typeof window !== "undefined"
         ? localStorage.getItem("cicero_token")
         : null;
-    if (!token) {
-      setError("Token tidak ditemukan. Silakan login ulang.");
+    const userClientId =
+      typeof window !== "undefined"
+        ? localStorage.getItem("client_id")
+        : null;
+    const role =
+      typeof window !== "undefined"
+        ? localStorage.getItem("user_role")
+        : null;
+    if (!token || !userClientId) {
+      setError("Token / Client ID tidak ditemukan. Silakan login ulang.");
       setLoading(false);
       return;
     }
+
+    const isDitbinmas = String(role).toLowerCase() === "ditbinmas";
+    const taskClientId = isDitbinmas ? "DITBINMAS" : userClientId;
 
     async function fetchData() {
       try {
@@ -69,14 +80,9 @@ export default function RekapLikesIGPage() {
           date,
           startDate,
           endDate,
+          taskClientId,
         );
-        const client_id =
-          statsData.client_id || localStorage.getItem("client_id");
-        if (!client_id) {
-          setError("Client ID tidak ditemukan.");
-          setLoading(false);
-          return;
-        }
+        const client_id = userClientId;
 
         const profileRes = await getClientProfile(token, client_id);
         const profile =

--- a/cicero-dashboard/utils/api.ts
+++ b/cicero-dashboard/utils/api.ts
@@ -42,13 +42,15 @@ export async function getDashboardStats(
   periode?: string,
   tanggal?: string,
   startDate?: string,
-  endDate?: string
+  endDate?: string,
+  client_id?: string
 ): Promise<any> {
   const params = new URLSearchParams();
   if (periode) params.append("periode", periode);
   if (tanggal) params.append("tanggal", tanggal);
   if (startDate) params.append("start_date", startDate);
   if (endDate) params.append("end_date", endDate);
+  if (client_id) params.append("client_id", client_id);
   const url = `${API_BASE_URL}/api/dashboard/stats${
     params.toString() ? `?${params.toString()}` : ""
   }`;


### PR DESCRIPTION
## Summary
- allow getDashboardStats to accept optional client_id for cross-client queries
- show Ditbinmas tasks but local users in Instagram engagement insight and rekap pages
- test getDashboardStats client_id parameter

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af00d84d2c832787b6666dc5b6cf36