### PR TITLE
feat: show rekap button in instagram recap

### DIFF
--- a/cicero-dashboard/app/likes/instagram/rekap/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/rekap/page.jsx
@@ -313,7 +313,7 @@ export default function RekapLikesIGPage() {
               users={chartData}
               totalIGPost={rekapSummary.totalIGPost}
               posts={igPosts}
-              showRekapButton={true}
+              showRekapButton
               clientName={clientName}
             />
           </div>

--- a/cicero-dashboard/components/RekapLikesIG.jsx
+++ b/cicero-dashboard/components/RekapLikesIG.jsx
@@ -22,7 +22,8 @@ export default function RekapLikesIG({
   users = [],
   totalIGPost = 0,
   posts = [],
-  showRekapButton = false,
+  // tampilkan tombol rekap secara default
+  showRekapButton = true,
   clientName = "",
 }) {
   const totalUser = users.length;


### PR DESCRIPTION
## Summary
- display Rekap button by default in Instagram recap component
- simplify prop usage on Rekapitulasi Likes IG page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b441f30d308327b73c23df3de74800