### PR TITLE
Fix posts grid props typing

### DIFF
--- a/cicero-dashboard/components/InstagramPostsGrid.tsx
+++ b/cicero-dashboard/components/InstagramPostsGrid.tsx
@@ -1,7 +1,26 @@
 "use client";
 import { Heart, MessageCircle, Eye } from "lucide-react";
-export default function InstagramPostsGrid({ posts = [] }) {
-  const getThumbnailSrc = (url) => {
+
+interface Post {
+  id?: string;
+  post_id?: string;
+  shortcode?: string;
+  thumbnail?: string;
+  thumbnail_url?: string;
+  image_url?: string;
+  images_url?: string[];
+  caption?: string;
+  like_count?: number;
+  comment_count?: number;
+  view_count?: number;
+}
+
+interface InstagramPostsGridProps {
+  posts?: Post[];
+}
+
+export default function InstagramPostsGrid({ posts = [] }: InstagramPostsGridProps) {
+  const getThumbnailSrc = (url?: string | null) => {
     if (!url) return "/file.svg";
     return url.replace(/\.heic(\?|$)/, ".jpg$1");
   };

--- a/cicero-dashboard/components/TiktokPostsGrid.tsx
+++ b/cicero-dashboard/components/TiktokPostsGrid.tsx
@@ -1,7 +1,25 @@
 "use client";
 import { Heart, MessageCircle, Eye } from "lucide-react";
-export default function TiktokPostsGrid({ posts = [] }) {
-  const getThumbnailSrc = (url) => {
+
+interface Post {
+  id?: string;
+  post_id?: string;
+  video_id?: string;
+  thumbnail?: string;
+  thumbnail_url?: string;
+  cover_url?: string;
+  caption?: string;
+  like_count?: number;
+  comment_count?: number;
+  view_count?: number;
+}
+
+interface TiktokPostsGridProps {
+  posts?: Post[];
+}
+
+export default function TiktokPostsGrid({ posts = [] }: TiktokPostsGridProps) {
+  const getThumbnailSrc = (url?: string | null) => {
     if (!url) return "/file.svg";
     return url.replace(/\.heic(\?|$)/, ".jpg$1");
   };


### PR DESCRIPTION
## Summary
- convert InstagramPostsGrid and TiktokPostsGrid components to TypeScript and type their posts props

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68c3b22b1cd483279da31dbbc5c5aec3