### PR TITLE
Sort Instagram engagement charts by like percentage

### DIFF
--- a/cicero-dashboard/app/likes/instagram/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/page.jsx
@@ -364,6 +364,7 @@ export default function InstagramEngagementInsightPage() {
                 totalPost={rekapSummary.totalIGPost}
                 groupBy="client_id"
                 orientation="horizontal"
+                sortBy="percentage"
               />
             ) : (
               <div className="flex flex-col gap-6">
@@ -372,30 +373,35 @@ export default function InstagramEngagementInsightPage() {
                   users={kelompok.BAG}
                   totalPost={rekapSummary.totalIGPost}
                   narrative="Grafik ini menunjukkan perbandingan jumlah like dari user di divisi BAG."
+                  sortBy="percentage"
                 />
                 <ChartBox
                   title="SAT"
                   users={kelompok.SAT}
                   totalPost={rekapSummary.totalIGPost}
                   narrative="Grafik ini menunjukkan perbandingan jumlah like dari user di divisi SAT."
+                  sortBy="percentage"
                 />
                 <ChartBox
                   title="SI & SPKT"
                   users={kelompok["SI & SPKT"]}
                   totalPost={rekapSummary.totalIGPost}
                   narrative="Grafik ini menunjukkan perbandingan jumlah like dari user di divisi SI & SPKT."
+                  sortBy="percentage"
                 />
                 <ChartBox
                   title="LAINNYA"
                   users={kelompok.LAINNYA}
                   totalPost={rekapSummary.totalIGPost}
                   narrative="Grafik ini menunjukkan perbandingan jumlah like dari user di divisi lainnya."
+                  sortBy="percentage"
                 />
                 <ChartHorizontal
                   title="POLSEK"
                   users={kelompok.POLSEK}
                   totalPost={rekapSummary.totalIGPost}
                   showTotalUser
+                  sortBy="percentage"
                 />
                 <Narrative>
                   Grafik POLSEK memperlihatkan jumlah like Instagram dari setiap
@@ -428,6 +434,7 @@ function ChartBox({
   totalPost,
   narrative,
   groupBy,
+  sortBy,
 }) {
   return (
     <div className="bg-white rounded-xl shadow p-4">
@@ -445,6 +452,7 @@ function ChartBox({
           groupBy={groupBy}
           showTotalUser
           labelTotalUser="Jumlah User"
+          sortBy={sortBy}
         />
       ) : (
         <div className="text-center text-gray-400 text-sm">Tidak ada data</div>

--- a/cicero-dashboard/components/ChartDivisiAbsensi.jsx
+++ b/cicero-dashboard/components/ChartDivisiAbsensi.jsx
@@ -40,6 +40,7 @@ export default function ChartDivisiAbsensi({
   orientation = "vertical",
   showTotalUser = false,
   labelTotalUser = "Jumlah User",
+  sortBy = "total_value",
 }) {
   const [enrichedUsers, setEnrichedUsers] = useState(users);
 
@@ -151,9 +152,14 @@ export default function ChartDivisiAbsensi({
     }
   });
 
-  const dataChart = Object.values(divisiMap).sort(
-    (a, b) => b.total_value - a.total_value
-  );
+  const dataChart = Object.values(divisiMap).sort((a, b) => {
+    if (sortBy === "percentage") {
+      const percA = a.total_user ? a.user_sudah / a.total_user : 0;
+      const percB = b.total_user ? b.user_sudah / b.total_user : 0;
+      return percB - percA;
+    }
+    return b.total_value - a.total_value;
+  });
 
   // Dynamic height
   const isHorizontal = orientation === "horizontal";

--- a/cicero-dashboard/components/ChartHorizontal.jsx
+++ b/cicero-dashboard/components/ChartHorizontal.jsx
@@ -32,6 +32,7 @@ export default function ChartHorizontal({
   labelTotal = "Total Likes",
   showTotalUser = false,
   labelTotalUser = "Jumlah User",
+  sortBy = "total_value",
 }) {
   const effectiveTotal =
     typeof totalPost !== "undefined" ? totalPost : totalIGPost;
@@ -72,7 +73,14 @@ export default function ChartHorizontal({
       divisiMap[key].user_belum += 1;
     }
   });
-  const dataChart = Object.values(divisiMap);
+  const dataChart = Object.values(divisiMap).sort((a, b) => {
+    if (sortBy === "percentage") {
+      const percA = a.total_user ? a.user_sudah / a.total_user : 0;
+      const percB = b.total_user ? b.user_sudah / b.total_user : 0;
+      return percB - percA;
+    }
+    return b.total_value - a.total_value;
+  });
 
   // Tinggi chart proporsional
   const barHeight = 34;


### PR DESCRIPTION
## Summary
- Allow charts to sort by percentage of users who liked.
- Apply percentage-based sorting to Instagram Engagement Insight charts for consistent ranking.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b82f6b29388327a96b2656a86667ce