### PR TITLE
Remove user exception filtering from engagement metrics

### DIFF
--- a/cicero-dashboard/app/likes/instagram/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/page.jsx
@@ -28,11 +28,6 @@ import {
   UserX,
 } from "lucide-react";
 
-// Helper: handle boolean/string/number for exception
-function isException(val) {
-  return val === true || val === "true" || val === 1 || val === "1";
-}
-
 export default function InstagramEngagementInsightPage() {
   useRequireAuth();
   const [stats, setStats] = useState(null);
@@ -239,7 +234,7 @@ export default function InstagramEngagementInsightPage() {
             totalBelumLike += 1;
             return;
           }
-          if (isException(u.exception) || jumlah >= totalIGPost * 0.5) {
+          if (jumlah >= totalIGPost * 0.5) {
             totalSudahLike += 1;
           } else if (jumlah > 0) {
             totalKurangLike += 1;

--- a/cicero-dashboard/app/likes/instagram/rekap/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/rekap/page.jsx
@@ -18,11 +18,6 @@ import ViewDataSelector, {
 } from "@/components/ViewDataSelector";
 import { ArrowLeft } from "lucide-react";
 
-// Helper: handle boolean/string/number for exception
-function isException(val) {
-  return val === true || val === "true" || val === 1 || val === "1";
-}
-
 export default function RekapLikesIGPage() {
   useRequireAuth();
   const [chartData, setChartData] = useState([]);
@@ -235,7 +230,7 @@ export default function RekapLikesIGPage() {
             totalBelumLike += 1;
             return;
           }
-          if (isException(u.exception) || jumlah >= totalIGPost * 0.5) {
+          if (jumlah >= totalIGPost * 0.5) {
             totalSudahLike += 1;
           } else if (jumlah > 0) {
             totalKurangLike += 1;

--- a/cicero-dashboard/components/ChartDivisiAbsensi.jsx
+++ b/cicero-dashboard/components/ChartDivisiAbsensi.jsx
@@ -13,11 +13,6 @@ import {
 import { useEffect, useState } from "react";
 import { getClientNames } from "@/utils/api";
 
-// Helper: handle boolean/string/number for exception
-function isException(val) {
-  return val === true || val === "true" || val === 1 || val === "1";
-}
-
 // Bersihkan "POLSEK" dan awalan angka pada nama divisi/satfung
 function bersihkanSatfung(divisi = "") {
   return divisi
@@ -109,14 +104,6 @@ export default function ChartDivisiAbsensi({
   // Jika tidak ada post, semua user dianggap belum
   const isZeroPost = (effectiveTotal || 0) === 0;
 
-  // Cari nilai jumlah_like tertinggi dari user non-exception
-  const maxJumlahLike = Math.max(
-    0,
-    ...enrichedUsers
-      .filter((u) => !isException(u.exception))
-      .map((u) => Number(u[fieldJumlah] || 0))
-  );
-
   // Group by divisi atau client_id jika diminta
   const divisiMap = {};
   const labelKey = groupBy === "client_id" ? "client_name" : "divisi";
@@ -133,11 +120,9 @@ export default function ChartDivisiAbsensi({
           ? u.nama_client || u.client_name || u.client || idKey
           : key;
     const jumlah = Number(u[fieldJumlah] || 0);
-    const sudah =
-      !isZeroPost && (jumlah >= effectiveTotal * 0.5 || isException(u.exception));
-    const kurang =
-      !sudah && !isZeroPost && jumlah > 0 && !isException(u.exception);
-    const nilai = isException(u.exception) ? maxJumlahLike : jumlah;
+    const sudah = !isZeroPost && jumlah >= effectiveTotal * 0.5;
+    const kurang = !sudah && !isZeroPost && jumlah > 0;
+    const nilai = jumlah;
     if (!divisiMap[key])
       divisiMap[key] = {
         [labelKey]: display,

--- a/cicero-dashboard/components/ChartHorizontal.jsx
+++ b/cicero-dashboard/components/ChartHorizontal.jsx
@@ -10,10 +10,6 @@ import {
   LabelList,
   Legend,
 } from "recharts";
-
-function isException(val) {
-  return val === true || val === "true" || val === 1 || val === "1";
-}
 function bersihkanSatfung(divisi = "") {
   return divisi
     .replace(/polsek\s*/i, "")
@@ -41,25 +37,15 @@ export default function ChartHorizontal({
   // Jika tidak ada post, semua user masuk belum (termasuk exception)
   const isZeroPost = (effectiveTotal || 0) === 0;
 
-  // Cari nilai jumlah_like tertinggi untuk user non-exception
-  const maxJumlahLike = Math.max(
-    0,
-    ...users
-      .filter((u) => !isException(u.exception))
-      .map((u) => Number(u[fieldJumlah] || 0))
-  );
-
   // Matrix 3 metrik per polsek
   const divisiMap = {};
   users.forEach((u) => {
     const key = bersihkanSatfung(u.divisi || "LAINNYA");
     // Logic: sudahLike hanya berlaku kalau ada post
     const jumlah = Number(u[fieldJumlah] || 0);
-    const sudah =
-      !isZeroPost && (jumlah >= effectiveTotal * 0.5 || isException(u.exception));
-    const kurang =
-      !sudah && !isZeroPost && jumlah > 0 && !isException(u.exception);
-    const nilai = isException(u.exception) ? maxJumlahLike : jumlah;
+    const sudah = !isZeroPost && jumlah >= effectiveTotal * 0.5;
+    const kurang = !sudah && !isZeroPost && jumlah > 0;
+    const nilai = jumlah;
     if (!divisiMap[key])
       divisiMap[key] = {
         divisi: key,

--- a/cicero-dashboard/components/RekapKomentarTiktok.jsx
+++ b/cicero-dashboard/components/RekapKomentarTiktok.jsx
@@ -3,10 +3,6 @@ import { useMemo, useEffect, useState } from "react";
 import usePersistentState from "@/hooks/usePersistentState";
 import { Music, Users, Check, X } from "lucide-react";
 
-function isException(val) {
-  return val === true || val === "true" || val === 1 || val === "1";
-}
-
 function bersihkanSatfung(divisi = "") {
   return divisi
     .replace(/polsek\s*/i, "")
@@ -18,9 +14,10 @@ const PAGE_SIZE = 25;
 
 export default function RekapKomentarTiktok({ users = [], totalTiktokPost = 0 }) {
   const totalUser = users.length;
-  const totalSudahKomentar = totalTiktokPost === 0
-    ? 0
-    : users.filter(u => Number(u.jumlah_komentar) > 0 || isException(u.exception)).length;
+  const totalSudahKomentar =
+    totalTiktokPost === 0
+      ? 0
+      : users.filter((u) => Number(u.jumlah_komentar) > 0).length;
   const totalBelumKomentar = totalUser - totalSudahKomentar;
 
   const hasClient = useMemo(
@@ -28,16 +25,6 @@ export default function RekapKomentarTiktok({ users = [], totalTiktokPost = 0 })
     [users]
   );
 
-  const maxJumlahKomentar = useMemo(
-    () =>
-      Math.max(
-        0,
-        ...users
-          .filter(u => !isException(u.exception))
-          .map(u => parseInt(u.jumlah_komentar || 0, 10))
-      ),
-    [users]
-  );
 
   const [search, setSearch] = useState("");
   const filtered = useMemo(() => {
@@ -55,30 +42,15 @@ export default function RekapKomentarTiktok({ users = [], totalTiktokPost = 0 })
 
   const sorted = useMemo(() => {
     return [...filtered].sort((a, b) => {
-      const aExc = isException(a.exception);
-      const bExc = isException(b.exception);
       const aCom = Number(a.jumlah_komentar);
       const bCom = Number(b.jumlah_komentar);
 
-      if (!aExc && aCom === maxJumlahKomentar && (bExc || bCom < maxJumlahKomentar)) return -1;
-      if (!bExc && bCom === maxJumlahKomentar && (aExc || aCom < maxJumlahKomentar)) return 1;
-
-      if (aExc && bExc) return 0;
-      if (aExc && !bExc && bCom === maxJumlahKomentar) return 1;
-      if (!aExc && bExc && aCom === maxJumlahKomentar) return -1;
-
-      if (!aExc && !bExc) {
-        if (aCom > 0 && bCom === 0) return -1;
-        if (aCom === 0 && bCom > 0) return 1;
-        if (aCom !== bCom) return bCom - aCom;
-        return (a.nama || "").localeCompare(b.nama || "");
-      }
-
-      if (aExc && !bExc) return -1;
-      if (!aExc && bExc) return 1;
+      if (aCom > 0 && bCom === 0) return -1;
+      if (aCom === 0 && bCom > 0) return 1;
+      if (aCom !== bCom) return bCom - aCom;
       return (a.nama || "").localeCompare(b.nama || "");
     });
-  }, [filtered, maxJumlahKomentar]);
+  }, [filtered]);
 
   const [page, setPage] = usePersistentState("rekapKomentarTiktok_page", 1);
   const totalPages = Math.ceil(sorted.length / PAGE_SIZE);
@@ -151,7 +123,7 @@ export default function RekapKomentarTiktok({ users = [], totalTiktokPost = 0 })
               const sudahKomentar =
                 totalTiktokPost === 0
                   ? false
-                  : Number(u.jumlah_komentar) > 0 || isException(u.exception);
+                  : Number(u.jumlah_komentar) > 0;
               return (
                 <tr
                   key={u.user_id}
@@ -184,7 +156,7 @@ export default function RekapKomentarTiktok({ users = [], totalTiktokPost = 0 })
                     )}
                   </td>
                   <td className="py-1 px-2 text-center font-bold">
-                    {isException(u.exception) ? maxJumlahKomentar : u.jumlah_komentar}
+                    {u.jumlah_komentar}
                   </td>
                 </tr>
               );

--- a/cicero-dashboard/components/RekapLikesIG.jsx
+++ b/cicero-dashboard/components/RekapLikesIG.jsx
@@ -10,11 +10,6 @@ import usePersistentState from "@/hooks/usePersistentState";
 import { Camera, Users, Check, X, AlertTriangle, UserX } from "lucide-react";
 import { compareUsersByPangkatAndNrp } from "@/utils/pangkat";
 
-// Utility: handle boolean/string/number for exception
-function isException(val) {
-  return val === true || val === "true" || val === 1 || val === "1";
-}
-
 const PAGE_SIZE = 25;
 
 /**
@@ -63,42 +58,26 @@ const RekapLikesIG = forwardRef(function RekapLikesIG(
   const totalSudahLike =
     totalIGPost === 0
       ? 0
-      : validUsers.filter(
-          (u) =>
-            Number(u.jumlah_like) >= totalIGPost * 0.5 || isException(u.exception),
-        ).length;
+      : validUsers.filter((u) => Number(u.jumlah_like) >= totalIGPost * 0.5)
+          .length;
   const totalKurangLike =
     totalIGPost === 0
       ? 0
       : validUsers.filter((u) => {
           const likes = Number(u.jumlah_like) || 0;
-          return likes > 0 && likes < totalIGPost * 0.5 && !isException(u.exception);
+          return likes > 0 && likes < totalIGPost * 0.5;
         }).length;
   const totalBelumLike =
     totalIGPost === 0
       ? validUsers.length
-      : validUsers.filter(
-          (u) => Number(u.jumlah_like) === 0 && !isException(u.exception),
-        ).length;
+      : validUsers.filter((u) => Number(u.jumlah_like) === 0).length;
   const totalTanpaUsername = tanpaUsernameUsers.length;
 
   // Hitung nilai jumlah_like tertinggi (max) di seluruh user
-  const maxJumlahLike = useMemo(
-    () =>
-      Math.max(
-        0,
-        ...validUsers
-          .filter((u) => !isException(u.exception))
-          .map((u) => parseInt(u.jumlah_like || 0, 10)),
-      ),
-    [validUsers],
-  );
-
   const sudahUsers = useMemo(() => {
     if (totalIGPost === 0) return [];
     return validUsers.filter(
-      (u) =>
-        Number(u.jumlah_like) >= totalIGPost * 0.5 || isException(u.exception),
+      (u) => Number(u.jumlah_like) >= totalIGPost * 0.5,
     );
   }, [validUsers, totalIGPost]);
 
@@ -106,15 +85,13 @@ const RekapLikesIG = forwardRef(function RekapLikesIG(
     if (totalIGPost === 0) return [];
     return validUsers.filter((u) => {
       const likes = Number(u.jumlah_like) || 0;
-      return likes > 0 && likes < totalIGPost * 0.5 && !isException(u.exception);
+      return likes > 0 && likes < totalIGPost * 0.5;
     });
   }, [validUsers, totalIGPost]);
 
   const belumUsers = useMemo(() => {
     if (totalIGPost === 0) return validUsers;
-    return validUsers.filter(
-      (u) => Number(u.jumlah_like) === 0 && !isException(u.exception),
-    );
+    return validUsers.filter((u) => Number(u.jumlah_like) === 0);
   }, [validUsers, totalIGPost]);
 
   function groupByDivisi(arr) {
@@ -219,7 +196,7 @@ const RekapLikesIG = forwardRef(function RekapLikesIG(
       const likes = Number(u.jumlah_like) || 0;
       let status = "Belum";
       if (totalIGPost !== 0) {
-        if (isException(u.exception) || likes >= totalIGPost * 0.5) status = "Sudah";
+        if (likes >= totalIGPost * 0.5) status = "Sudah";
         else if (likes > 0) status = "Kurang";
       }
       clients[client][status].push(u);
@@ -399,9 +376,7 @@ const RekapLikesIG = forwardRef(function RekapLikesIG(
                   <X className="w-3 h-3" /> Belum
                 </span>
               );
-              let jumlahDisplay = isException(u.exception)
-                ? maxJumlahLike
-                : u.jumlah_like;
+              let jumlahDisplay = u.jumlah_like;
               if (!username) {
                 rowClass = "bg-gray-50";
                 statusEl = (
@@ -412,7 +387,7 @@ const RekapLikesIG = forwardRef(function RekapLikesIG(
                 jumlahDisplay = 0;
               } else if (totalIGPost !== 0) {
                 const likes = Number(u.jumlah_like) || 0;
-                if (isException(u.exception) || likes >= totalIGPost * 0.5) {
+                if (likes >= totalIGPost * 0.5) {
                   rowClass = "bg-green-50";
                   statusEl = (
                     <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs bg-green-500 text-white font-semibold">

--- a/cicero-dashboard/utils/absensiLikes.ts
+++ b/cicero-dashboard/utils/absensiLikes.ts
@@ -1,9 +1,5 @@
 import { getDashboardStats, getRekapLikesIG, getClientProfile, getClientNames, getUserDirectory } from "@/utils/api";
 
-function isException(val: any) {
-  return val === true || val === "true" || val === 1 || val === "1";
-}
-
 interface FetchParams {
   periode: string;
   date?: string;
@@ -115,7 +111,7 @@ export async function fetchDitbinmasAbsensiLikes(
       totalBelumLike += 1;
       return;
     }
-    if (isException(u.exception) || jumlah >= totalIGPost * 0.5) {
+    if (jumlah >= totalIGPost * 0.5) {
       totalSudahLike += 1;
     } else if (jumlah > 0) {
       totalKurangLike += 1;


### PR DESCRIPTION
## Summary
- stop classifying Instagram likes via exception flags; counts now based purely on like totals
- drop exception handling from charts and recap components
- simplify TikTok comment recap to show raw counts for all users

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba7815ade48327a897152fc3d41cee