### PR TITLE
Allow query params in claim profile URLs

### DIFF
--- a/cicero-dashboard/app/claim/edit/page.jsx
+++ b/cicero-dashboard/app/claim/edit/page.jsx
@@ -6,12 +6,12 @@ import { getUserById, updateUserViaClaim } from "@/utils/api";
 
 function isValidInstagram(url) {
   if (!url) return true;
-  return /^https?:\/\/(www\.)?instagram\.com\/[A-Za-z0-9._-]+\/?$/.test(url);
+  return /^https?:\/\/(www\.)?instagram\.com\/[A-Za-z0-9._-]+\/?(\?.*)?$/.test(url);
 }
 
 function isValidTiktok(url) {
   if (!url) return true;
-  return /^https?:\/\/(www\.)?tiktok\.com\/@[A-Za-z0-9._-]+\/?$/.test(url);
+  return /^https?:\/\/(www\.)?tiktok\.com\/@[A-Za-z0-9._-]+\/?(\?.*)?$/.test(url);
 }
 
 export default function EditUserPage() {


### PR DESCRIPTION
## Summary
- Allow Instagram profile field to accept URLs with query strings on claim/update page
- Allow TikTok profile field to accept URLs with query strings on claim/update page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b928e9cfe083278c5a6341847f55dd