### PR TITLE
feat: enhance dashboard social cards

### DIFF
--- a/cicero-dashboard/components/DashboardStats.jsx
+++ b/cicero-dashboard/components/DashboardStats.jsx
@@ -2,10 +2,22 @@ import CardStat from "./CardStat";
 
 export default function DashboardStats({ igProfile, igPosts, tiktokProfile, tiktokPosts }) {
   const stats = [
-    { title: "IG Followers", value: igProfile?.followers ?? 0 },
-    { title: "IG Posts", value: igPosts?.length ?? 0 },
-    { title: "TikTok Followers", value: tiktokProfile?.followers ?? 0 },
-    { title: "TikTok Posts", value: tiktokPosts?.length ?? 0 },
+    {
+      title: "IG Followers",
+      value: igProfile?.follower_count ?? igProfile?.followers ?? 0,
+    },
+    {
+      title: "IG Posts",
+      value: igProfile?.post_count ?? igPosts?.length ?? 0,
+    },
+    {
+      title: "TikTok Followers",
+      value: tiktokProfile?.follower_count ?? tiktokProfile?.followers ?? 0,
+    },
+    {
+      title: "TikTok Posts",
+      value: tiktokProfile?.video_count ?? tiktokPosts?.length ?? 0,
+    },
   ];
 
   return (

--- a/cicero-dashboard/components/InstagramPostsGrid.jsx
+++ b/cicero-dashboard/components/InstagramPostsGrid.jsx
@@ -10,11 +10,16 @@ export default function InstagramPostsGrid({ posts = [] }) {
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
       {posts.map((post) => (
         <div
-          key={post.id || post.post_id}
+          key={post.id || post.post_id || post.shortcode}
           className="bg-white rounded-lg shadow border overflow-hidden"
         >
           <img
-            src={getThumbnailSrc(post.thumbnail)}
+            src={getThumbnailSrc(
+              post.thumbnail ||
+                post.thumbnail_url ||
+                post.image_url ||
+                (post.images_url && post.images_url[0])
+            )}
             alt={post.caption || "thumbnail"}
             className="w-full h-48 object-cover"
             onError={(e) => {

--- a/cicero-dashboard/components/SocialCard.tsx
+++ b/cicero-dashboard/components/SocialCard.tsx
@@ -1,5 +1,7 @@
 "use client";
 import { useState } from "react";
+import InstagramPostsGrid from "./InstagramPostsGrid";
+import TiktokPostsGrid from "./TiktokPostsGrid";
 
 interface SocialCardProps {
   platform: string;
@@ -10,7 +12,7 @@ interface SocialCardProps {
 export default function SocialCard({ platform, profile, posts }: SocialCardProps) {
   const [showTooltip, setShowTooltip] = useState(false);
 
-  const getThumb = (url: string) => {
+  const getThumb = (url: string | undefined | null) => {
     if (!url) return null;
     return url.replace(/\.heic(\?|$)/, ".jpg$1");
   };
@@ -38,6 +40,12 @@ export default function SocialCard({ platform, profile, posts }: SocialCardProps
       : `https://www.tiktok.com/@${profile.username}`;
   const avatarSrc = getThumb(avatar);
 
+  const followers = profile.followers ?? profile.follower_count ?? 0;
+  const following = profile.following ?? profile.following_count ?? 0;
+  const postCount = profile.post_count ?? posts?.length ?? 0;
+  const bio = profile.bio ?? profile.biography;
+  const name = profile.full_name ?? profile.nickname;
+
   return (
     <div className="bg-white rounded-xl shadow p-4 flex flex-col">
       <h2 className="font-semibold capitalize mb-2">{platform} Profile</h2>
@@ -53,52 +61,44 @@ export default function SocialCard({ platform, profile, posts }: SocialCardProps
             }}
           />
         )}
-        <a
-          href={link}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="font-semibold text-blue-600 hover:underline"
-        >
-          @{profile.username}
-        </a>
+        <div className="flex flex-col">
+          {name && <span className="font-semibold">{name}</span>}
+          <a
+            href={link}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-600 hover:underline"
+          >
+            @{profile.username}
+          </a>
+        </div>
         <span
           className="text-sm text-gray-500 relative"
           onMouseEnter={() => setShowTooltip(true)}
           onMouseLeave={() => setShowTooltip(false)}
         >
-          {profile.followers} followers
+          {followers} followers
           {showTooltip && (
             <span className="absolute left-0 top-full mt-1 w-max bg-black text-white text-xs rounded px-2 py-1">
               Total pengikut akun
             </span>
           )}
         </span>
-        <span className="text-sm text-gray-500">{profile.following} following</span>
+        <span className="text-sm text-gray-500">{following} following</span>
+        <span className="text-sm text-gray-500">{postCount} posts</span>
       </div>
-      {profile.bio && (
-        <div className="text-sm text-gray-500 whitespace-pre-line mt-1">
-          {profile.bio}
+      {bio && (
+        <div className="text-sm text-gray-500 whitespace-pre-line mt-2">
+          {bio}
         </div>
       )}
       {posts && posts.length > 0 && (
-        <div className="flex gap-2 mt-4">
-          {posts.slice(0, 3).map((p) => {
-            const thumb = getThumb(p.thumbnail);
-            return (
-              thumb && (
-                <img
-                  key={p.id || p.post_id}
-                  src={thumb}
-                  alt="thumb"
-                  loading="lazy"
-                  className="w-16 h-16 object-cover rounded"
-                  onError={(e) => {
-                    e.currentTarget.style.display = "none";
-                  }}
-                />
-              )
-            );
-          })}
+        <div className="mt-4">
+          {platform === "instagram" ? (
+            <InstagramPostsGrid posts={posts.slice(0, 3)} />
+          ) : (
+            <TiktokPostsGrid posts={posts.slice(0, 3)} />
+          )}
         </div>
       )}
     </div>

--- a/cicero-dashboard/components/TiktokPostsGrid.jsx
+++ b/cicero-dashboard/components/TiktokPostsGrid.jsx
@@ -10,11 +10,13 @@ export default function TiktokPostsGrid({ posts = [] }) {
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
       {posts.map((post) => (
         <div
-          key={post.id || post.post_id}
+          key={post.id || post.post_id || post.video_id}
           className="bg-white rounded-lg shadow border overflow-hidden"
         >
           <img
-            src={getThumbnailSrc(post.thumbnail)}
+            src={getThumbnailSrc(
+              post.thumbnail || post.thumbnail_url || post.cover_url
+            )}
             alt={post.caption || "thumbnail"}
             className="w-full h-48 object-cover"
             onError={(e) => {


### PR DESCRIPTION
## Summary
- adapt dashboard stats to new follower and post fields
- redesign social card to show full profile info and recent posts
- support flexible thumbnail fields for Instagram and TikTok grids

## Testing
- `npm test`
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68c3b0469b3483279eac8d846de38910