### PR TITLE
Allow flexible IG and TikTok profile inputs

### DIFF
--- a/cicero-dashboard/app/claim/edit/page.jsx
+++ b/cicero-dashboard/app/claim/edit/page.jsx
@@ -230,20 +230,18 @@ export default function EditUserPage() {
         <div className="mb-3">
           <label className="block text-sm mb-1">Link Profile Instagram</label>
           <input
-            type="url"
+            type="text"
             value={insta}
             onChange={(e) => setInsta(e.target.value)}
-            pattern="^https?:\\/\\/(www\\.)?instagram\\.com\\/[A-Za-z0-9._-]+(\\/?(\\?.*)?)?$"
             className="w-full px-3 py-2 rounded-md border border-gray-300 focus:outline-none focus:border-blue-400"
           />
         </div>
         <div className="mb-4">
           <label className="block text-sm mb-1">Link Profile TikTok</label>
           <input
-            type="url"
+            type="text"
             value={tiktok}
             onChange={(e) => setTiktok(e.target.value)}
-            pattern="^https?:\\/\\/(www\\.)?tiktok\\.com\\/@[A-Za-z0-9._-]+(\\/?(\\?.*)?)?$"
             className="w-full px-3 py-2 rounded-md border border-gray-300 focus:outline-none focus:border-blue-400"
           />
         </div>


### PR DESCRIPTION
## Summary
- remove strict URL validation from Instagram and TikTok fields so links or usernames are accepted

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68bcf15bea688327872b3d483d8daa64