### PR TITLE
refactor: centralize user form validation

### DIFF
--- a/cicero-dashboard/__tests__/validateUserForm.test.ts
+++ b/cicero-dashboard/__tests__/validateUserForm.test.ts
@@ -1,0 +1,69 @@
+import { validateNewUser } from "@/utils/validateUserForm";
+
+describe("validateNewUser", () => {
+  it("returns trimmed values for valid input", () => {
+    const res = validateNewUser({
+      nama: "John",
+      pangkat: "BRIPDA",
+      nrpNip: " 12345 ",
+      satfung: "SAT LANTAS",
+      polsekName: "",
+    });
+    expect(res).toEqual({ nrpNip: "12345", satfungValue: "SAT LANTAS" });
+  });
+
+  it("returns error for non numeric nrp", () => {
+    const res = validateNewUser({
+      nama: "Jane",
+      pangkat: "BRIPDA",
+      nrpNip: "12a45",
+      satfung: "SAT LANTAS",
+      polsekName: "",
+    });
+    expect(res.error).toBe("NRP hanya boleh angka");
+  });
+
+  it("returns error for invalid pangkat", () => {
+    const res = validateNewUser({
+      nama: "Jane",
+      pangkat: "UNKNOWN",
+      nrpNip: "12345",
+      satfung: "SAT LANTAS",
+      polsekName: "",
+    });
+    expect(res.error).toBe("Pangkat tidak valid");
+  });
+
+  it("returns error when polsek name is missing", () => {
+    const res = validateNewUser({
+      nama: "Jane",
+      pangkat: "BRIPDA",
+      nrpNip: "12345",
+      satfung: "POLSEK",
+      polsekName: " ",
+    });
+    expect(res.error).toBe("Nama Polsek wajib diisi");
+  });
+
+  it("returns error for invalid satfung", () => {
+    const res = validateNewUser({
+      nama: "Jane",
+      pangkat: "BRIPDA",
+      nrpNip: "12345",
+      satfung: "UNKNOWN",
+      polsekName: "",
+    });
+    expect(res.error).toBe("Satfung tidak valid");
+  });
+
+  it("formats polsek satfung correctly", () => {
+    const res = validateNewUser({
+      nama: "Jane",
+      pangkat: "BRIPDA",
+      nrpNip: "12345",
+      satfung: "POLSEK",
+      polsekName: "Bojonegoro",
+    });
+    expect(res).toEqual({ nrpNip: "12345", satfungValue: "POLSEK Bojonegoro" });
+  });
+});

--- a/cicero-dashboard/app/users/page.jsx
+++ b/cicero-dashboard/app/users/page.jsx
@@ -17,6 +17,7 @@ import useAuth from "@/hooks/useAuth";
 import { compareUsersByPangkatAndNrp } from "@/utils/pangkat";
 import * as XLSX from "xlsx";
 import { showToast } from "@/utils/showToast";
+import { validateNewUser } from "@/utils/validateUserForm";
 
 const PAGE_SIZE = 50;
 
