### PR TITLE
feat: add rekap button to Instagram likes summary

### DIFF
--- a/cicero-dashboard/app/likes/instagram/rekap/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/rekap/page.jsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import {
   getDashboardStats,
   getRekapLikesIG,
@@ -44,6 +44,7 @@ export default function RekapLikesIGPage() {
 
   const [igPosts, setIgPosts] = useState([]);
   const [clientName, setClientName] = useState("");
+  const rekapRef = useRef(null);
 
   const viewOptions = VIEW_OPTIONS;
 
@@ -288,7 +289,13 @@ export default function RekapLikesIGPage() {
               Kembali
             </Link>
           </div>
-          <div className="flex items-center justify-end gap-3 mb-2">
+          <div className="flex flex-wrap items-center justify-end gap-3 mb-2">
+            <button
+              onClick={() => rekapRef.current?.copyRekap()}
+              className="px-3 py-2 bg-green-600 hover:bg-green-700 text-white rounded-lg text-sm"
+            >
+              Rekap Likes
+            </button>
             <ViewDataSelector
               value={viewBy}
               onChange={setViewBy}
@@ -310,6 +317,7 @@ export default function RekapLikesIGPage() {
 
           {/* Kirim data dari fetch ke komponen rekap likes */}
             <RekapLikesIG
+              ref={rekapRef}
               users={chartData}
               totalIGPost={rekapSummary.totalIGPost}
               posts={igPosts}

--- a/cicero-dashboard/components/RekapLikesIG.jsx
+++ b/cicero-dashboard/components/RekapLikesIG.jsx
@@ -1,5 +1,11 @@
 "use client";
-import { useMemo, useEffect, useState } from "react";
+import {
+  useMemo,
+  useEffect,
+  useState,
+  forwardRef,
+  useImperativeHandle,
+} from "react";
 import usePersistentState from "@/hooks/usePersistentState";
 import { Camera, Users, Check, X, AlertTriangle, UserX } from "lucide-react";
 
@@ -18,14 +24,17 @@ const PAGE_SIZE = 25;
  * @param {boolean} showRekapButton - tampilkan tombol salin rekap jika true
  * @param {string} clientName - nama client ORG
  */
-export default function RekapLikesIG({
-  users = [],
-  totalIGPost = 0,
-  posts = [],
-  // tampilkan tombol rekap secara default
-  showRekapButton = true,
-  clientName = "",
-}) {
+const RekapLikesIG = forwardRef(function RekapLikesIG(
+  {
+    users = [],
+    totalIGPost = 0,
+    posts = [],
+    // tampilkan tombol rekap secara default
+    showRekapButton = true,
+    clientName = "",
+  },
+  ref,
+) {
   const totalUser = users.length;
   const hasClient = useMemo(
     () => users.some((u) => u.nama_client || u.client_name || u.client),
@@ -279,6 +288,11 @@ export default function RekapLikesIG({
     URL.revokeObjectURL(url);
   }
 
+  useImperativeHandle(ref, () => ({
+    copyRekap: handleCopyRekap,
+    downloadRekap: handleDownloadRekap,
+  }));
+
   return (
     <div className="flex flex-col gap-6 mt-8 min-h-screen">
       {/* Ringkasan */}
@@ -456,7 +470,9 @@ export default function RekapLikesIG({
       )}
     </div>
   );
-}
+});
+
+export default RekapLikesIG;
 
 // Semua card mengikuti style IG Post Hari Ini
 function SummaryCard({ title, value, color, icon }) {


### PR DESCRIPTION
## Summary
- expose copy & download handlers from RekapLikesIG component via forwardRef
- add top-level Rekap Likes button on Instagram likes rekap page

## Testing
- `npm test`
- `npm run lint` *(fails: requires interactive configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b44435722c8327a6a7ed09d9f61af4