### PR TITLE
Fix date range payload for Instagram likes API

### DIFF
--- a/cicero-dashboard/__tests__/api.test.ts
+++ b/cicero-dashboard/__tests__/api.test.ts
@@ -19,8 +19,8 @@ test("getDashboardStats supports date range params", async () => {
   await getDashboardStats("token123", undefined, undefined, "2024-01-01", "2024-01-31");
   const call = (global.fetch as jest.Mock).mock.calls[0];
   expect(call[0]).toContain("/api/dashboard/stats");
-  expect(call[0]).toContain("start_date=2024-01-01");
-  expect(call[0]).toContain("end_date=2024-01-31");
+  expect(call[0]).toContain("tanggal_mulai=2024-01-01");
+  expect(call[0]).toContain("tanggal_selesai=2024-01-31");
   expect(call[1].headers.Authorization).toBe("Bearer token123");
 });
 
@@ -51,8 +51,8 @@ test("getRekapLikesIG supports date range params", async () => {
   );
   const url = (global.fetch as jest.Mock).mock.calls[0][0];
   expect(url).toContain("/api/insta/rekap-likes");
-  expect(url).toContain("start_date=2023-12-01");
-  expect(url).toContain("end_date=2023-12-31");
+  expect(url).toContain("tanggal_mulai=2023-12-01");
+  expect(url).toContain("tanggal_selesai=2023-12-31");
 });
 
 test("getRekapKomentarTiktok supports date range params", async () => {
@@ -86,15 +86,15 @@ test("getDashboardStats normalizes fields", async () => {
 test("getDashboardStats handles partial date range params", async () => {
   await getDashboardStats("tok", undefined, undefined, "2024-06-01");
   let url = (global.fetch as jest.Mock).mock.calls[0][0];
-  expect(url).toContain("start_date=2024-06-01");
-  expect(url).not.toContain("end_date");
+  expect(url).toContain("tanggal_mulai=2024-06-01");
+  expect(url).not.toContain("tanggal_selesai");
 
   (global.fetch as jest.Mock).mockClear();
 
   await getDashboardStats("tok", undefined, undefined, undefined, "2024-06-30");
   url = (global.fetch as jest.Mock).mock.calls[0][0];
-  expect(url).toContain("end_date=2024-06-30");
-  expect(url).not.toContain("start_date");
+  expect(url).toContain("tanggal_selesai=2024-06-30");
+  expect(url).not.toContain("tanggal_mulai");
 });
 
 test("getDashboardStats includes client_id when provided", async () => {

--- a/cicero-dashboard/utils/api.ts
+++ b/cicero-dashboard/utils/api.ts
@@ -48,8 +48,8 @@ export async function getDashboardStats(
   const params = new URLSearchParams();
   if (periode) params.append("periode", periode);
   if (tanggal) params.append("tanggal", tanggal);
-  if (startDate) params.append("start_date", startDate);
-  if (endDate) params.append("end_date", endDate);
+  if (startDate) params.append("tanggal_mulai", startDate);
+  if (endDate) params.append("tanggal_selesai", endDate);
   if (client_id) params.append("client_id", client_id);
   const url = `${API_BASE_URL}/api/dashboard/stats${
     params.toString() ? `?${params.toString()}` : ""
@@ -82,8 +82,8 @@ export async function getRekapLikesIG(
 ): Promise<any> {
   const params = new URLSearchParams({ client_id, periode });
   if (tanggal) params.append("tanggal", tanggal);
-  if (startDate) params.append("start_date", startDate);
-  if (endDate) params.append("end_date", endDate);
+  if (startDate) params.append("tanggal_mulai", startDate);
+  if (endDate) params.append("tanggal_selesai", endDate);
   const url = `${API_BASE_URL}/api/insta/rekap-likes?${params.toString()}`;
 
   const res = await fetchWithAuth(url, token);


### PR DESCRIPTION
## Summary
- use `tanggal_mulai` and `tanggal_selesai` query params for `getDashboardStats`
- use `tanggal_mulai` and `tanggal_selesai` in `getRekapLikesIG`
- update API tests for new parameter names

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b272a1fb60832794f4c4c832bb4f7d