### PR TITLE
Fix refresh icons to reload current page data

### DIFF
--- a/cicero-dashboard/app/posts/instagram/page.jsx
+++ b/cicero-dashboard/app/posts/instagram/page.jsx
@@ -42,7 +42,7 @@ export default function InstagramPostAnalysisPage() {
   const [endDate, setEndDate] = useState(lastDay);
   const [search, setSearch] = useState("");
 
-  useEffect(() => {
+  const fetchData = async () => {
     const token =
       typeof window !== "undefined" ? localStorage.getItem("cicero_token") : null;
     const clientId =
@@ -54,39 +54,39 @@ export default function InstagramPostAnalysisPage() {
       return;
     }
 
-    async function fetchData() {
-      try {
-        setLoading(true);
-        const clientProfile = await getClientProfile(token, clientId);
-        const username =
-          clientProfile.client?.client_insta?.replace(/^@/, "") ||
-          clientProfile.client_insta?.replace(/^@/, "") ||
-          process.env.NEXT_PUBLIC_INSTAGRAM_USER ||
-          "instagram";
+    try {
+      setLoading(true);
+      const clientProfile = await getClientProfile(token, clientId);
+      const username =
+        clientProfile.client?.client_insta?.replace(/^@/, "") ||
+        clientProfile.client_insta?.replace(/^@/, "") ||
+        process.env.NEXT_PUBLIC_INSTAGRAM_USER ||
+        "instagram";
 
-        const profileRes = await getInstagramProfileViaBackend(token, username);
-        setProfile(profileRes.data || profileRes.profile || profileRes);
+      const profileRes = await getInstagramProfileViaBackend(token, username);
+      setProfile(profileRes.data || profileRes.profile || profileRes);
 
-        const infoRes = await getInstagramInfoViaBackend(token, username);
-        const infoData = infoRes.data || infoRes.info || infoRes;
-        setInfo(infoData);
+      const infoRes = await getInstagramInfoViaBackend(token, username);
+      const infoData = infoRes.data || infoRes.info || infoRes;
+      setInfo(infoData);
 
-        const postRes = await getInstagramPostsViaBackend(
-          token,
-          username,
-          12,
-          startDate,
-          endDate,
-        );
-        const postData = postRes.data || postRes.posts || postRes;
-        setPosts(Array.isArray(postData) ? postData : []);
-      } catch (err) {
-        setError("Gagal mengambil data: " + (err.message || err));
-      } finally {
-        setLoading(false);
-      }
+      const postRes = await getInstagramPostsViaBackend(
+        token,
+        username,
+        12,
+        startDate,
+        endDate,
+      );
+      const postData = postRes.data || postRes.posts || postRes;
+      setPosts(Array.isArray(postData) ? postData : []);
+    } catch (err) {
+      setError("Gagal mengambil data: " + (err.message || err));
+    } finally {
+      setLoading(false);
     }
+  };
 
+  useEffect(() => {
     fetchData();
   }, [startDate, endDate]);
 
@@ -339,7 +339,7 @@ export default function InstagramPostAnalysisPage() {
             Instagram Post Analysis
           </h1>
           <button
-            onClick={() => window.location.reload()}
+            onClick={fetchData}
             className="p-2 text-gray-500 hover:text-gray-700"
             aria-label="Refresh"
           >

--- a/cicero-dashboard/app/posts/tiktok/page.jsx
+++ b/cicero-dashboard/app/posts/tiktok/page.jsx
@@ -43,7 +43,7 @@ export default function TiktokPostAnalysisPage() {
   const [endDate, setEndDate] = useState(lastDay);
   const [search, setSearch] = useState("");
 
-  useEffect(() => {
+  const fetchData = async () => {
     const token =
       typeof window !== "undefined" ? localStorage.getItem("cicero_token") : null;
     const clientId =
@@ -55,39 +55,39 @@ export default function TiktokPostAnalysisPage() {
       return;
     }
 
-    async function fetchData() {
-      try {
-        setLoading(true);
-        const clientProfile = await getClientProfile(token, clientId);
-        const username =
-          clientProfile.client?.client_tiktok?.replace(/^@/, "") ||
-          clientProfile.client_tiktok?.replace(/^@/, "") ||
-          process.env.NEXT_PUBLIC_TIKTOK_USER ||
-          "tiktok";
+    try {
+      setLoading(true);
+      const clientProfile = await getClientProfile(token, clientId);
+      const username =
+        clientProfile.client?.client_tiktok?.replace(/^@/, "") ||
+        clientProfile.client_tiktok?.replace(/^@/, "") ||
+        process.env.NEXT_PUBLIC_TIKTOK_USER ||
+        "tiktok";
 
-        const profileRes = await getTiktokProfileViaBackend(token, username);
-        setProfile(profileRes);
+      const profileRes = await getTiktokProfileViaBackend(token, username);
+      setProfile(profileRes);
 
-        const infoRes = await getTiktokInfoViaBackend(token, username);
-        const infoData = infoRes.data || infoRes.info || infoRes;
-        setInfo(infoData);
+      const infoRes = await getTiktokInfoViaBackend(token, username);
+      const infoData = infoRes.data || infoRes.info || infoRes;
+      setInfo(infoData);
 
-        const postRes = await getTiktokPostsViaBackend(
-          token,
-          clientId,
-          50,
-          startDate,
-          endDate,
-        );
-        const postData = postRes.data || postRes.posts || postRes;
-        setPosts(Array.isArray(postData) ? postData : []);
-      } catch (err) {
-        setError("Gagal mengambil data: " + (err.message || err));
-      } finally {
-        setLoading(false);
-      }
+      const postRes = await getTiktokPostsViaBackend(
+        token,
+        clientId,
+        50,
+        startDate,
+        endDate,
+      );
+      const postData = postRes.data || postRes.posts || postRes;
+      setPosts(Array.isArray(postData) ? postData : []);
+    } catch (err) {
+      setError("Gagal mengambil data: " + (err.message || err));
+    } finally {
+      setLoading(false);
     }
+  };
 
+  useEffect(() => {
     fetchData();
   }, [startDate, endDate]);
 
@@ -340,7 +340,7 @@ export default function TiktokPostAnalysisPage() {
             TikTok Post Analysis
           </h1>
           <button
-            onClick={() => window.location.reload()}
+            onClick={fetchData}
             className="p-2 text-gray-500 hover:text-gray-700"
             aria-label="Refresh"
           >

--- a/cicero-dashboard/app/user-insight/page.jsx
+++ b/cicero-dashboard/app/user-insight/page.jsx
@@ -47,7 +47,10 @@ export default function UserInsightPage() {
   const [chartPolres, setChartPolres] = useState([]);
 
   useEffect(() => {
-    async function fetchData() {
+    fetchData();
+  }, [token, clientId]);
+
+  async function fetchData() {
       if (!token || !clientId) {
         setError("Token / Client ID tidak ditemukan. Silakan login ulang.");
         setLoading(false);
@@ -183,8 +186,6 @@ export default function UserInsightPage() {
         setLoading(false);
       }
     }
-    fetchData();
-  }, [token, clientId]);
 
   function handleCopyRekap() {
     const now = new Date();
@@ -255,7 +256,7 @@ export default function UserInsightPage() {
                   Salin Rekap
                 </button>
                 <button
-                  onClick={() => window.location.reload()}
+                  onClick={fetchData}
                   className="p-2 text-gray-500 hover:text-gray-700"
                   aria-label="Refresh"
                 >

--- a/cicero-dashboard/app/users/page.jsx
+++ b/cicero-dashboard/app/users/page.jsx
@@ -344,7 +344,7 @@ export default function UserDirectoryPage() {
     <div className="min-h-screen bg-gray-100 flex flex-col items-center py-12">
       <div className="max-w-6xl w-full bg-white rounded-2xl shadow-md p-8 relative">
         <button
-          onClick={() => window.location.reload()}
+          onClick={fetchUsers}
           className="absolute top-4 right-4 text-gray-500 hover:text-gray-700"
           aria-label="Refresh"
         >


### PR DESCRIPTION
## Summary
- prevent refresh icons from redirecting to the dashboard by refetching data on the current page
- update Instagram and TikTok post analysis pages to reuse data loaders for refresh
- let user insight and user directory pages trigger data reloads via their existing fetch functions

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68b914ee565c832788851da1d6c31330