### PR TITLE
feat: integrate toast notifications

### DIFF
--- a/cicero-dashboard/app/layout.tsx
+++ b/cicero-dashboard/app/layout.tsx
@@ -2,6 +2,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import LayoutClient from "@/components/LayoutClient";
 import { AuthProvider } from "@/context/AuthContext";
+import Toast from "@/components/Toast";
 
 export const metadata = {
   title: "CICERO Dashboard",
@@ -30,6 +31,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
         <a href="#main-content" className="skip-link">Skip to main content</a>
         <AuthProvider>
+          <Toast />
           <LayoutClient>{children}</LayoutClient>
         </AuthProvider>
       </body>

--- a/cicero-dashboard/app/users/page.jsx
+++ b/cicero-dashboard/app/users/page.jsx
@@ -16,6 +16,7 @@ import useRequireAuth from "@/hooks/useRequireAuth";
 import useAuth from "@/hooks/useAuth";
 import { compareUsersByPangkatAndNrp } from "@/utils/pangkat";
 import * as XLSX from "xlsx";
+import { showToast } from "@/utils/showToast";
 
 const PAGE_SIZE = 50;
 
@@ -330,9 +331,12 @@ export default function UserDirectoryPage() {
     });
     try {
       await navigator.clipboard.writeText(lines.join("\n"));
-      alert("Rekap user berhasil disalin ke clipboard");
+      showToast("Rekap user berhasil disalin ke clipboard", "success");
     } catch (err) {
-      alert("Gagal menyalin rekap user: " + (err.message || err));
+      showToast(
+        "Gagal menyalin rekap user: " + (err.message || err),
+        "error",
+      );
     }
   }
 

--- a/cicero-dashboard/components/Toast.jsx
+++ b/cicero-dashboard/components/Toast.jsx
@@ -1,0 +1,6 @@
+"use client";
+import { Toaster } from "react-hot-toast";
+
+export default function Toast() {
+  return <Toaster position="top-right" />;
+}

--- a/cicero-dashboard/package-lock.json
+++ b/cicero-dashboard/package-lock.json
@@ -19,6 +19,7 @@
         "react-chartjs-2": "^5.3.0",
         "react-d3-cloud": "^1.0.6",
         "react-dom": "18.3.1",
+        "react-hot-toast": "^2.6.0",
         "react-pro-sidebar": "^1.1.0",
         "recharts": "^2.15.3",
         "swr": "^2.3.6",
@@ -5129,6 +5130,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/goober": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.16.tgz",
+      "integrity": "sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -7993,6 +8003,23 @@
       },
       "peerDependencies": {
         "react": "*"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.6.0.tgz",
+      "integrity": "sha512-bH+2EBMZ4sdyou/DPrfgIouFpcRLCJ+HoCA32UoAYHn6T3Ur5yfcDCeSr5mwldl6pFOsiocmrXMuoCJ1vV8bWg==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.1.3",
+        "goober": "^2.1.16"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-is": {

--- a/cicero-dashboard/package.json
+++ b/cicero-dashboard/package.json
@@ -21,6 +21,7 @@
     "react-chartjs-2": "^5.3.0",
     "react-d3-cloud": "^1.0.6",
     "react-dom": "18.3.1",
+    "react-hot-toast": "^2.6.0",
     "react-pro-sidebar": "^1.1.0",
     "recharts": "^2.15.3",
     "swr": "^2.3.6",

--- a/cicero-dashboard/utils/showToast.ts
+++ b/cicero-dashboard/utils/showToast.ts
@@ -1,0 +1,19 @@
+import { toast } from "react-hot-toast";
+
+export type ToastType = "success" | "error" | "loading" | "info";
+
+export function showToast(message: string, type: ToastType = "info") {
+  switch (type) {
+    case "success":
+      toast.success(message);
+      break;
+    case "error":
+      toast.error(message);
+      break;
+    case "loading":
+      toast.loading(message);
+      break;
+    default:
+      toast(message);
+  }
+}


### PR DESCRIPTION
## Summary
- add react-hot-toast dependency and Toast component
- implement showToast utility for consistent notifications
- use toast notifications in user rekap copy action

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c4ed604128832783af9e36f381ea0d