### PR TITLE
refactor: centralize client profile fetch

### DIFF
--- a/cicero-dashboard/components/ClientProfileMenu.tsx
+++ b/cicero-dashboard/components/ClientProfileMenu.tsx
@@ -1,26 +1,11 @@
 "use client";
 import { useState, useEffect, useRef } from "react";
-import { getClientProfile } from "@/utils/api";
 import { useAuth } from "@/context/AuthContext";
 
 export default function ClientProfileMenu() {
-  const { token, clientId } = useAuth();
-  const [profile, setProfile] = useState<any>(null);
+  const { profile } = useAuth();
   const [open, setOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    async function fetchProfile() {
-      if (!token || !clientId) return;
-      try {
-        const res = await getClientProfile(token, clientId);
-        setProfile(res.client || res.profile || res);
-      } catch (err) {
-        console.error(err);
-      }
-    }
-    fetchProfile();
-  }, [token, clientId]);
 
   useEffect(() => {
     function handleClick(e: MouseEvent) {

--- a/cicero-dashboard/components/Sidebar.jsx
+++ b/cicero-dashboard/components/Sidebar.jsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import { usePathname } from "next/navigation";
@@ -25,27 +25,12 @@ import {
   SheetTitle,
 } from "@/components/ui/sheet";
 import { useAuth } from "@/context/AuthContext";
-import { getClientProfile } from "@/utils/api";
 
 export default function Sidebar() {
   const pathname = usePathname();
   const [open, setOpen] = useState(false);
   const [collapsed, setCollapsed] = useState(false);
-  const { token, clientId, role } = useAuth();
-  const [profile, setProfile] = useState(null);
-
-  useEffect(() => {
-    async function fetchProfile() {
-      if (!token || !clientId) return;
-      try {
-        const res = await getClientProfile(token, clientId);
-        setProfile(res.client || res.profile || res);
-      } catch (err) {
-        console.error(err);
-      }
-    }
-    fetchProfile();
-  }, [token, clientId]);
+  const { role, profile } = useAuth();
   function isActive(val) {
     return val === true || val === "true" || val === 1 || val === "1";
   }

--- a/cicero-dashboard/context/AuthContext.tsx
+++ b/cicero-dashboard/context/AuthContext.tsx
@@ -1,11 +1,13 @@
 "use client";
 import { createContext, useContext, useEffect, useState } from "react";
+import { getClientProfile } from "@/utils/api";
 
 type AuthState = {
   token: string | null;
   clientId: string | null;
   userId: string | null;
   role: string | null;
+  profile: any | null;
   setAuth: (
     token: string | null,
     clientId: string | null,
@@ -21,6 +23,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [clientId, setClientId] = useState<string | null>(null);
   const [userId, setUserId] = useState<string | null>(null);
   const [role, setRole] = useState<string | null>(null);
+  const [profile, setProfile] = useState<any | null>(null);
 
   useEffect(() => {
     const storedToken = localStorage.getItem("cicero_token");
@@ -32,6 +35,19 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     setUserId(storedUser);
     setRole(storedRole);
   }, []);
+
+  useEffect(() => {
+    async function fetchProfile() {
+      if (!token || !clientId) return;
+      try {
+        const res = await getClientProfile(token, clientId);
+        setProfile(res.client || res.profile || res);
+      } catch (err) {
+        console.error(err);
+      }
+    }
+    fetchProfile();
+  }, [token, clientId]);
 
   const setAuth = (
     newToken: string | null,
@@ -54,7 +70,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   };
 
   return (
-    <AuthContext.Provider value={{ token, clientId, userId, role, setAuth }}>
+    <AuthContext.Provider value={{ token, clientId, userId, role, profile, setAuth }}>
       {children}
     </AuthContext.Provider>
   );


### PR DESCRIPTION
## Summary
- avoid duplicate `/api/clients/profile` calls by fetching client profile once in `AuthContext`
- consume shared profile in `Sidebar` and `ClientProfileMenu`

## Testing
- `npm test`
- `npm run lint` *(fails: requires interactive ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68c399ede08483279c0f6f21df1b9bfe