### PR TITLE
Normalize WhatsApp numbers and fix OTP verification

### DIFF
--- a/cicero-dashboard/app/claim/otp/page.jsx
+++ b/cicero-dashboard/app/claim/otp/page.jsx
@@ -31,7 +31,8 @@ export default function OtpPage() {
     setLoading(true);
     try {
       const res = await verifyClaimOtp(nrp, whatsapp, otp.trim());
-      if (res.success && res.verified) {
+      const verified = res.verified ?? res.data?.verified;
+      if (res.success && verified) {
         router.push("/claim/edit");
       } else {
         setError(res.message || "OTP tidak valid");

--- a/cicero-dashboard/app/claim/page.jsx
+++ b/cicero-dashboard/app/claim/page.jsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { requestClaimOtp } from "@/utils/api";
+import { requestClaimOtp, normalizeWhatsapp } from "@/utils/api";
 
 export default function ClaimPage() {
   const [nrp, setNrp] = useState("");
@@ -16,11 +16,12 @@ export default function ClaimPage() {
     setError("");
     setLoading(true);
     try {
-      const res = await requestClaimOtp(nrp.trim(), whatsapp.trim());
+      const normalizedWhatsapp = normalizeWhatsapp(whatsapp);
+      const res = await requestClaimOtp(nrp.trim(), normalizedWhatsapp);
       if (res.success) {
         if (typeof window !== "undefined") {
           sessionStorage.setItem("claim_nrp", nrp.trim());
-          sessionStorage.setItem("claim_whatsapp", whatsapp.trim());
+          sessionStorage.setItem("claim_whatsapp", normalizedWhatsapp);
         }
         router.push("/claim/otp");
       } else {

--- a/cicero-dashboard/app/login/page.jsx
+++ b/cicero-dashboard/app/login/page.jsx
@@ -6,6 +6,7 @@ import { Eye, EyeOff } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/context/AuthContext";
 import DarkModeToggle from "@/components/DarkModeToggle";
+import { normalizeWhatsapp } from "@/utils/api";
 
 export default function LoginPage() {
   useAuthRedirect(); // Akan redirect ke /dashboard jika sudah login
@@ -82,10 +83,10 @@ export default function LoginPage() {
 
     try {
       const apiUrl = process.env.NEXT_PUBLIC_API_URL || "";
-      const trimmedUsername = username.trim();
-      const trimmedRole = role.trim();
-      const trimmedClientId = client_id.trim();
-      const trimmedWhatsapp = whatsapp.trim();
+    const trimmedUsername = username.trim();
+    const trimmedRole = role.trim();
+    const trimmedClientId = client_id.trim();
+    const normalizedWhatsapp = normalizeWhatsapp(whatsapp);
       const res = await fetch(`${apiUrl}/api/auth/dashboard-register`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -94,7 +95,7 @@ export default function LoginPage() {
           password: trimmedPassword,
           role: trimmedRole ? trimmedRole.toLowerCase() : undefined,
           client_id: trimmedClientId || undefined,
-          whatsapp: trimmedWhatsapp,
+          whatsapp: normalizedWhatsapp,
         }),
       });
       const data = await res.json();


### PR DESCRIPTION
## Summary
- Normalize WhatsApp numbers by converting leading 0 to 62
- Ensure OTP request/verification uses normalized numbers and surface verification result correctly
- Apply normalization when registering users

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b6dd9241ec83278a436e17b0e6efd5