### PR TITLE
fix: specify client ID string type

### DIFF
--- a/cicero-dashboard/utils/absensiLikes.ts
+++ b/cicero-dashboard/utils/absensiLikes.ts
@@ -39,8 +39,8 @@ export async function fetchDitbinmasAbsensiLikes(
   const directoryRes = await getUserDirectory(token, clientId);
   const dirData = directoryRes.data || directoryRes.users || directoryRes || [];
   const expectedRole = clientId.toLowerCase();
-  const clientIds = Array.from(
-    new Set(
+  const clientIds: string[] = Array.from(
+    new Set<string>(
       dirData
         .filter(
           (u: any) =>


### PR DESCRIPTION
## Summary
- ensure `clientIds` typed as string array when gathering user directory IDs

## Testing
- `npm test`
- `npm run build` *(fails: failed to fetch font file during `next/font`)*
- `npm run lint` *(fails: interactive ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68b26f630efc8327b53d89ee28c880ab