### PR TITLE
Enable rekap actions on Instagram likes recap page for all users

### DIFF
--- a/cicero-dashboard/app/likes/instagram/rekap/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/rekap/page.jsx
@@ -43,7 +43,6 @@ export default function RekapLikesIGPage() {
   });
 
   const [igPosts, setIgPosts] = useState([]);
-  const [isOrg, setIsOrg] = useState(false);
   const [clientName, setClientName] = useState("");
 
   const viewOptions = VIEW_OPTIONS;
@@ -93,7 +92,6 @@ export default function RekapLikesIGPage() {
           setChartData(users);
           setIgPosts(posts);
           setClientName(clientName);
-          setIsOrg(false);
           return;
         }
 
@@ -120,10 +118,6 @@ export default function RekapLikesIGPage() {
           profileRes.client || profileRes.profile || profileRes || {};
         const dir =
           (profile.client_type || "").toUpperCase() === "DIREKTORAT";
-        setIsOrg(
-          (profile.client_type || profile.clientType || "")
-            .toUpperCase() === "ORG",
-        );
         setClientName(
           profile.nama ||
             profile.nama_client ||
@@ -319,7 +313,7 @@ export default function RekapLikesIGPage() {
             users={chartData}
             totalIGPost={rekapSummary.totalIGPost}
             posts={igPosts}
-            showRekapButton={isOrg}
+            showRekapButton
             clientName={clientName}
           />
         </div>


### PR DESCRIPTION
## Summary
- Always show download and copy rekap buttons on Instagram likes recap page
- Remove ORG-only gating

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68b43c14215483278fab9bca56022a27