### PR TITLE
fix: add explicit any type for map callbacks

### DIFF
--- a/cicero-dashboard/utils/absensiLikes.ts
+++ b/cicero-dashboard/utils/absensiLikes.ts
@@ -60,12 +60,12 @@ export async function fetchDitbinmasAbsensiLikes(
 
   const nameMap = await getClientNames(
     token,
-    users.map((u) =>
+    users.map((u: any) =>
       String(u.client_id || u.clientId || u.clientID || u.client || ""),
     ),
   );
 
-  users = users.map((u) => {
+  users = users.map((u: any) => {
     const clientName =
       nameMap[
         String(u.client_id || u.clientId || u.clientID || u.client || "")


### PR DESCRIPTION
## Summary
- explicitly type user parameter in map callbacks to avoid implicit any in absensiLikes util

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4068bc9508327a3cc50ecbecdd375