### PR TITLE
feat: add lazy loading and fallback for images

### DIFF
--- a/cicero-dashboard/app/info/instagram/page.jsx
+++ b/cicero-dashboard/app/info/instagram/page.jsx
@@ -224,6 +224,7 @@ export default function InstagramInfoPage() {
             <img
               src={getProfilePicSrc(profilePic)}
               alt="profile"
+              loading="lazy"
               className="w-24 h-24 rounded-full object-cover flex-shrink-0"
               onError={(e) => {
                 e.currentTarget.src = "/file.svg";

--- a/cicero-dashboard/app/posts/instagram/page.jsx
+++ b/cicero-dashboard/app/posts/instagram/page.jsx
@@ -353,6 +353,7 @@ export default function InstagramPostAnalysisPage() {
             <img
               src={getProfilePicSrc(profilePic)}
               alt="profile"
+              loading="lazy"
               className="w-24 h-24 rounded-full object-cover flex-shrink-0"
               onError={(e) => {
                 e.currentTarget.src = "/file.svg";

--- a/cicero-dashboard/app/posts/tiktok/page.jsx
+++ b/cicero-dashboard/app/posts/tiktok/page.jsx
@@ -354,6 +354,7 @@ export default function TiktokPostAnalysisPage() {
             <img
               src={getProfilePicSrc(profilePic)}
               alt="profile"
+              loading="lazy"
               className="w-24 h-24 rounded-full object-cover flex-shrink-0"
               onError={(e) => {
                 e.currentTarget.src = "/file.svg";

--- a/cicero-dashboard/components/InstagramPostsGrid.tsx
+++ b/cicero-dashboard/components/InstagramPostsGrid.tsx
@@ -40,6 +40,7 @@ export default function InstagramPostsGrid({ posts = [] }: InstagramPostsGridPro
                 (post.images_url && post.images_url[0])
             )}
             alt={post.caption || "thumbnail"}
+            loading="lazy"
             className="w-full h-48 object-cover"
             onError={(e) => {
               e.currentTarget.src = "/file.svg";

--- a/cicero-dashboard/components/TiktokPostsGrid.tsx
+++ b/cicero-dashboard/components/TiktokPostsGrid.tsx
@@ -36,6 +36,7 @@ export default function TiktokPostsGrid({ posts = [] }: TiktokPostsGridProps) {
               post.thumbnail || post.thumbnail_url || post.cover_url
             )}
             alt={post.caption || "thumbnail"}
+            loading="lazy"
             className="w-full h-48 object-cover"
             onError={(e) => {
               e.currentTarget.src = "/file.svg";

--- a/cicero-dashboard/components/profile/atoms/Avatar.tsx
+++ b/cicero-dashboard/components/profile/atoms/Avatar.tsx
@@ -2,6 +2,14 @@
 
 export default function Avatar({ src, alt }: { src: string; alt: string }) {
   return (
-    <img src={src} alt={alt} className="w-24 h-24 rounded-full object-cover" />
+    <img
+      src={src}
+      alt={alt}
+      loading="lazy"
+      className="w-24 h-24 rounded-full object-cover"
+      onError={(e) => {
+        e.currentTarget.src = "/file.svg";
+      }}
+    />
   );
 }

--- a/cicero-dashboard/components/tiktok/Info.jsx
+++ b/cicero-dashboard/components/tiktok/Info.jsx
@@ -229,6 +229,7 @@ export default function TiktokInfoPage({ embedded = false, hideHeader = false })
             <img
               src={getProfilePicSrc(profilePic)}
               alt="profile"
+              loading="lazy"
               className="w-24 h-24 rounded-full object-cover flex-shrink-0"
               onError={(e) => {
                 e.currentTarget.src = "/file.svg";

--- a/cicero-dashboard/components/tiktok/PostAnalysis.jsx
+++ b/cicero-dashboard/components/tiktok/PostAnalysis.jsx
@@ -264,6 +264,7 @@ export default function TiktokPostAnalysisPage({ embedded = false, hideHeader = 
             <img
               src={getProfilePicSrc(profilePic)}
               alt="profile"
+              loading="lazy"
               className="w-24 h-24 rounded-full object-cover flex-shrink-0"
               onError={(e) => {
                 e.currentTarget.src = "/file.svg";


### PR DESCRIPTION
## Summary
- add lazy loading and fallback for avatar images
- apply lazy loading to Instagram and TikTok post thumbnails
- ensure profile images on info and posts pages include lazy loading

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3db56fb9083278bc29dad53351d80