### PR TITLE
Limit rekap to DITBINMAS users

### DIFF
--- a/cicero-dashboard/app/users/page.jsx
+++ b/cicero-dashboard/app/users/page.jsx
@@ -75,13 +75,24 @@ export default function UserDirectoryPage() {
 
   const rekapUsers = useMemo(() => {
     const grouped = {};
-    users.forEach((u) => {
-      const key = u.divisi || "-";
-      if (!grouped[key]) grouped[key] = [];
-      grouped[key].push(u);
-    });
+    users
+      .filter((u) => !u.exception)
+      .filter((u) => {
+        if (isDitbinmasClient && !showAllDitbinmas) {
+          const cid = String(
+            u.client_id || u.clientId || u.clientID || u.client || "",
+          ).toUpperCase();
+          return cid === "DITBINMAS";
+        }
+        return true;
+      })
+      .forEach((u) => {
+        const key = u.divisi || "-";
+        if (!grouped[key]) grouped[key] = [];
+        grouped[key].push(u);
+      });
     return grouped;
-  }, [users]);
+  }, [users, isDitbinmasClient, showAllDitbinmas]);
 
   async function fetchUsers() {
     if (!token) {


### PR DESCRIPTION
## Summary
- filter rekap user results to only DITBINMAS when the Hanya DITBINMAS toggle is active

## Testing
- `cd cicero-dashboard && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b23f92d0108327affce32f41c2cea2