### PR TITLE
feat: add rekap copy button for ORG

### DIFF
--- a/cicero-dashboard/app/likes/instagram/rekap/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/rekap/page.jsx
@@ -39,6 +39,10 @@ export default function RekapLikesIGPage() {
     totalIGPost: 0,
   });
 
+  const [igPosts, setIgPosts] = useState([]);
+  const [isOrg, setIsOrg] = useState(false);
+  const [clientName, setClientName] = useState("");
+
   const viewOptions = VIEW_OPTIONS;
 
 
@@ -82,6 +86,14 @@ export default function RekapLikesIGPage() {
           endDate,
           taskClientId,
         );
+        const posts = Array.isArray(statsData.ig_posts)
+          ? statsData.ig_posts
+          : Array.isArray(statsData.igPosts)
+          ? statsData.igPosts
+          : Array.isArray(statsData.instagram_posts)
+          ? statsData.instagram_posts
+          : [];
+        setIgPosts(posts);
         const client_id = userClientId;
 
         const profileRes = await getClientProfile(token, client_id);
@@ -89,6 +101,17 @@ export default function RekapLikesIGPage() {
           profileRes.client || profileRes.profile || profileRes || {};
         const dir =
           (profile.client_type || "").toUpperCase() === "DIREKTORAT";
+        setIsOrg(
+          (profile.client_type || profile.clientType || "")
+            .toUpperCase() === "ORG",
+        );
+        setClientName(
+          profile.nama ||
+            profile.nama_client ||
+            profile.client_name ||
+            profile.client ||
+            "",
+        );
 
         let users = [];
         if (dir) {
@@ -265,6 +288,9 @@ export default function RekapLikesIGPage() {
           <RekapLikesIG
             users={chartData}
             totalIGPost={rekapSummary.totalIGPost}
+            posts={igPosts}
+            showRekapButton={isOrg}
+            clientName={clientName}
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add "Salin Rekap" button on IG likes recap page for ORG clients
- fetch IG post links and client name to build recap message
- generate formatted recap text and copy to clipboard

## Testing
- `npm test`
- `npm run lint` (interactive prompt)


------
https://chatgpt.com/codex/tasks/task_e_68af05b03cb88327b2911130d876b2fb