### PR TITLE
Sync user roles when editing user NRP

### DIFF
--- a/cicero-dashboard/app/users/page.jsx
+++ b/cicero-dashboard/app/users/page.jsx
@@ -7,6 +7,7 @@ import {
   updateUser,
   getClientProfile,
   getClientNames,
+  updateUserRoles,
 } from "@/utils/api";
 import { Pencil, Check, X } from "lucide-react";
 import Loader from "@/components/Loader";
@@ -166,6 +167,9 @@ export default function UserDirectoryPage() {
         divisi: editSatfung,
         user_id: editNrpNip,
       });
+      if (userId !== editNrpNip) {
+        await updateUserRoles(token || "", userId, editNrpNip);
+      }
       await fetchUsers();
       setEditingRowId(null);
     } catch (err) {

--- a/cicero-dashboard/utils/api.ts
+++ b/cicero-dashboard/utils/api.ts
@@ -187,6 +187,24 @@ export async function updateUser(
   return res.json();
 }
 
+// Perbarui relasi user_roles ketika NRP/NIP berubah
+export async function updateUserRoles(
+  token: string,
+  oldUserId: string,
+  newUserId: string,
+): Promise<any> {
+  const url = `${API_BASE_URL}/api/user_roles/update`;
+  const res = await fetchWithAuth(url, token, {
+    method: "PUT",
+    body: JSON.stringify({ old_user_id: oldUserId, new_user_id: newUserId }),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Gagal memperbarui user_roles: ${text}`);
+  }
+  return res.json();
+}
+
 // Ambil komentar TikTok
 export async function getTikTokComments(token: string): Promise<any> {
   const url = `${API_BASE_URL}/api/tiktok/comments`;


### PR DESCRIPTION
## Summary
- update user_roles relation when a user's NRP/NIP is edited
- call new updateUserRoles API from user directory page to keep roles in sync

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b159475ca48327ad4f4a02265c5fcb