### PR TITLE
Align text styling across screens

### DIFF
--- a/cicero-dashboard/app/globals.css
+++ b/cicero-dashboard/app/globals.css
@@ -7,6 +7,11 @@
   --foreground: #111827;
 }
 
+html {
+  font-size: 16px;
+  color: var(--foreground);
+}
+
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
@@ -31,12 +36,6 @@ body {
   color: var(--foreground);
   font-family: var(--font-geist-sans, Arial, Helvetica, sans-serif);
   line-height: 1.6;
-}
-
-@media (max-width: 640px) {
-  .text-gray-500 {
-    color: #374151 !important;
-  }
 }
 
 .container {


### PR DESCRIPTION
## Summary
- enforce base font size and text color via global `html` rule
- remove mobile-only text color override to ensure consistency with PC styling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68afc79dd5b08327a8fcdf3d79e80586