### PR TITLE
Handle Ditbinmas likes without client filter

### DIFF
--- a/cicero-dashboard/__tests__/api.test.ts
+++ b/cicero-dashboard/__tests__/api.test.ts
@@ -55,6 +55,20 @@ test("getRekapLikesIG supports date range params", async () => {
   expect(url).toContain("tanggal_selesai=2023-12-31");
 });
 
+test("getRekapLikesIG supports user_role param", async () => {
+  await getRekapLikesIG(
+    "tok",
+    undefined,
+    "harian",
+    undefined,
+    undefined,
+    undefined,
+    "ditbinmas",
+  );
+  const url = (global.fetch as jest.Mock).mock.calls[0][0];
+  expect(url).toContain("user_role=ditbinmas");
+});
+
 test("getRekapKomentarTiktok supports date range params", async () => {
   await getRekapKomentarTiktok(
     "tok",

--- a/cicero-dashboard/utils/absensiLikes.ts
+++ b/cicero-dashboard/utils/absensiLikes.ts
@@ -1,4 +1,4 @@
-import { getDashboardStats, getRekapLikesIG, getClientProfile, getClientNames, getUserDirectory } from "@/utils/api";
+import { getDashboardStats, getRekapLikesIG, getClientProfile, getClientNames } from "@/utils/api";
 
 function isException(val: any) {
   return val === true || val === "true" || val === 1 || val === "1";
@@ -32,51 +32,30 @@ export async function fetchDitbinmasAbsensiLikes(
     [];
   const totalIGPost = Number(statsData.instagramPosts) || 0;
 
-  // gather user directory
   const profileRes = await getClientProfile(token, clientId);
   const profile = profileRes.client || profileRes.profile || profileRes || {};
 
-  const directoryRes = await getUserDirectory(token, clientId);
-  const dirData = directoryRes.data || directoryRes.users || directoryRes || [];
-  const expectedRole = clientId.toLowerCase();
-  const clientIds: string[] = Array.from(
-    new Set<string>(
-      dirData
-        .filter(
-          (u: any) =>
-            String(
-              u.role || u.user_role || u.userRole || u.roleName || "",
-            ).toLowerCase() === expectedRole,
-        )
-        .map((u: any) =>
-          String(
-            u.client_id || u.clientId || u.clientID || u.client || "",
-          ),
-        )
-        .filter(Boolean),
-    ),
-  );
-  if (!clientIds.includes(clientId)) clientIds.push(clientId);
+  const rekapRes = await getRekapLikesIG(
+    token,
+    undefined,
+    periode,
+    date,
+    startDate,
+    endDate,
+    "ditbinmas",
+  ).catch(() => ({ data: [] }));
 
-  const rekapAll = await Promise.all(
-    clientIds.map((cid) =>
-      getRekapLikesIG(
-        token,
-        cid,
-        periode,
-        date,
-        startDate,
-        endDate,
-      ).catch(() => ({ data: [] })),
-    ),
-  );
+  let users = Array.isArray(rekapRes?.data)
+    ? rekapRes.data
+    : Array.isArray(rekapRes)
+    ? rekapRes
+    : [];
 
-  let users = rekapAll.flatMap((res) =>
-    Array.isArray(res?.data)
-      ? res.data
-      : Array.isArray(res)
-      ? res
-      : [],
+  users = users.filter(
+    (u: any) =>
+      String(
+        u.role || u.user_role || u.userRole || u.roleName || "",
+      ).toLowerCase() === "ditbinmas",
   );
 
   const nameMap = await getClientNames(

--- a/cicero-dashboard/utils/api.ts
+++ b/cicero-dashboard/utils/api.ts
@@ -74,16 +74,19 @@ export async function getDashboardStats(
 // Ambil rekap absensi instagram harian
 export async function getRekapLikesIG(
   token: string,
-  client_id: string,
+  client_id?: string,
   periode: string = "harian",
   tanggal?: string,
   startDate?: string,
-  endDate?: string
+  endDate?: string,
+  role?: string,
 ): Promise<any> {
-  const params = new URLSearchParams({ client_id, periode });
+  const params = new URLSearchParams({ periode });
+  if (client_id) params.append("client_id", client_id);
   if (tanggal) params.append("tanggal", tanggal);
   if (startDate) params.append("tanggal_mulai", startDate);
   if (endDate) params.append("tanggal_selesai", endDate);
+  if (role) params.append("user_role", role);
   const url = `${API_BASE_URL}/api/insta/rekap-likes?${params.toString()}`;
 
   const res = await fetchWithAuth(url, token);


### PR DESCRIPTION
## Summary
- allow optional `user_role` and `client_id` when fetching Instagram likes
- collect Ditbinmas likes without client filter and limit users to role `ditbinmas`
- cover new API option with unit test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4004b6d988327a7e15588588a8413