### PR TITLE
Prioritize senior officers and enhance IG recap

### DIFF
--- a/cicero-dashboard/app/users/page.jsx
+++ b/cicero-dashboard/app/users/page.jsx
@@ -303,9 +303,20 @@ export default function UserDirectoryPage() {
     [users, search, isDitbinmasClient, showAllDitbinmas],
   );
 
-  // Paging logic
-  const totalPages = Math.ceil(filtered.length / PAGE_SIZE);
-  const currentRows = filtered.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
+  // Urutkan sehingga pangkat KOMBES POL dan AKBP berada di atas
+  const sorted = useMemo(() => {
+    const rank = (u) => {
+      const t = String(u.title || "").toUpperCase();
+      if (t.includes("KOMBES POL")) return 0;
+      if (t.includes("AKBP")) return 1;
+      return 2;
+    };
+    return [...filtered].sort((a, b) => rank(a) - rank(b));
+  }, [filtered]);
+
+  // Paging logic menggunakan data yang sudah diurutkan
+  const totalPages = Math.ceil(sorted.length / PAGE_SIZE);
+  const currentRows = sorted.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
 
   // Reset ke halaman 1 saat search berubah
   useEffect(() => setPage(1), [search, setPage]);


### PR DESCRIPTION
## Summary
- Ensure users with ranks **KOMBES POL** and **AKBP** are shown first in the User Directory
- Sort Instagram recap tables so senior officers appear on top and expand download recap to include users without usernames

## Testing
- `npm test --prefix cicero-dashboard`
- `npm run lint --prefix cicero-dashboard` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b44cbea530832788b8f6118309a906