### PR TITLE
Switch claim OTP flow to email

### DIFF
--- a/cicero-dashboard/app/claim/edit/page.jsx
+++ b/cicero-dashboard/app/claim/edit/page.jsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { getUserById, updateUserViaClaim } from "@/utils/api";
+import { getClaimUserData, updateUserViaClaim } from "@/utils/api";
 
 function extractInstagramUsername(url) {
   if (!url) return "";
@@ -49,7 +49,7 @@ function isValidTiktok(url) {
 
 export default function EditUserPage() {
   const [nrp, setNrp] = useState("");
-  const [whatsapp, setWhatsapp] = useState("");
+  const [email, setEmail] = useState("");
   const [kesatuan, setKesatuan] = useState("");
   const [nama, setNama] = useState("");
   const [pangkat, setPangkat] = useState("");
@@ -66,20 +66,20 @@ export default function EditUserPage() {
   useEffect(() => {
     if (typeof window !== "undefined") {
       const n = sessionStorage.getItem("claim_nrp");
-      const w = sessionStorage.getItem("claim_whatsapp");
+      const w = sessionStorage.getItem("claim_email");
       if (!n || !w) {
         router.replace("/claim");
         return;
       }
       setNrp(n);
-      setWhatsapp(w);
-      loadUser(n);
+      setEmail(w);
+      loadUser(n, w);
     }
   }, [router]);
 
-  async function loadUser(n) {
+  async function loadUser(n, w) {
     try {
-      const res = await getUserById(n);
+      const res = await getClaimUserData(n, w);
       const user = res.data || res.user || res;
       setKesatuan(user.nama_client || user.client_name || user.client_id || "");
       setNama(user.nama || "");
@@ -116,7 +116,7 @@ export default function EditUserPage() {
     try {
       const res = await updateUserViaClaim({
         nrp,
-        whatsapp,
+        email,
         nama: nama.trim(),
         title: pangkat.trim(),
         divisi: satfung.trim(),

--- a/cicero-dashboard/app/claim/otp/page.jsx
+++ b/cicero-dashboard/app/claim/otp/page.jsx
@@ -6,7 +6,7 @@ import { verifyClaimOtp } from "@/utils/api";
 
 export default function OtpPage() {
   const [nrp, setNrp] = useState("");
-  const [whatsapp, setWhatsapp] = useState("");
+  const [email, setEmail] = useState("");
   const [otp, setOtp] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
@@ -15,12 +15,12 @@ export default function OtpPage() {
   useEffect(() => {
     if (typeof window !== "undefined") {
       const n = sessionStorage.getItem("claim_nrp");
-      const w = sessionStorage.getItem("claim_whatsapp");
+      const w = sessionStorage.getItem("claim_email");
       if (!n || !w) {
         router.replace("/claim");
       } else {
         setNrp(n);
-        setWhatsapp(w);
+        setEmail(w);
       }
     }
   }, [router]);
@@ -30,7 +30,7 @@ export default function OtpPage() {
     setError("");
     setLoading(true);
     try {
-      const res = await verifyClaimOtp(nrp, whatsapp, otp.trim());
+      const res = await verifyClaimOtp(nrp, email, otp.trim());
       const verified = res.verified ?? res.data?.verified;
       if (res.success && verified) {
         router.push("/claim/edit");

--- a/cicero-dashboard/app/claim/page.jsx
+++ b/cicero-dashboard/app/claim/page.jsx
@@ -2,11 +2,11 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { requestClaimOtp, normalizeWhatsapp } from "@/utils/api";
+import { requestClaimOtp } from "@/utils/api";
 
 export default function ClaimPage() {
   const [nrp, setNrp] = useState("");
-  const [whatsapp, setWhatsapp] = useState("");
+  const [email, setEmail] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
   const router = useRouter();
@@ -16,12 +16,11 @@ export default function ClaimPage() {
     setError("");
     setLoading(true);
     try {
-      const normalizedWhatsapp = normalizeWhatsapp(whatsapp);
-      const res = await requestClaimOtp(nrp.trim(), normalizedWhatsapp);
+      const res = await requestClaimOtp(nrp.trim(), email.trim());
       if (res.success) {
         if (typeof window !== "undefined") {
           sessionStorage.setItem("claim_nrp", nrp.trim());
-          sessionStorage.setItem("claim_whatsapp", normalizedWhatsapp);
+          sessionStorage.setItem("claim_email", email.trim());
         }
         router.push("/claim/otp");
       } else {
@@ -60,15 +59,15 @@ export default function ClaimPage() {
           />
         </div>
         <div className="mb-4">
-          <label htmlFor="wa" className="sr-only">
-            Nomor WhatsApp
+          <label htmlFor="email" className="sr-only">
+            Email
           </label>
           <input
-            id="wa"
-            type="tel"
-            placeholder="Nomor WhatsApp"
-            value={whatsapp}
-            onChange={(e) => setWhatsapp(e.target.value)}
+            id="email"
+            type="email"
+            placeholder="Email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
             required
             className="w-full px-3 py-2 rounded-md border border-gray-300 focus:outline-none focus:border-blue-400"
           />

--- a/cicero-dashboard/utils/api.ts
+++ b/cicero-dashboard/utils/api.ts
@@ -516,17 +516,31 @@ export async function getUserById(nrp: string): Promise<any> {
   return res.json();
 }
 
-// Request OTP to be sent via WhatsApp
-export async function requestClaimOtp(
+// Fetch user data in claim flow after OTP verification
+export async function getClaimUserData(
   nrp: string,
-  whatsapp: string,
+  email: string,
 ): Promise<any> {
-  const url = `${API_BASE_URL}/api/claim/request-otp`;
-  const normalizedWhatsapp = normalizeWhatsapp(whatsapp);
+  const url = `${API_BASE_URL}/api/claim/user-data`;
   const res = await fetch(url, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ nrp, whatsapp: normalizedWhatsapp }),
+    body: JSON.stringify({ nrp, email }),
+  });
+  if (!res.ok) throw new Error("Failed to fetch user");
+  return res.json();
+}
+
+// Request OTP to be sent via email
+export async function requestClaimOtp(
+  nrp: string,
+  email: string,
+): Promise<any> {
+  const url = `${API_BASE_URL}/api/claim/request-otp`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ nrp, email }),
   });
   if (!res.ok) throw new Error("Failed to request OTP");
   return res.json();
@@ -535,15 +549,14 @@ export async function requestClaimOtp(
 // Verify OTP provided by user
 export async function verifyClaimOtp(
   nrp: string,
-  whatsapp: string,
+  email: string,
   otp: string,
 ): Promise<any> {
   const url = `${API_BASE_URL}/api/claim/verify-otp`;
-  const normalizedWhatsapp = normalizeWhatsapp(whatsapp);
   const res = await fetch(url, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ nrp, whatsapp: normalizedWhatsapp, otp }),
+    body: JSON.stringify({ nrp, email, otp }),
   });
   if (!res.ok) throw new Error("Failed to verify OTP");
   const data = await res.json();
@@ -554,7 +567,7 @@ export async function verifyClaimOtp(
 export async function updateUserViaClaim(
   data: {
     nrp: string;
-    whatsapp: string;
+    email: string;
     nama?: string;
     title?: string;
     divisi?: string;


### PR DESCRIPTION
## Summary
- use claim user-data endpoint requiring email for verified claim users
- update claim edit page to load data with email after OTP verification

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c00bfcb3608327a83880d451bf0238