### PR TITLE
feat: add comment element selection

### DIFF
--- a/cicero-dashboard/app/dashboard/page.tsx
+++ b/cicero-dashboard/app/dashboard/page.tsx
@@ -37,6 +37,13 @@ export default function DashboardPage() {
     fetchData();
   }, [token]);
 
+  useEffect(() => {
+    const comment = document.querySelector<HTMLElement>("#comm1");
+    if (comment) {
+      comment.style.border = "1px solid red";
+    }
+  }, []);
+
   return (
     <div className="min-h-screen bg-gray-100 flex flex-col items-center py-8">
       <div className="w-full max-w-6xl space-y-6">


### PR DESCRIPTION
## Summary
- highlight comment element `#comm1` on dashboard using `document.querySelector`

## Testing
- `cd cicero-dashboard && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3a60101908327b1b7b63abaafeb70