### PR TITLE
feat: expose claim pages from dashboard layout

### DIFF
--- a/cicero-dashboard/components/LayoutClient.tsx
+++ b/cicero-dashboard/components/LayoutClient.tsx
@@ -5,9 +5,11 @@ import Header from "./Header";
 
 export default function LayoutClient({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
+  const isStandalone =
+    pathname === "/" || pathname.startsWith("/login") || pathname.startsWith("/claim");
 
-  // Landing and login pages render without sidebar or header
-  if (pathname === "/" || pathname === "/login") {
+  // Landing, login, and claim-related pages render without sidebar or header
+  if (isStandalone) {
     return (
       <main id="main-content" className="min-h-screen">
         {children}


### PR DESCRIPTION
## Summary
- avoid rendering claim pages inside dashboard layout
- treat claim, login, and landing pages as standalone views

## Testing
- `npm test`
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68b6d657a800832789c407f7ac3d9460