### PR TITLE
Add Ditbinmas Instagram likes recap helper

### DIFF
--- a/cicero-dashboard/app/likes/instagram/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/page.jsx
@@ -7,6 +7,7 @@ import {
   getClientNames,
   getUserDirectory,
 } from "@/utils/api";
+import { fetchDitbinmasAbsensiLikes } from "@/utils/absensiLikes";
 import Loader from "@/components/Loader";
 import ChartDivisiAbsensi from "@/components/ChartDivisiAbsensi";
 import ChartHorizontal from "@/components/ChartHorizontal";
@@ -89,6 +90,19 @@ export default function InstagramEngagementInsightPage() {
             : customDate;
         const { periode, date, startDate, endDate } =
           getPeriodeDateForView(viewBy, selectedDate);
+        if (isDitbinmas) {
+          const { users, summary } = await fetchDitbinmasAbsensiLikes(token, {
+            periode,
+            date,
+            startDate,
+            endDate,
+          });
+          setRekapSummary(summary);
+          setChartData(users);
+          setIsDirectorate(true);
+          return;
+        }
+
         const statsData = await getDashboardStats(
           token,
           periode,

--- a/cicero-dashboard/app/likes/instagram/rekap/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/rekap/page.jsx
@@ -7,6 +7,7 @@ import {
   getClientNames,
   getUserDirectory,
 } from "@/utils/api";
+import { fetchDitbinmasAbsensiLikes } from "@/utils/absensiLikes";
 import Loader from "@/components/Loader";
 import RekapLikesIG from "@/components/RekapLikesIG";
 import Link from "next/link";
@@ -80,6 +81,22 @@ export default function RekapLikesIGPage() {
             : customDate;
         const { periode, date, startDate, endDate } =
           getPeriodeDateForView(viewBy, selectedDate);
+        if (isDitbinmas) {
+          const { users, summary, posts, clientName } =
+            await fetchDitbinmasAbsensiLikes(token, {
+              periode,
+              date,
+              startDate,
+              endDate,
+            });
+          setRekapSummary(summary);
+          setChartData(users);
+          setIgPosts(posts);
+          setClientName(clientName);
+          setIsOrg(false);
+          return;
+        }
+
         const statsData = await getDashboardStats(
           token,
           periode,

--- a/cicero-dashboard/utils/absensiLikes.ts
+++ b/cicero-dashboard/utils/absensiLikes.ts
@@ -1,0 +1,146 @@
+import { getDashboardStats, getRekapLikesIG, getClientProfile, getClientNames, getUserDirectory } from "@/utils/api";
+
+function isException(val: any) {
+  return val === true || val === "true" || val === 1 || val === "1";
+}
+
+interface FetchParams {
+  periode: string;
+  date?: string;
+  startDate?: string;
+  endDate?: string;
+}
+
+export async function fetchDitbinmasAbsensiLikes(
+  token: string,
+  { periode, date, startDate, endDate }: FetchParams,
+) {
+  const clientId = "DITBINMAS";
+
+  const statsData = await getDashboardStats(
+    token,
+    periode,
+    date,
+    startDate,
+    endDate,
+    clientId,
+  );
+  const posts =
+    statsData.ig_posts ||
+    statsData.igPosts ||
+    statsData.instagram_posts ||
+    [];
+  const totalIGPost = Number(statsData.instagramPosts) || 0;
+
+  // gather user directory
+  const profileRes = await getClientProfile(token, clientId);
+  const profile = profileRes.client || profileRes.profile || profileRes || {};
+
+  const directoryRes = await getUserDirectory(token, clientId);
+  const dirData = directoryRes.data || directoryRes.users || directoryRes || [];
+  const expectedRole = clientId.toLowerCase();
+  const clientIds = Array.from(
+    new Set(
+      dirData
+        .filter(
+          (u: any) =>
+            String(
+              u.role || u.user_role || u.userRole || u.roleName || "",
+            ).toLowerCase() === expectedRole,
+        )
+        .map((u: any) =>
+          String(
+            u.client_id || u.clientId || u.clientID || u.client || "",
+          ),
+        )
+        .filter(Boolean),
+    ),
+  );
+  if (!clientIds.includes(clientId)) clientIds.push(clientId);
+
+  const rekapAll = await Promise.all(
+    clientIds.map((cid) =>
+      getRekapLikesIG(
+        token,
+        cid,
+        periode,
+        date,
+        startDate,
+        endDate,
+      ).catch(() => ({ data: [] })),
+    ),
+  );
+
+  let users = rekapAll.flatMap((res) =>
+    Array.isArray(res?.data)
+      ? res.data
+      : Array.isArray(res)
+      ? res
+      : [],
+  );
+
+  const nameMap = await getClientNames(
+    token,
+    users.map((u) =>
+      String(u.client_id || u.clientId || u.clientID || u.client || ""),
+    ),
+  );
+
+  users = users.map((u) => {
+    const clientName =
+      nameMap[
+        String(u.client_id || u.clientId || u.clientID || u.client || "")
+      ] ||
+      u.nama_client ||
+      u.client_name ||
+      u.client;
+    return { ...u, nama_client: clientName, client_name: clientName };
+  });
+
+  const totalUser = users.length;
+  const isZeroPost = totalIGPost === 0;
+  let totalSudahLike = 0;
+  let totalKurangLike = 0;
+  let totalBelumLike = 0;
+  let totalTanpaUsername = 0;
+
+  users.forEach((u: any) => {
+    const username = String(u.username || "").trim();
+    if (!username) {
+      totalTanpaUsername += 1;
+      return;
+    }
+    const jumlah = Number(u.jumlah_like) || 0;
+    if (isZeroPost) {
+      totalBelumLike += 1;
+      return;
+    }
+    if (isException(u.exception) || jumlah >= totalIGPost * 0.5) {
+      totalSudahLike += 1;
+    } else if (jumlah > 0) {
+      totalKurangLike += 1;
+    } else {
+      totalBelumLike += 1;
+    }
+  });
+
+  const summary = {
+    totalUser,
+    totalSudahLike,
+    totalKurangLike,
+    totalBelumLike,
+    totalTanpaUsername,
+    totalIGPost,
+  };
+
+  const clientName =
+    profile.nama ||
+    profile.nama_client ||
+    profile.client_name ||
+    profile.client ||
+    "";
+
+  return { users, summary, posts, clientName };
+}
+
+export default fetchDitbinmasAbsensiLikes;


### PR DESCRIPTION
## Summary
- support Ditbinmas role on likes pages using centralized absensi logic
- add helper to gather Ditbinmas Instagram like data and summary

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b26dd0d4e4832794bd29bfe701a9a8