### PR TITLE
feat: add claim flow with OTP

### DIFF
--- a/cicero-dashboard/app/claim/edit/page.jsx
+++ b/cicero-dashboard/app/claim/edit/page.jsx
@@ -1,0 +1,209 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { getUserById, updateUserViaClaim } from "@/utils/api";
+
+function isValidInstagram(url) {
+  if (!url) return true;
+  return /^https?:\/\/(www\.)?instagram\.com\/[A-Za-z0-9._-]+\/?$/.test(url);
+}
+
+function isValidTiktok(url) {
+  if (!url) return true;
+  return /^https?:\/\/(www\.)?tiktok\.com\/@[A-Za-z0-9._-]+\/?$/.test(url);
+}
+
+export default function EditUserPage() {
+  const [nrp, setNrp] = useState("");
+  const [whatsapp, setWhatsapp] = useState("");
+  const [kesatuan, setKesatuan] = useState("");
+  const [nama, setNama] = useState("");
+  const [pangkat, setPangkat] = useState("");
+  const [satfung, setSatfung] = useState("");
+  const [jabatan, setJabatan] = useState("");
+  const [desa, setDesa] = useState("");
+  const [insta, setInsta] = useState("");
+  const [tiktok, setTiktok] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [message, setMessage] = useState("");
+  const router = useRouter();
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const n = sessionStorage.getItem("claim_nrp");
+      const w = sessionStorage.getItem("claim_whatsapp");
+      if (!n || !w) {
+        router.replace("/claim");
+        return;
+      }
+      setNrp(n);
+      setWhatsapp(w);
+      loadUser(n);
+    }
+  }, [router]);
+
+  async function loadUser(n) {
+    try {
+      const res = await getUserById(n);
+      const user = res.data || res.user || res;
+      setKesatuan(
+        user.nama_client || user.client_name || user.client_id || ""
+      );
+      setNama(user.nama || "");
+      setPangkat(user.title || "");
+      setSatfung(user.divisi || "");
+      setJabatan(user.jabatan || "");
+      setDesa(user.desa || "");
+      setInsta(user.insta || "");
+      setTiktok(user.tiktok || "");
+    } catch (err) {
+      setError("Gagal mengambil data user");
+    }
+  }
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    setError("");
+    setMessage("");
+    if (!isValidInstagram(insta)) {
+      setError("Link Instagram tidak valid");
+      return;
+    }
+    if (!isValidTiktok(tiktok)) {
+      setError("Link TikTok tidak valid");
+      return;
+    }
+    setLoading(true);
+    try {
+      const res = await updateUserViaClaim({
+        nrp,
+        whatsapp,
+        nama: nama.trim(),
+        title: pangkat.trim(),
+        divisi: satfung.trim(),
+        jabatan: jabatan.trim(),
+        desa: desa.trim(),
+        insta: insta.trim(),
+        tiktok: tiktok.trim(),
+      });
+      if (res.success) {
+        setMessage("Data berhasil diperbarui");
+      } else {
+        setError(res.message || "Gagal memperbarui data");
+      }
+    } catch (err) {
+      setError("Gagal terhubung ke server");
+    }
+    setLoading(false);
+  }
+
+  return (
+    <main className="min-h-screen flex items-center justify-center bg-slate-100 p-4">
+      <form
+        onSubmit={handleSubmit}
+        className="bg-white p-6 rounded-2xl shadow-md w-full max-w-md"
+      >
+        <h2 className="text-xl font-semibold text-center mb-4">
+          Edit Data User
+        </h2>
+        {error && (
+          <p className="mb-2 text-red-500 text-sm text-center">{error}</p>
+        )}
+        {message && (
+          <p className="mb-2 text-green-600 text-sm text-center">{message}</p>
+        )}
+        <div className="mb-3">
+          <label className="block text-sm mb-1">Kesatuan</label>
+          <input
+            type="text"
+            value={kesatuan}
+            readOnly
+            className="w-full px-3 py-2 rounded-md border border-gray-300 bg-gray-100"
+          />
+        </div>
+        <div className="mb-3">
+          <label className="block text-sm mb-1">Nama</label>
+          <input
+            type="text"
+            value={nama}
+            onChange={(e) => setNama(e.target.value)}
+            className="w-full px-3 py-2 rounded-md border border-gray-300 focus:outline-none focus:border-blue-400"
+            required
+          />
+        </div>
+        <div className="mb-3">
+          <label className="block text-sm mb-1">Pangkat</label>
+          <input
+            type="text"
+            value={pangkat}
+            onChange={(e) => setPangkat(e.target.value)}
+            className="w-full px-3 py-2 rounded-md border border-gray-300 focus:outline-none focus:border-blue-400"
+          />
+        </div>
+        <div className="mb-3">
+          <label className="block text-sm mb-1">NRP</label>
+          <input
+            type="text"
+            value={nrp}
+            readOnly
+            className="w-full px-3 py-2 rounded-md border border-gray-300 bg-gray-100"
+          />
+        </div>
+        <div className="mb-3">
+          <label className="block text-sm mb-1">Satfung</label>
+          <input
+            type="text"
+            value={satfung}
+            onChange={(e) => setSatfung(e.target.value)}
+            className="w-full px-3 py-2 rounded-md border border-gray-300 focus:outline-none focus:border-blue-400"
+          />
+        </div>
+        <div className="mb-3">
+          <label className="block text-sm mb-1">Jabatan</label>
+          <input
+            type="text"
+            value={jabatan}
+            onChange={(e) => setJabatan(e.target.value)}
+            className="w-full px-3 py-2 rounded-md border border-gray-300 focus:outline-none focus:border-blue-400"
+          />
+        </div>
+        <div className="mb-3">
+          <label className="block text-sm mb-1">Desa Binaan</label>
+          <input
+            type="text"
+            value={desa}
+            onChange={(e) => setDesa(e.target.value)}
+            className="w-full px-3 py-2 rounded-md border border-gray-300 focus:outline-none focus:border-blue-400"
+          />
+        </div>
+        <div className="mb-3">
+          <label className="block text-sm mb-1">Link Profile Instagram</label>
+          <input
+            type="url"
+            value={insta}
+            onChange={(e) => setInsta(e.target.value)}
+            className="w-full px-3 py-2 rounded-md border border-gray-300 focus:outline-none focus:border-blue-400"
+          />
+        </div>
+        <div className="mb-4">
+          <label className="block text-sm mb-1">Link Profile TikTok</label>
+          <input
+            type="url"
+            value={tiktok}
+            onChange={(e) => setTiktok(e.target.value)}
+            className="w-full px-3 py-2 rounded-md border border-gray-300 focus:outline-none focus:border-blue-400"
+          />
+        </div>
+        <button
+          type="submit"
+          disabled={loading}
+          className="w-full bg-blue-600 text-white py-2 rounded-md hover:bg-blue-700 disabled:opacity-50"
+        >
+          {loading ? "Menyimpan..." : "Simpan"}
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/cicero-dashboard/app/claim/otp/page.jsx
+++ b/cicero-dashboard/app/claim/otp/page.jsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { verifyClaimOtp } from "@/utils/api";
+
+export default function OtpPage() {
+  const [nrp, setNrp] = useState("");
+  const [whatsapp, setWhatsapp] = useState("");
+  const [otp, setOtp] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+  const router = useRouter();
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const n = sessionStorage.getItem("claim_nrp");
+      const w = sessionStorage.getItem("claim_whatsapp");
+      if (!n || !w) {
+        router.replace("/claim");
+      } else {
+        setNrp(n);
+        setWhatsapp(w);
+      }
+    }
+  }, [router]);
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    setError("");
+    setLoading(true);
+    try {
+      const res = await verifyClaimOtp(nrp, whatsapp, otp.trim());
+      if (res.success && res.verified) {
+        router.push("/claim/edit");
+      } else {
+        setError(res.message || "OTP tidak valid");
+      }
+    } catch (err) {
+      setError("Gagal terhubung ke server");
+    }
+    setLoading(false);
+  }
+
+  return (
+    <main className="min-h-screen flex items-center justify-center bg-slate-100 p-4">
+      <form
+        onSubmit={handleSubmit}
+        className="bg-white p-6 rounded-2xl shadow-md w-full max-w-sm"
+      >
+        <h2 className="text-xl font-semibold text-center mb-4">Verifikasi OTP</h2>
+        {error && (
+          <p className="mb-2 text-red-500 text-sm text-center">{error}</p>
+        )}
+        <div className="mb-4">
+          <label htmlFor="otp" className="sr-only">
+            OTP
+          </label>
+          <input
+            id="otp"
+            type="text"
+            placeholder="Masukkan OTP"
+            value={otp}
+            onChange={(e) => setOtp(e.target.value)}
+            required
+            className="w-full px-3 py-2 rounded-md border border-gray-300 focus:outline-none focus:border-blue-400"
+          />
+        </div>
+        <button
+          type="submit"
+          disabled={loading}
+          className="w-full bg-blue-600 text-white py-2 rounded-md hover:bg-blue-700 disabled:opacity-50"
+        >
+          {loading ? "Memverifikasi..." : "Verifikasi"}
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/cicero-dashboard/app/claim/page.jsx
+++ b/cicero-dashboard/app/claim/page.jsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { requestClaimOtp } from "@/utils/api";
+
+export default function ClaimPage() {
+  const [nrp, setNrp] = useState("");
+  const [whatsapp, setWhatsapp] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+  const router = useRouter();
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    setError("");
+    setLoading(true);
+    try {
+      const res = await requestClaimOtp(nrp.trim(), whatsapp.trim());
+      if (res.success) {
+        if (typeof window !== "undefined") {
+          sessionStorage.setItem("claim_nrp", nrp.trim());
+          sessionStorage.setItem("claim_whatsapp", whatsapp.trim());
+        }
+        router.push("/claim/otp");
+      } else {
+        setError(res.message || "Gagal mengirim OTP");
+      }
+    } catch (err) {
+      setError("Gagal terhubung ke server");
+    }
+    setLoading(false);
+  }
+
+  return (
+    <main className="min-h-screen flex items-center justify-center bg-slate-100 p-4">
+      <form
+        onSubmit={handleSubmit}
+        className="bg-white p-6 rounded-2xl shadow-md w-full max-w-sm"
+      >
+        <h2 className="text-xl font-semibold text-center mb-4">
+          Klaim &amp; Edit Data User
+        </h2>
+        {error && (
+          <p className="mb-2 text-red-500 text-sm text-center">{error}</p>
+        )}
+        <div className="mb-4">
+          <label htmlFor="nrp" className="sr-only">
+            NRP
+          </label>
+          <input
+            id="nrp"
+            type="text"
+            placeholder="NRP"
+            value={nrp}
+            onChange={(e) => setNrp(e.target.value)}
+            required
+            className="w-full px-3 py-2 rounded-md border border-gray-300 focus:outline-none focus:border-blue-400"
+          />
+        </div>
+        <div className="mb-4">
+          <label htmlFor="wa" className="sr-only">
+            Nomor WhatsApp
+          </label>
+          <input
+            id="wa"
+            type="tel"
+            placeholder="Nomor WhatsApp"
+            value={whatsapp}
+            onChange={(e) => setWhatsapp(e.target.value)}
+            required
+            className="w-full px-3 py-2 rounded-md border border-gray-300 focus:outline-none focus:border-blue-400"
+          />
+        </div>
+        <button
+          type="submit"
+          disabled={loading}
+          className="w-full bg-blue-600 text-white py-2 rounded-md hover:bg-blue-700 disabled:opacity-50"
+        >
+          {loading ? "Mengirim..." : "Kirim OTP"}
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/cicero-dashboard/utils/api.ts
+++ b/cicero-dashboard/utils/api.ts
@@ -501,3 +501,68 @@ export async function getTiktokPosts(token: string, client_id: string): Promise<
   return res.json();
 }
 
+// === Claim & User Update without auth token ===
+
+// Fetch user data by NRP without requiring auth
+export async function getUserById(nrp: string): Promise<any> {
+  const url = `${API_BASE_URL}/api/users/${encodeURIComponent(nrp)}`;
+  const res = await fetch(url);
+  if (!res.ok) throw new Error("Failed to fetch user");
+  return res.json();
+}
+
+// Request OTP to be sent via WhatsApp
+export async function requestClaimOtp(
+  nrp: string,
+  whatsapp: string,
+): Promise<any> {
+  const url = `${API_BASE_URL}/api/claim/request-otp`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ nrp, whatsapp }),
+  });
+  if (!res.ok) throw new Error("Failed to request OTP");
+  return res.json();
+}
+
+// Verify OTP provided by user
+export async function verifyClaimOtp(
+  nrp: string,
+  whatsapp: string,
+  otp: string,
+): Promise<any> {
+  const url = `${API_BASE_URL}/api/claim/verify-otp`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ nrp, whatsapp, otp }),
+  });
+  if (!res.ok) throw new Error("Failed to verify OTP");
+  return res.json();
+}
+
+// Update user data after OTP verification
+export async function updateUserViaClaim(
+  data: {
+    nrp: string;
+    whatsapp: string;
+    nama?: string;
+    title?: string;
+    divisi?: string;
+    jabatan?: string;
+    desa?: string;
+    insta?: string;
+    tiktok?: string;
+  },
+): Promise<any> {
+  const url = `${API_BASE_URL}/api/claim/update`;
+  const res = await fetch(url, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw new Error("Failed to update user");
+  return res.json();
+}
+


### PR DESCRIPTION
## Summary
- add claim page to request OTP using NRP and WhatsApp
- add OTP verification and user data edit forms with Instagram/TikTok link validation
- expose API helpers for claim flow

## Testing
- `npm test`
- `npm run lint` *(fails: requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_68b6d270cbac8327bebf6418f86bf71d