### PR TITLE
Sort user insight charts by combined performance score

### DIFF
--- a/cicero-dashboard/app/user-insight/page.jsx
+++ b/cicero-dashboard/app/user-insight/page.jsx
@@ -85,7 +85,9 @@ export default function UserInsightPage() {
             if (hasTT) map[key].tiktokFilled += 1;
             else map[key].tiktokEmpty += 1;
           });
-          return Object.values(map);
+          const result = Object.values(map);
+          const score = (o) => o.total + o.instagramFilled + o.tiktokFilled;
+          return result.sort((a, b) => score(b) - score(a));
         };
 
         // Cek tipe client
@@ -167,8 +169,9 @@ export default function UserInsightPage() {
             if (hasTT) clientMap[id].tiktokFilled += 1;
             else clientMap[id].tiktokEmpty += 1;
           });
+          const score = (o) => o.total + o.instagramFilled + o.tiktokFilled;
           setChartPolres(
-            Object.values(clientMap).sort((a, b) => b.total - a.total),
+            Object.values(clientMap).sort((a, b) => score(b) - score(a)),
           );
         } else {
           const grouped = groupUsersByKelompok(processedUsers);


### PR DESCRIPTION
## Summary
- order division data by combined total, Instagram, and TikTok inputs for clearer performance ranking

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68babb02b04c8327a62aae588877c273