### PR TITLE
Sort users by rank and NRP/NIP

### DIFF
--- a/cicero-dashboard/utils/pangkat.ts
+++ b/cicero-dashboard/utils/pangkat.ts
@@ -1,0 +1,32 @@
+export const PANGKAT_ORDER = [
+  "KOMISARIS BESAR POLISI",
+  "AKBP",
+  "KOMPOL",
+  "AKP",
+  "IPTU",
+  "IPDA",
+  "AIPTU",
+  "AIPDA",
+  "BRIPKA",
+  "BRIGADIR",
+  "BRIPTU",
+  "BRIPDA",
+];
+
+export function getPangkatRank(title?: string): number {
+  const t = String(title || "").toUpperCase();
+  const index = PANGKAT_ORDER.findIndex((p) => t.includes(p));
+  return index === -1 ? PANGKAT_ORDER.length : index;
+}
+
+export function compareUsersByPangkatAndNrp(a: any, b: any): number {
+  const rankDiff = getPangkatRank(a.title) - getPangkatRank(b.title);
+  if (rankDiff !== 0) return rankDiff;
+  const aId = String(
+    a.user_id || a.userId || a.nrp || a.nip || a.nrp_nip || "",
+  );
+  const bId = String(
+    b.user_id || b.userId || b.nrp || b.nip || b.nrp_nip || "",
+  );
+  return aId.localeCompare(bId);
+}


### PR DESCRIPTION
## Summary
- order ranks using police hierarchy and fall back to NRP/NIP for ties
- apply consistent rank/NRP sorting to User Directory and IG likes rekap pages
- add shared utility for rank comparison

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4e51e19a48327b3f08a8c05db229d