### PR TITLE
Exclude clients with data from 'belum' charts

### DIFF
--- a/cicero-dashboard/components/ChartDivisiAbsensi.jsx
+++ b/cicero-dashboard/components/ChartDivisiAbsensi.jsx
@@ -151,6 +151,14 @@ export default function ChartDivisiAbsensi({
     }
   });
 
+  // Jika sebuah client sudah memiliki user pada kolom "sudah",
+  // jangan hitung lagi user lain pada kolom "belum" untuk client tersebut.
+  Object.values(divisiMap).forEach((entry) => {
+    if (entry.user_sudah > 0) {
+      entry.user_belum = 0;
+    }
+  });
+
   const dataChart = Object.values(divisiMap).sort(
     (a, b) => b.total_value - a.total_value
   );

--- a/cicero-dashboard/components/ChartHorizontal.jsx
+++ b/cicero-dashboard/components/ChartHorizontal.jsx
@@ -72,6 +72,15 @@ export default function ChartHorizontal({
       divisiMap[key].user_belum += 1;
     }
   });
+
+  // Jika sebuah client sudah berada pada kolom "sudah",
+  // maka data "belum" untuk client tersebut diabaikan.
+  Object.values(divisiMap).forEach((entry) => {
+    if (entry.user_sudah > 0) {
+      entry.user_belum = 0;
+    }
+  });
+
   const dataChart = Object.values(divisiMap);
 
   // Tinggi chart proporsional


### PR DESCRIPTION
## Summary
- avoid counting clients in the "belum" column if they already have "sudah" users
- apply the exclusion logic to both ChartDivisiAbsensi and ChartHorizontal components

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68afd6e9979883279690a22a2d0b99e4