@@ -212,28 +213,10 @@ export default function UserDirectoryPage() {
     setSubmitError("");
     setSubmitLoading(true);
     try {
-      const trimmedNrpNip = nrpNip.trim();
-      if (!/^\d+$/.test(trimmedNrpNip)) {
-        throw new Error("NRP hanya boleh angka");
-      }
-      if (!PANGKAT_OPTIONS.includes(pangkat)) {
-        throw new Error("Pangkat tidak valid");
-      }
-      const satfungValue =
-        satfung === "POLSEK"
-          ? polsekName.trim()
-            ? `POLSEK ${polsekName.trim()}`
-            : ""
-          : satfung;
-      if (
-        satfung === "POLSEK" && !polsekName.trim()
-      ) {
-        throw new Error("Nama Polsek wajib diisi");
-      }
-      if (
-        satfung !== "POLSEK" && !SATFUNG_OPTIONS.includes(satfung)
-      ) {
-        throw new Error("Satfung tidak valid");
+      const { error: validationError, nrpNip: trimmedNrpNip, satfungValue } =
+        validateNewUser({ nama, pangkat, nrpNip, satfung, polsekName });
+      if (validationError) {
+        throw new Error(validationError);
       }
       await createUser(token || "", {
         client_id,

--- a/cicero-dashboard/utils/validateUserForm.ts
+++ b/cicero-dashboard/utils/validateUserForm.ts
@@ -1,0 +1,101 @@
+export const PANGKAT_OPTIONS = [
+  "BHARADA",
+  "BHARATU",
+  "BHARAKA",
+  "BRIPDA",
+  "BRIPTU",
+  "BRIGADIR",
+  "BRIPKA",
+  "AIPDA",
+  "AIPTU",
+  "IPDA",
+  "IPTU",
+  "AKP",
+  "KOMPOL",
+  "AKBP",
+  "KOMISARIS BESAR POLISI",
+  "JURU MUDA",
+  "JURU MUDA TINGKAT I",
+  "JURU",
+  "JURU TINGKAT I",
+  "PENGATUR MUDA",
+  "PENGATUR MUDA TINGKAT I",
+  "PENGATUR",
+  "PENGATUR TINGKAT I",
+  "PENATA MUDA",
+  "PENATA MUDA TINGKAT I",
+  "PENATA",
+  "PENATA TINGKAT I",
+  "PEMBINA",
+  "PEMBINA TINGKAT I",
+  "PEMBINA UTAMA MUDA",
+  "PEMBINA UTAMA MADYA",
+  "PEMBINA UTAMA",
+];
+
+export const SATFUNG_OPTIONS = [
+  "BAG LOG",
+  "BAG SDM",
+  "BAG REN",
+  "BAG OPS",
+  "SAT SAMAPTA",
+  "SAT RESKRIM",
+  "SAT INTEL",
+  "SAT NARKOBA",
+  "SAT BINMAS",
+  "SAT LANTAS",
+  "SI UM",
+  "SI TIK",
+  "SI WAS",
+  "SI PROPAM",
+  "SI DOKES",
+  "SPKT",
+  "SAT TAHTI",
+  "DITBINMAS",
+  "SUBBAGRENMIN",
+  "BAGBINOPSNAL",
+  "SUBDIT BINPOLMAS",
+  "SUBDIT SATPAMPOLSUS",
+  "SUBDIT BHABINKAMTIBMAS",
+  "SUBDIT BINTIBSOS",
+  "POLSEK",
+];
+
+interface NewUserData {
+  nama: string;
+  pangkat: string;
+  nrpNip: string;
+  satfung: string;
+  polsekName: string;
+}
+
+interface ValidationResult {
+  error?: string;
+  nrpNip?: string;
+  satfungValue?: string;
+}
+
+export function validateNewUser({ nama, pangkat, nrpNip, satfung, polsekName }: NewUserData): ValidationResult {
+  const trimmedNrpNip = nrpNip.trim();
+  if (!/^\d+$/.test(trimmedNrpNip)) {
+    return { error: "NRP hanya boleh angka" };
+  }
+  if (!PANGKAT_OPTIONS.includes(pangkat)) {
+    return { error: "Pangkat tidak valid" };
+  }
+  const trimmedPolsek = polsekName.trim();
+  const satfungValue =
+    satfung === "POLSEK"
+      ? trimmedPolsek
+        ? `POLSEK ${trimmedPolsek}`
+        : ""
+      : satfung;
+  if (satfung === "POLSEK" && !trimmedPolsek) {
+    return { error: "Nama Polsek wajib diisi" };
+  }
+  if (satfung !== "POLSEK" && !SATFUNG_OPTIONS.includes(satfung)) {
+    return { error: "Satfung tidak valid" };
+  }
+  return { nrpNip: trimmedNrpNip, satfungValue };
+}
+


### PR DESCRIPTION
## Summary
- add `validateNewUser` utility to verify new user form fields
- use validation util in user directory submission handler
- cover validation cases with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c4ee09164c832799bacf8ac15e47b1