### PR TITLE
feat: add refresh actions

### DIFF
--- a/cicero-dashboard/app/posts/instagram/page.jsx
+++ b/cicero-dashboard/app/posts/instagram/page.jsx
@@ -12,6 +12,7 @@ import Narrative from "@/components/Narrative";
 import PostCompareChart from "@/components/PostCompareChart";
 import FilterBar from "@/components/FilterBar";
 import useRequireAuth from "@/hooks/useRequireAuth";
+import { RefreshCw } from "lucide-react";
 import {
   getInstagramProfileViaBackend,
   getInstagramPostsViaBackend,
@@ -333,7 +334,18 @@ export default function InstagramPostAnalysisPage() {
   return (
     <div className="min-h-screen bg-gray-100 flex flex-col items-center py-8">
       <div className="w-full max-w-5xl flex flex-col gap-8">
-        <h1 className="text-2xl font-bold text-blue-700">Instagram Post Analysis</h1>
+        <div className="flex items-center justify-between">
+          <h1 className="text-2xl font-bold text-blue-700">
+            Instagram Post Analysis
+          </h1>
+          <button
+            onClick={() => window.location.reload()}
+            className="p-2 text-gray-500 hover:text-gray-700"
+            aria-label="Refresh"
+          >
+            <RefreshCw className="w-5 h-5" />
+          </button>
+        </div>
         <p className="text-gray-600">Analisis performa postingan Instagram.</p>
 
         <div className="bg-white p-4 rounded-xl shadow flex gap-4 items-start">

--- a/cicero-dashboard/app/posts/tiktok/page.jsx
+++ b/cicero-dashboard/app/posts/tiktok/page.jsx
@@ -12,6 +12,7 @@ import Loader from "@/components/Loader";
 import Narrative from "@/components/Narrative";
 import PostCompareChart from "@/components/PostCompareChart";
 import useRequireAuth from "@/hooks/useRequireAuth";
+import { RefreshCw } from "lucide-react";
 import {
   getTiktokProfileViaBackend,
   getTiktokPostsViaBackend,
@@ -334,7 +335,18 @@ export default function TiktokPostAnalysisPage() {
   return (
     <div className="min-h-screen bg-gray-100 flex flex-col items-center py-8">
       <div className="w-full max-w-5xl flex flex-col gap-8">
-        <h1 className="text-2xl font-bold text-blue-700">TikTok Post Analysis</h1>
+        <div className="flex items-center justify-between">
+          <h1 className="text-2xl font-bold text-blue-700">
+            TikTok Post Analysis
+          </h1>
+          <button
+            onClick={() => window.location.reload()}
+            className="p-2 text-gray-500 hover:text-gray-700"
+            aria-label="Refresh"
+          >
+            <RefreshCw className="w-5 h-5" />
+          </button>
+        </div>
         <p className="text-gray-600">Analisis performa postingan TikTok.</p>
 
         <div className="bg-white p-4 rounded-xl shadow flex gap-4 items-start">

--- a/cicero-dashboard/app/user-insight/page.jsx
+++ b/cicero-dashboard/app/user-insight/page.jsx
@@ -20,7 +20,7 @@ import { groupUsersByKelompok } from "@/utils/grouping";
 import Loader from "@/components/Loader";
 import useRequireAuth from "@/hooks/useRequireAuth";
 import { useAuth } from "@/context/AuthContext";
-import { User, Instagram, Music } from "lucide-react";
+import { User, Instagram, Music, RefreshCw } from "lucide-react";
 
 export default function UserInsightPage() {
   useRequireAuth();
@@ -247,12 +247,21 @@ export default function UserInsightPage() {
               <h1 className="text-2xl md:text-3xl font-bold text-blue-700">
                 User Insight
               </h1>
-              <button
-                onClick={handleCopyRekap}
-                className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg shadow"
-              >
-                Salin Rekap
-              </button>
+              <div className="flex items-center gap-2">
+                <button
+                  onClick={handleCopyRekap}
+                  className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg shadow"
+                >
+                  Salin Rekap
+                </button>
+                <button
+                  onClick={() => window.location.reload()}
+                  className="p-2 text-gray-500 hover:text-gray-700"
+                  aria-label="Refresh"
+                >
+                  <RefreshCw className="w-5 h-5" />
+                </button>
+              </div>
             </div>
 
             <div className="bg-gradient-to-tr from-blue-50 to-white rounded-2xl shadow flex flex-col md:flex-row items-stretch justify-between p-3 md:p-5 gap-2 md:gap-4 border">

--- a/cicero-dashboard/app/users/page.jsx
+++ b/cicero-dashboard/app/users/page.jsx
@@ -9,7 +9,7 @@ import {
   getClientNames,
   updateUserRoles,
 } from "@/utils/api";
-import { Pencil, Check, X } from "lucide-react";
+import { Pencil, Check, X, RefreshCw } from "lucide-react";
 import Loader from "@/components/Loader";
 import useRequireAuth from "@/hooks/useRequireAuth";
 import { compareUsersByPangkatAndNrp } from "@/utils/pangkat";
@@ -342,7 +342,14 @@ export default function UserDirectoryPage() {
 
   return (
     <div className="min-h-screen bg-gray-100 flex flex-col items-center py-12">
-      <div className="max-w-6xl w-full bg-white rounded-2xl shadow-md p-8">
+      <div className="max-w-6xl w-full bg-white rounded-2xl shadow-md p-8 relative">
+        <button
+          onClick={() => window.location.reload()}
+          className="absolute top-4 right-4 text-gray-500 hover:text-gray-700"
+          aria-label="Refresh"
+        >
+          <RefreshCw className="w-5 h-5" />
+        </button>
         <h1 className="text-2xl font-bold text-blue-700">User Directory</h1>
         <div className="mb-4 text-sm text-gray-600">
           Client Name: {clientName || "-"} | {day}, {dateStr} {timeStr}


### PR DESCRIPTION
## Summary
- add refresh controls to user and insight pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b90f8a57e88327b39dc607fabbbd9a