### PR TITLE
Normalize client IDs for task lookup

### DIFF
--- a/cicero-dashboard/__tests__/api.test.ts
+++ b/cicero-dashboard/__tests__/api.test.ts
@@ -104,3 +104,9 @@ test("getDashboardStats includes client_id when provided", async () => {
   expect(url).toContain("client_id=DITBINMAS");
 });
 
+test("getDashboardStats normalizes client_id to uppercase", async () => {
+  await getDashboardStats("tok", undefined, undefined, undefined, undefined, "ditbinmas");
+  const url = (global.fetch as jest.Mock).mock.calls[0][0];
+  expect(url).toContain("client_id=DITBINMAS");
+});
+

--- a/cicero-dashboard/utils/api.ts
+++ b/cicero-dashboard/utils/api.ts
@@ -16,6 +16,10 @@ function handleTokenExpired(): void {
   }
 }
 
+function normalizeClientId(client_id?: string): string | undefined {
+  return client_id ? String(client_id).toUpperCase() : undefined;
+}
+
 // Wrapper around fetch that attaches the Authorization header and
 // automatically logs the user out when the token is rejected by the backend
 async function fetchWithAuth(
@@ -50,7 +54,8 @@ export async function getDashboardStats(
   if (tanggal) params.append("tanggal", tanggal);
   if (startDate) params.append("start_date", startDate);
   if (endDate) params.append("end_date", endDate);
-  if (client_id) params.append("client_id", client_id);
+  const cid = normalizeClientId(client_id);
+  if (cid) params.append("client_id", cid);
   const url = `${API_BASE_URL}/api/dashboard/stats${
     params.toString() ? `?${params.toString()}` : ""
   }`;
@@ -80,7 +85,10 @@ export async function getRekapLikesIG(
   startDate?: string,
   endDate?: string
 ): Promise<any> {
-  const params = new URLSearchParams({ client_id, periode });
+  const params = new URLSearchParams({
+    client_id: normalizeClientId(client_id) || "",
+    periode,
+  });
   if (tanggal) params.append("tanggal", tanggal);
   if (startDate) params.append("start_date", startDate);
   if (endDate) params.append("end_date", endDate);
@@ -96,7 +104,9 @@ export async function getClientProfile(
   token: string,
   client_id: string,
 ): Promise<any> {
-  const params = new URLSearchParams({ client_id });
+  const params = new URLSearchParams({
+    client_id: normalizeClientId(client_id) || "",
+  });
   const url = `${API_BASE_URL}/api/clients/profile?${params.toString()}`;
 
   const res = await fetchWithAuth(url, token);
@@ -139,7 +149,8 @@ export async function getClientNames(
 
 // Ambil daftar user untuk User Directory
 export async function getUserDirectory(token: string, client_id: string): Promise<any> {
-  const url = `${API_BASE_URL}/api/users/list?client_id=${encodeURIComponent(client_id)}`;
+  const cid = normalizeClientId(client_id) || "";
+  const url = `${API_BASE_URL}/api/users/list?client_id=${encodeURIComponent(cid)}`;
 
   const res = await fetchWithAuth(url, token);
   if (!res.ok) throw new Error("Gagal fetch daftar user");
@@ -158,9 +169,13 @@ export async function createUser(
   },
 ): Promise<any> {
   const url = `${API_BASE_URL}/api/users/create`;
+  const payload = {
+    ...data,
+    client_id: normalizeClientId(data.client_id) || data.client_id,
+  };
   const res = await fetchWithAuth(url, token, {
     method: "POST",
-    body: JSON.stringify(data),
+    body: JSON.stringify(payload),
   });
   if (!res.ok) {
     const text = await res.text();
@@ -176,9 +191,13 @@ export async function updateUser(
   data: Record<string, any>,
 ): Promise<any> {
   const url = `${API_BASE_URL}/api/users/${encodeURIComponent(userId)}`;
+  const payload = {
+    ...data,
+    ...(data.client_id && { client_id: normalizeClientId(data.client_id) }),
+  };
   const res = await fetchWithAuth(url, token, {
     method: "PUT",
-    body: JSON.stringify(data),
+    body: JSON.stringify(payload),
   });
   if (!res.ok) {
     const text = await res.text();
@@ -203,7 +222,10 @@ export async function getRekapKomentarTiktok(
   startDate?: string,
   endDate?: string
 ): Promise<any> {
-  const params = new URLSearchParams({ client_id, periode });
+  const params = new URLSearchParams({
+    client_id: normalizeClientId(client_id) || "",
+    periode,
+  });
   if (tanggal) params.append("tanggal", tanggal);
   if (startDate) params.append("start_date", startDate);
   if (endDate) params.append("end_date", endDate);
@@ -226,7 +248,10 @@ export async function getRekapAmplify(
   startDate?: string,
   endDate?: string
 ): Promise<any> {
-  const params = new URLSearchParams({ client_id, periode });
+  const params = new URLSearchParams({
+    client_id: normalizeClientId(client_id) || "",
+    periode,
+  });
   if (tanggal) params.append("tanggal", tanggal);
   if (startDate) params.append("start_date", startDate);
   if (endDate) params.append("end_date", endDate);
@@ -238,7 +263,9 @@ export async function getRekapAmplify(
 }
 
 export async function getInstagramPosts(token: string, client_id: string): Promise<any> {
-  const params = new URLSearchParams({ client_id });
+  const params = new URLSearchParams({
+    client_id: normalizeClientId(client_id) || "",
+  });
   const url = `${API_BASE_URL}/api/insta/posts?${params.toString()}`;
   const res = await fetchWithAuth(url, token);
   if (!res.ok) throw new Error("Failed to fetch instagram posts");
@@ -401,7 +428,10 @@ export async function getTiktokPostsViaBackend(
   startDate?: string,
   endDate?: string
 ): Promise<any> {
-  const params = new URLSearchParams({ client_id, limit: String(limit) });
+  const params = new URLSearchParams({
+    client_id: normalizeClientId(client_id) || "",
+    limit: String(limit),
+  });
   if (startDate) params.append("start_date", startDate);
   if (endDate) params.append("end_date", endDate);
   const url = `${API_BASE_URL}/api/tiktok/rapid-posts?${params.toString()}`;
@@ -476,7 +506,9 @@ export async function getTiktokPostsByUsernameViaBackend(
 }
 
 export async function getTiktokPosts(token: string, client_id: string): Promise<any> {
-  const params = new URLSearchParams({ client_id });
+  const params = new URLSearchParams({
+    client_id: normalizeClientId(client_id) || "",
+  });
   const url = `${API_BASE_URL}/api/tiktok/posts?${params.toString()}`;
   const res = await fetchWithAuth(url, token);
   if (!res.ok) throw new Error("Failed to fetch tiktok posts");


### PR DESCRIPTION
## Summary
- ensure all API helpers uppercase `client_id` before request
- test that dashboard stats accepts lowercase client IDs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af0a4e3840832790b167122aabe175