### PR TITLE
feat: centralize auth context with new hook

### DIFF
--- a/cicero-dashboard/app/amplify/page.jsx
+++ b/cicero-dashboard/app/amplify/page.jsx
@@ -11,7 +11,7 @@ import ChartDivisiAbsensi from "@/components/ChartDivisiAbsensi";
 import ChartHorizontal from "@/components/ChartHorizontal";
 import { groupUsersByKelompok } from "@/utils/grouping";
 import useRequireAuth from "@/hooks/useRequireAuth";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { Link as LinkIcon, User, Check, X, ArrowRight } from "lucide-react";
 
 export default function AmplifikasiLinkPage() {

--- a/cicero-dashboard/app/amplify/rekap/page.jsx
+++ b/cicero-dashboard/app/amplify/rekap/page.jsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import useRequireAuth from "@/hooks/useRequireAuth";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { getRekapAmplify, getClientProfile, getClientNames } from "@/utils/api";
 import Loader from "@/components/Loader";
 import RekapAmplifikasi from "@/components/RekapAmplifikasi";

--- a/cicero-dashboard/app/dashboard/page.tsx
+++ b/cicero-dashboard/app/dashboard/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import DashboardStats from "@/components/DashboardStats";
 import SocialCardsClient from "@/components/SocialCardsClient";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "";
 

--- a/cicero-dashboard/app/login/page.jsx
+++ b/cicero-dashboard/app/login/page.jsx
@@ -4,7 +4,7 @@ import useAuthRedirect from "@/hooks/useAuthRedirect";
 import { useState } from "react";
 import { Eye, EyeOff } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import DarkModeToggle from "@/components/DarkModeToggle";
 import { normalizeWhatsapp } from "@/utils/api";
 

--- a/cicero-dashboard/app/user-insight/page.jsx
+++ b/cicero-dashboard/app/user-insight/page.jsx
@@ -19,7 +19,7 @@ import {
 import { groupUsersByKelompok } from "@/utils/grouping";
 import Loader from "@/components/Loader";
 import useRequireAuth from "@/hooks/useRequireAuth";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import { User, Instagram, Music, RefreshCw } from "lucide-react";
 
 export default function UserInsightPage() {

--- a/cicero-dashboard/app/users/page.jsx
+++ b/cicero-dashboard/app/users/page.jsx
@@ -12,6 +12,7 @@ import {
 import { Pencil, Check, X, RefreshCw } from "lucide-react";
 import Loader from "@/components/Loader";
 import useRequireAuth from "@/hooks/useRequireAuth";
+import useAuth from "@/hooks/useAuth";
 import { compareUsersByPangkatAndNrp } from "@/utils/pangkat";
 import * as XLSX from "xlsx";
 
@@ -109,16 +110,9 @@ export default function UserDirectoryPage() {
   const [isDirectorate, setIsDirectorate] = useState(false);
   const [clientName, setClientName] = useState("");
   const [currentDate, setCurrentDate] = useState(new Date());
-
-  // Ambil client_id dan role dari localStorage
-  const client_id =
-    typeof window !== "undefined"
-      ? localStorage.getItem("client_id") || "BOJONEGORO"
-      : "BOJONEGORO";
-  const role =
-    typeof window !== "undefined" ? localStorage.getItem("role") || "" : "";
-  const token =
-    typeof window !== "undefined" ? localStorage.getItem("cicero_token") : null;
+  const { token, clientId, role: authRole } = useAuth();
+  const client_id = clientId || "BOJONEGORO";
+  const role = authRole || "";
 
   const isDitbinmasClient = client_id === "DITBINMAS";
   const isDitbinmas =

--- a/cicero-dashboard/components/ClientProfileMenu.tsx
+++ b/cicero-dashboard/components/ClientProfileMenu.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useState, useEffect, useRef } from "react";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export default function ClientProfileMenu() {
   const { profile } = useAuth();

--- a/cicero-dashboard/components/Header.tsx
+++ b/cicero-dashboard/components/Header.tsx
@@ -1,7 +1,7 @@
 "use client";
 import Link from "next/link";
 import Image from "next/image";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import DarkModeToggle from "./DarkModeToggle";
 import { usePathname, useRouter } from "next/navigation";
 import ClientProfileMenu from "./ClientProfileMenu";

--- a/cicero-dashboard/components/Sidebar.jsx
+++ b/cicero-dashboard/components/Sidebar.jsx
@@ -24,7 +24,7 @@ import {
   SheetContent,
   SheetTitle,
 } from "@/components/ui/sheet";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export default function Sidebar() {
   const pathname = usePathname();

--- a/cicero-dashboard/components/profile/organisms/ProfileDashboard.tsx
+++ b/cicero-dashboard/components/profile/organisms/ProfileDashboard.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import Loader from "@/components/Loader";
 import { getClientProfile } from "@/utils/api";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 import ProfileHeader from "../molecules/ProfileHeader";
 import StatsGrid from "../molecules/StatsGrid";
 import ActivityList from "../molecules/ActivityList";

--- a/cicero-dashboard/context/AuthContext.tsx
+++ b/cicero-dashboard/context/AuthContext.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { createContext, useContext, useEffect, useState } from "react";
+import { createContext, useEffect, useState } from "react";
 import { getClientProfile } from "@/utils/api";
 
 type AuthState = {
@@ -16,7 +16,7 @@ type AuthState = {
   ) => void;
 };
 
-const AuthContext = createContext<AuthState | undefined>(undefined);
+export const AuthContext = createContext<AuthState | undefined>(undefined);
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [token, setToken] = useState<string | null>(null);
@@ -76,8 +76,3 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   );
 }
 
-export function useAuth() {
-  const ctx = useContext(AuthContext);
-  if (!ctx) throw new Error("useAuth must be used within AuthProvider");
-  return ctx;
-}

--- a/cicero-dashboard/hooks/useAuth.ts
+++ b/cicero-dashboard/hooks/useAuth.ts
@@ -1,0 +1,9 @@
+"use client";
+import { useContext } from "react";
+import { AuthContext } from "@/context/AuthContext";
+
+export default function useAuth() {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error("useAuth must be used within AuthProvider");
+  return ctx;
+}

--- a/cicero-dashboard/hooks/useAuthRedirect.ts
+++ b/cicero-dashboard/hooks/useAuthRedirect.ts
@@ -2,7 +2,7 @@
 "use client";
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export default function useAuthRedirect() {
   const router = useRouter();

--- a/cicero-dashboard/hooks/useRequireAuth.ts
+++ b/cicero-dashboard/hooks/useRequireAuth.ts
@@ -1,7 +1,7 @@
 "use client";
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { useAuth } from "@/context/AuthContext";
+import useAuth from "@/hooks/useAuth";
 
 export default function useRequireAuth() {
   const router = useRouter();


### PR DESCRIPTION
## Summary
- persist token, client ID, and role in `AuthContext`
- add `useAuth` hook and refactor components to use context
- replace localStorage usage in user directory page with `useAuth`

## Testing
- `cd cicero-dashboard && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c4eaf900188327928ffa91833232ee