### PR TITLE
Add bar for users with insufficient likes in charts

### DIFF
--- a/cicero-dashboard/app/amplify/page.jsx
+++ b/cicero-dashboard/app/amplify/page.jsx
@@ -260,6 +260,7 @@ function ChartBox({
           totalPost={1}
           fieldJumlah="jumlah_link"
           labelSudah="User Sudah Post"
+          labelKurang="User Kurang Post"
           labelBelum="User Belum Post"
           labelTotal="Total Link Amplifikasi"
           groupBy={groupBy}

--- a/cicero-dashboard/app/comments/tiktok/page.jsx
+++ b/cicero-dashboard/app/comments/tiktok/page.jsx
@@ -336,6 +336,7 @@ function ChartBox({
           totalPost={totalTiktokPost}
           fieldJumlah={fieldJumlah}
           labelSudah="User Sudah Komentar"
+          labelKurang="User Kurang Komentar"
           labelBelum="User Belum Komentar"
           labelTotal="Total Komentar"
           groupBy={groupBy}

--- a/cicero-dashboard/app/likes/instagram/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/page.jsx
@@ -447,6 +447,7 @@ function ChartBox({
           totalPost={totalPost}
           fieldJumlah="jumlah_like"
           labelSudah="User Sudah Like"
+          labelKurang="User Kurang Like"
           labelBelum="User Belum Like"
           labelTotal="Total Likes"
           groupBy={groupBy}

--- a/cicero-dashboard/components/ChartDivisiAbsensi.jsx
+++ b/cicero-dashboard/components/ChartDivisiAbsensi.jsx
@@ -34,6 +34,7 @@ export default function ChartDivisiAbsensi({
   totalTiktokPost, // fallback untuk tiktok (kompatibilitas lama)
   fieldJumlah = "jumlah_like", // bisa "jumlah_komentar" untuk tiktok
   labelSudah = "User Sudah Komentar",
+  labelKurang = "User Kurang Komentar",
   labelBelum = "User Belum Komentar",
   labelTotal = "Total Komentar",
   groupBy = "divisi",
@@ -134,12 +135,15 @@ export default function ChartDivisiAbsensi({
     const jumlah = Number(u[fieldJumlah] || 0);
     const sudah =
       !isZeroPost && (jumlah >= effectiveTotal * 0.5 || isException(u.exception));
+    const kurang =
+      !sudah && !isZeroPost && jumlah > 0 && !isException(u.exception);
     const nilai = isException(u.exception) ? maxJumlahLike : jumlah;
     if (!divisiMap[key])
       divisiMap[key] = {
         [labelKey]: display,
         total_user: 0,
         user_sudah: 0,
+        user_kurang: 0,
         user_belum: 0,
         total_value: 0,
       };
@@ -147,6 +151,8 @@ export default function ChartDivisiAbsensi({
     divisiMap[key].total_value += nilai;
     if (sudah) {
       divisiMap[key].user_sudah += 1;
+    } else if (kurang) {
+      divisiMap[key].user_kurang += 1;
     } else {
       divisiMap[key].user_belum += 1;
     }
@@ -237,6 +243,8 @@ export default function ChartDivisiAbsensi({
                     ? labelTotalUser
                     : name === "user_sudah"
                     ? labelSudah
+                    : name === "user_kurang"
+                    ? labelKurang
                     : name === "user_belum"
                     ? labelBelum
                     : name === "total_value"
@@ -271,6 +279,18 @@ export default function ChartDivisiAbsensi({
             >
               <LabelList
                 dataKey="user_sudah"
+                position={isHorizontal ? "right" : "top"}
+                fontSize={isHorizontal ? 10 : 12}
+              />
+            </Bar>
+            <Bar
+              dataKey="user_kurang"
+              fill="#f97316"
+              name={labelKurang}
+              barSize={isHorizontal ? 20 * thicknessMultiplier : undefined}
+            >
+              <LabelList
+                dataKey="user_kurang"
                 position={isHorizontal ? "right" : "top"}
                 fontSize={isHorizontal ? 10 : 12}
               />

--- a/cicero-dashboard/components/ChartHorizontal.jsx
+++ b/cicero-dashboard/components/ChartHorizontal.jsx
@@ -28,6 +28,7 @@ export default function ChartHorizontal({
   totalIGPost,
   fieldJumlah = "jumlah_like",
   labelSudah = "User Sudah Like",
+  labelKurang = "User Kurang Like",
   labelBelum = "User Belum Like",
   labelTotal = "Total Likes",
   showTotalUser = false,
@@ -55,20 +56,25 @@ export default function ChartHorizontal({
     // Logic: sudahLike hanya berlaku kalau ada post
     const jumlah = Number(u[fieldJumlah] || 0);
     const sudah =
-      !isZeroPost && (jumlah > 0 || isException(u.exception));
+      !isZeroPost && (jumlah >= effectiveTotal * 0.5 || isException(u.exception));
+    const kurang =
+      !sudah && !isZeroPost && jumlah > 0 && !isException(u.exception);
     const nilai = isException(u.exception) ? maxJumlahLike : jumlah;
     if (!divisiMap[key])
       divisiMap[key] = {
         divisi: key,
         total_user: 0,
         user_sudah: 0,
+        user_kurang: 0,
         user_belum: 0,
         total_value: 0,
       };
     divisiMap[key].total_user += 1;
+    divisiMap[key].total_value += nilai;
     if (sudah) {
       divisiMap[key].user_sudah += 1;
-      divisiMap[key].total_value += nilai;
+    } else if (kurang) {
+      divisiMap[key].user_kurang += 1;
     } else {
       divisiMap[key].user_belum += 1;
     }
@@ -128,6 +134,8 @@ export default function ChartHorizontal({
                     ? labelTotalUser
                     : name === "user_sudah"
                     ? labelSudah
+                    : name === "user_kurang"
+                    ? labelKurang
                     : name === "user_belum"
                     ? labelBelum
                     : name === "total_value"
@@ -154,6 +162,14 @@ export default function ChartHorizontal({
             )}
             <Bar dataKey="user_sudah" fill="#22c55e" name={labelSudah} barSize={10}>
               <LabelList dataKey="user_sudah" position="right" fontSize={10} />
+            </Bar>
+            <Bar
+              dataKey="user_kurang"
+              fill="#f97316"
+              name={labelKurang}
+              barSize={10}
+            >
+              <LabelList dataKey="user_kurang" position="right" fontSize={10} />
             </Bar>
             <Bar dataKey="total_value" fill="#2563eb" name={labelTotal} barSize={10}>
               <LabelList dataKey="total_value" position="right" fontSize={10} />


### PR DESCRIPTION
## Summary
- extend ChartHorizontal and ChartDivisiAbsensi to compute and display users with "Kurang Like"
- wire likes, comments, and amplify pages to supply descriptive label for the new bar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b8317c8b5c8327846ea3904c082dee