### PR TITLE
feat: add informational tag for non-direktorat user insight

### DIFF
--- a/cicero-dashboard/app/user-insight/page.jsx
+++ b/cicero-dashboard/app/user-insight/page.jsx
@@ -268,6 +268,16 @@ export default function UserInsightPage() {
               </div>
             </div>
 
+            {!isDirectorate && (
+              <div className="self-start">
+                <span
+                  className="inline-block bg-blue-100 text-blue-800 text-xs md:text-sm font-medium px-3 py-1 rounded border border-blue-200"
+                >
+                  Polres Jajaran dapat mengajukan request sistem untuk diterapkan di kesatuan masing-masing, sekaligus melakukan absensi personil guna meningkatkan engagement media sosial resmi kesatuannya.
+                </span>
+              </div>
+            )}
+
             <div className="bg-gradient-to-tr from-blue-50 to-white rounded-2xl shadow flex flex-col md:flex-row items-stretch justify-between p-3 md:p-5 gap-2 md:gap-4 border">
               <SummaryItem
                 label="Total User"


### PR DESCRIPTION
## Summary
- show information tag on User Insight page when client type is not DIREKTORAT

## Testing
- `npm test`
- `npm run lint` *(fails: interactive prompt `How would you like to configure ESLint?`)*

------
https://chatgpt.com/codex/tasks/task_e_68c0b6e1b24c832782f652ec0173fb2c