### PR TITLE
feat: split social profile and posts cards

### DIFF
--- a/cicero-dashboard/components/InstagramPostsGrid.tsx
+++ b/cicero-dashboard/components/InstagramPostsGrid.tsx
@@ -27,49 +27,54 @@ export default function InstagramPostsGrid({ posts = [] }: InstagramPostsGridPro
 
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-      {posts.map((post) => (
-        <div
-          key={post.id || post.post_id || post.shortcode}
-          className="bg-white rounded-lg shadow border overflow-hidden"
-        >
-          <img
-            src={getThumbnailSrc(
-              post.thumbnail ||
-                post.thumbnail_url ||
-                post.image_url ||
-                (post.images_url && post.images_url[0])
-            )}
-            alt={post.caption || "thumbnail"}
-            loading="lazy"
-            className="w-full h-48 object-cover"
-            onError={(e) => {
-              e.currentTarget.src = "/file.svg";
-            }}
-          />
-          <div className="p-4 flex flex-col gap-2">
-            <p className="font-semibold text-sm break-words">
-              {post.caption || "-"}
-            </p>
-            <div className="text-xs text-gray-600 flex gap-4">
-              {post.like_count != null && (
-                <span className="flex items-center gap-1">
-                  <Heart className="w-3 h-3" /> {post.like_count}
-                </span>
+      {posts.map((post) => {
+        const caption = post.caption || "-";
+        const truncated =
+          caption.length > 140 ? caption.slice(0, 140) + "..." : caption;
+        return (
+          <div
+            key={post.id || post.post_id || post.shortcode}
+            className="bg-white rounded-lg shadow border overflow-hidden"
+          >
+            <img
+              src={getThumbnailSrc(
+                post.thumbnail ||
+                  post.thumbnail_url ||
+                  post.image_url ||
+                  (post.images_url && post.images_url[0])
               )}
-              {post.comment_count != null && (
-                <span className="flex items-center gap-1">
-                  <MessageCircle className="w-3 h-3" /> {post.comment_count}
-                </span>
-              )}
-              {post.view_count != null && (
-                <span className="flex items-center gap-1">
-                  <Eye className="w-3 h-3" /> {post.view_count}
-                </span>
-              )}
+              alt={post.caption || "thumbnail"}
+              loading="lazy"
+              className="w-full h-48 object-cover"
+              onError={(e) => {
+                e.currentTarget.src = "/file.svg";
+              }}
+            />
+            <div className="p-4 flex flex-col gap-2">
+              <p className="font-semibold text-sm break-words">
+                {truncated}
+              </p>
+              <div className="text-xs text-gray-600 flex gap-4">
+                {post.like_count != null && (
+                  <span className="flex items-center gap-1">
+                    <Heart className="w-3 h-3" /> {post.like_count}
+                  </span>
+                )}
+                {post.comment_count != null && (
+                  <span className="flex items-center gap-1">
+                    <MessageCircle className="w-3 h-3" /> {post.comment_count}
+                  </span>
+                )}
+                {post.view_count != null && (
+                  <span className="flex items-center gap-1">
+                    <Eye className="w-3 h-3" /> {post.view_count}
+                  </span>
+                )}
+              </div>
             </div>
           </div>
-        </div>
-      ))}
+        );
+      })}
       {posts.length === 0 && (
         <div className="col-span-full text-center text-gray-500">
           No posts available

--- a/cicero-dashboard/components/SocialCardsClient.tsx
+++ b/cicero-dashboard/components/SocialCardsClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useState } from "react";
-import SocialCard from "./SocialCard";
+import SocialProfileCard from "./SocialProfileCard";
+import SocialPostsCard from "./SocialPostsCard";
 
 interface Props {
   igProfile: any;
@@ -15,7 +16,9 @@ export default function SocialCardsClient({
   tiktokProfile,
   tiktokPosts,
 }: Props) {
-  const [platform, setPlatform] = useState<"all" | "instagram" | "tiktok">("all");
+  const [platform, setPlatform] = useState<"all" | "instagram" | "tiktok">(
+    "all"
+  );
 
   const buttons = [
     { key: "all", label: "Semua" },
@@ -29,7 +32,9 @@ export default function SocialCardsClient({
         {buttons.map((b) => (
           <button
             key={b.key}
-            className={`px-3 py-1 rounded ${platform === b.key ? "bg-blue-500 text-white" : "bg-gray-200"}`}
+            className={`px-3 py-1 rounded ${
+              platform === b.key ? "bg-blue-500 text-white" : "bg-gray-200"
+            }`}
             onClick={() => setPlatform(b.key)}
           >
             {b.label}
@@ -38,17 +43,26 @@ export default function SocialCardsClient({
       </div>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         {(platform === "all" || platform === "instagram") && (
-          <SocialCard platform="instagram" profile={igProfile} posts={igPosts} />
+          <>
+            <SocialProfileCard
+              platform="instagram"
+              profile={igProfile}
+              postCount={igPosts.length}
+            />
+            <SocialPostsCard platform="instagram" posts={igPosts} />
+          </>
         )}
         {(platform === "all" || platform === "tiktok") && (
-          <SocialCard
-            platform="tiktok"
-            profile={tiktokProfile}
-            posts={tiktokPosts}
-          />
+          <>
+            <SocialProfileCard
+              platform="tiktok"
+              profile={tiktokProfile}
+              postCount={tiktokPosts.length}
+            />
+            <SocialPostsCard platform="tiktok" posts={tiktokPosts} />
+          </>
         )}
       </div>
     </>
   );
 }
-

--- a/cicero-dashboard/components/SocialPostsCard.tsx
+++ b/cicero-dashboard/components/SocialPostsCard.tsx
@@ -1,0 +1,30 @@
+"use client";
+import InstagramPostsGrid from "./InstagramPostsGrid";
+import TiktokPostsGrid from "./TiktokPostsGrid";
+
+interface SocialPostsCardProps {
+  platform: string;
+  posts: any[];
+}
+
+export default function SocialPostsCard({
+  platform,
+  posts,
+}: SocialPostsCardProps) {
+  return (
+    <div className="bg-white rounded-xl shadow p-4 flex flex-col">
+      <h2 className="font-semibold capitalize mb-2">{platform} Posts</h2>
+      {posts && posts.length > 0 ? (
+        <div>
+          {platform === "instagram" ? (
+            <InstagramPostsGrid posts={posts.slice(0, 3)} />
+          ) : (
+            <TiktokPostsGrid posts={posts.slice(0, 3)} />
+          )}
+        </div>
+      ) : (
+        <div className="text-sm text-gray-500">No posts available</div>
+      )}
+    </div>
+  );
+}

--- a/cicero-dashboard/components/SocialProfileCard.tsx
+++ b/cicero-dashboard/components/SocialProfileCard.tsx
@@ -1,15 +1,17 @@
 "use client";
 import { useState } from "react";
-import InstagramPostsGrid from "./InstagramPostsGrid";
-import TiktokPostsGrid from "./TiktokPostsGrid";
 
-interface SocialCardProps {
+interface SocialProfileCardProps {
   platform: string;
   profile: any;
-  posts: any[];
+  postCount?: number;
 }
 
-export default function SocialCard({ platform, profile, posts }: SocialCardProps) {
+export default function SocialProfileCard({
+  platform,
+  profile,
+  postCount = 0,
+}: SocialProfileCardProps) {
   const [showTooltip, setShowTooltip] = useState(false);
 
   const getThumb = (url: string | undefined | null) => {
@@ -42,7 +44,6 @@ export default function SocialCard({ platform, profile, posts }: SocialCardProps
 
   const followers = profile.followers ?? profile.follower_count ?? 0;
   const following = profile.following ?? profile.following_count ?? 0;
-  const postCount = profile.post_count ?? posts?.length ?? 0;
   const bio = profile.bio ?? profile.biography;
   const name = profile.full_name ?? profile.nickname;
 
@@ -92,16 +93,6 @@ export default function SocialCard({ platform, profile, posts }: SocialCardProps
           {bio}
         </div>
       )}
-      {posts && posts.length > 0 && (
-        <div className="mt-4">
-          {platform === "instagram" ? (
-            <InstagramPostsGrid posts={posts.slice(0, 3)} />
-          ) : (
-            <TiktokPostsGrid posts={posts.slice(0, 3)} />
-          )}
-        </div>
-      )}
     </div>
   );
 }
-

--- a/cicero-dashboard/components/TiktokPostsGrid.tsx
+++ b/cicero-dashboard/components/TiktokPostsGrid.tsx
@@ -26,46 +26,51 @@ export default function TiktokPostsGrid({ posts = [] }: TiktokPostsGridProps) {
 
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-      {posts.map((post) => (
-        <div
-          key={post.id || post.post_id || post.video_id}
-          className="bg-white rounded-lg shadow border overflow-hidden"
-        >
-          <img
-            src={getThumbnailSrc(
-              post.thumbnail || post.thumbnail_url || post.cover_url
-            )}
-            alt={post.caption || "thumbnail"}
-            loading="lazy"
-            className="w-full h-48 object-cover"
-            onError={(e) => {
-              e.currentTarget.src = "/file.svg";
-            }}
-          />
-          <div className="p-4 flex flex-col gap-2">
-            <p className="font-semibold text-sm break-words">
-              {post.caption || "-"}
-            </p>
-            <div className="text-xs text-gray-600 flex gap-4">
-              {post.like_count != null && (
-                <span className="flex items-center gap-1">
-                  <Heart className="w-3 h-3" /> {post.like_count}
-                </span>
+      {posts.map((post) => {
+        const caption = post.caption || "-";
+        const truncated =
+          caption.length > 140 ? caption.slice(0, 140) + "..." : caption;
+        return (
+          <div
+            key={post.id || post.post_id || post.video_id}
+            className="bg-white rounded-lg shadow border overflow-hidden"
+          >
+            <img
+              src={getThumbnailSrc(
+                post.thumbnail || post.thumbnail_url || post.cover_url
               )}
-              {post.comment_count != null && (
-                <span className="flex items-center gap-1">
-                  <MessageCircle className="w-3 h-3" /> {post.comment_count}
-                </span>
-              )}
-              {post.view_count != null && (
-                <span className="flex items-center gap-1">
-                  <Eye className="w-3 h-3" /> {post.view_count}
-                </span>
-              )}
+              alt={post.caption || "thumbnail"}
+              loading="lazy"
+              className="w-full h-48 object-cover"
+              onError={(e) => {
+                e.currentTarget.src = "/file.svg";
+              }}
+            />
+            <div className="p-4 flex flex-col gap-2">
+              <p className="font-semibold text-sm break-words">
+                {truncated}
+              </p>
+              <div className="text-xs text-gray-600 flex gap-4">
+                {post.like_count != null && (
+                  <span className="flex items-center gap-1">
+                    <Heart className="w-3 h-3" /> {post.like_count}
+                  </span>
+                )}
+                {post.comment_count != null && (
+                  <span className="flex items-center gap-1">
+                    <MessageCircle className="w-3 h-3" /> {post.comment_count}
+                  </span>
+                )}
+                {post.view_count != null && (
+                  <span className="flex items-center gap-1">
+                    <Eye className="w-3 h-3" /> {post.view_count}
+                  </span>
+                )}
+              </div>
             </div>
           </div>
-        </div>
-      ))}
+        );
+      })}
       {posts.length === 0 && (
         <div className="col-span-full text-center text-gray-500">
           No posts available


### PR DESCRIPTION
## Summary
- separate social media profile and posts into distinct cards
- limit caption text length to 140 characters in post grids

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3dea8296c83279d07d81590af2fea