### PR TITLE
Ensure input text appears black with grey placeholders

### DIFF
--- a/cicero-dashboard/app/globals.css
+++ b/cicero-dashboard/app/globals.css
@@ -66,3 +66,16 @@ body {
   padding: 0.5rem 1rem;
   z-index: 50;
 }
+
+/* Input text should always be black while placeholders remain grey */
+input::placeholder,
+textarea::placeholder,
+select::placeholder {
+  color: #9ca3af; /* gray */
+}
+
+input,
+textarea,
+select {
+  color: #000; /* black */
+}


### PR DESCRIPTION
## Summary
- enforce black text for all inputs and textareas
- style placeholders to remain gray across the app

## Testing
- `npm test`
- `npm run lint` *(fails: requires interactive configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68bafb52f75083279e611d35cec72d83