### PR TITLE
Refactor instagram likes page components

### DIFF
--- a/cicero-dashboard/app/likes/instagram/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/page.jsx
@@ -1,24 +1,15 @@
 "use client";
-import { useEffect, useState } from "react";
-import {
-  getDashboardStats,
-  getRekapLikesIG,
-  getClientProfile,
-  getClientNames,
-  getUserDirectory,
-} from "@/utils/api";
-import { fetchDitbinmasAbsensiLikes } from "@/utils/absensiLikes";
 import Loader from "@/components/Loader";
-import ChartDivisiAbsensi from "@/components/ChartDivisiAbsensi";
+import ChartBox from "@/components/likes/instagram/ChartBox";
+import SummaryItem from "@/components/likes/instagram/SummaryItem";
+import Divider from "@/components/likes/instagram/Divider";
 import ChartHorizontal from "@/components/ChartHorizontal";
 import { groupUsersByKelompok } from "@/utils/grouping"; // pastikan path benar
 import Link from "next/link";
 import Narrative from "@/components/Narrative";
 import useRequireAuth from "@/hooks/useRequireAuth";
-import ViewDataSelector, {
-  getPeriodeDateForView,
-  VIEW_OPTIONS,
-} from "@/components/ViewDataSelector";
+import useInstagramEngagement from "@/hooks/useInstagramEngagement";
+import ViewDataSelector, { VIEW_OPTIONS } from "@/components/ViewDataSelector";
 import {
   Camera,
   User,
@@ -31,246 +22,24 @@ import {
 
 export default function InstagramEngagementInsightPage() {
   useRequireAuth();
-  const [stats, setStats] = useState(null);
-  const [chartData, setChartData] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState("");
-  const [viewBy, setViewBy] = useState("today");
-  const today = new Date().toISOString().split("T")[0];
-  const [customDate, setCustomDate] = useState(today);
-  const [fromDate, setFromDate] = useState(today);
-  const [toDate, setToDate] = useState(today);
-
-  // Untuk rekap likes summary (total user, sudah likes, belum likes)
-  const [rekapSummary, setRekapSummary] = useState({
-    totalUser: 0,
-    totalSudahLike: 0,
-    totalKurangLike: 0,
-    totalBelumLike: 0,
-    totalTanpaUsername: 0,
-    totalIGPost: 0,
-  });
-  const [isDirectorate, setIsDirectorate] = useState(false);
-  const [clientName, setClientName] = useState("");
+  const {
+    chartData,
+    loading,
+    error,
+    viewBy,
+    setViewBy,
+    customDate,
+    setCustomDate,
+    fromDate,
+    setFromDate,
+    toDate,
+    setToDate,
+    rekapSummary,
+    isDirectorate,
+    clientName,
+  } = useInstagramEngagement();
 
   const viewOptions = VIEW_OPTIONS;
-
-  useEffect(() => {
-    setLoading(true);
-    setError("");
-    const token =
-      typeof window !== "undefined"
-        ? localStorage.getItem("cicero_token")
-        : null;
-    const userClientId =
-      typeof window !== "undefined"
-        ? localStorage.getItem("client_id")
-        : null;
-    const role =
-      typeof window !== "undefined"
-        ? localStorage.getItem("user_role")
-        : null;
-    if (!token || !userClientId) {
-      setError("Token / Client ID tidak ditemukan. Silakan login ulang.");
-      setLoading(false);
-      return;
-    }
-
-    const isDitbinmas = String(role).toLowerCase() === "ditbinmas";
-    const taskClientId = isDitbinmas ? "DITBINMAS" : userClientId;
-
-    async function fetchData() {
-      try {
-        const selectedDate =
-          viewBy === "custom_range"
-            ? { startDate: fromDate, endDate: toDate }
-            : customDate;
-        const { periode, date, startDate, endDate } =
-          getPeriodeDateForView(viewBy, selectedDate);
-        if (isDitbinmas) {
-          const { users, summary } = await fetchDitbinmasAbsensiLikes(token, {
-            periode,
-            date,
-            startDate,
-            endDate,
-          });
-          setRekapSummary(summary);
-          setChartData(users);
-          setIsDirectorate(true);
-          return;
-        }
-
-        const statsData = await getDashboardStats(
-          token,
-          periode,
-          date,
-          startDate,
-          endDate,
-          taskClientId,
-        );
-        setStats(statsData);
-
-        const client_id = userClientId;
-
-
-        const profileRes = await getClientProfile(token, client_id);
-        const profile =
-          profileRes.client || profileRes.profile || profileRes || {};
-        const dir =
-          (profile.client_type || "").toUpperCase() === "DIREKTORAT";
-        setIsDirectorate(dir);
-        setClientName(
-          profile.nama ||
-            profile.nama_client ||
-            profile.client_name ||
-            profile.client ||
-            ""
-        );
-
-        let users = [];
-        if (dir) {
-          const directoryRes = await getUserDirectory(token, client_id);
-          const dirData =
-            directoryRes.data || directoryRes.users || directoryRes || [];
-          const expectedRole = String(client_id).toLowerCase();
-          const clientIds = Array.from(
-            new Set(
-              dirData
-                .filter(
-                  (u) =>
-                    String(
-                      u.role ||
-                        u.user_role ||
-                        u.userRole ||
-                        u.roleName ||
-                        "",
-                    ).toLowerCase() === expectedRole,
-                )
-                .map((u) =>
-                  String(
-                    u.client_id ||
-                      u.clientId ||
-                      u.clientID ||
-                      u.client ||
-                      "",
-                  ),
-                )
-                .filter(Boolean),
-            ),
-          );
-          if (!clientIds.includes(String(client_id))) {
-            clientIds.push(String(client_id));
-          }
-          const rekapAll = await Promise.all(
-            clientIds.map((cid) =>
-              getRekapLikesIG(
-                token,
-                cid,
-                periode,
-                date,
-                startDate,
-                endDate,
-              ).catch(() => ({ data: [] })),
-            ),
-          );
-          users = rekapAll.flatMap((res) =>
-            Array.isArray(res?.data)
-              ? res.data
-              : Array.isArray(res)
-              ? res
-              : [],
-          );
-        } else {
-          const rekapRes = await getRekapLikesIG(
-            token,
-            client_id,
-            periode,
-            date,
-            startDate,
-            endDate,
-          );
-          users = Array.isArray(rekapRes?.data)
-            ? rekapRes.data
-            : Array.isArray(rekapRes)
-            ? rekapRes
-            : [];
-        }
-
-        let enrichedUsers = users;
-        if (dir) {
-          const nameMap = await getClientNames(
-            token,
-            users.map((u) =>
-              String(
-                u.client_id || u.clientId || u.clientID || u.client || "",
-              ),
-            ),
-          );
-          enrichedUsers = users.map((u) => {
-            const clientName =
-              nameMap[
-                String(
-                  u.client_id || u.clientId || u.clientID || u.client || "",
-                )
-              ] ||
-              u.nama_client ||
-              u.client_name ||
-              u.client;
-            return {
-              ...u,
-              nama_client: clientName,
-              client_name: clientName,
-            };
-          });
-        }
-
-        // Rekap summary dengan klasifikasi lengkap
-        const totalUser = enrichedUsers.length;
-        const totalIGPost = Number(statsData.instagramPosts) || 0;
-        const isZeroPost = (totalIGPost || 0) === 0;
-        let totalSudahLike = 0;
-        let totalKurangLike = 0;
-        let totalBelumLike = 0;
-        let totalTanpaUsername = 0;
-        enrichedUsers.forEach((u) => {
-          const username = String(u.username || "").trim();
-          if (!username) {
-            totalTanpaUsername += 1;
-            return;
-          }
-          const jumlah = Number(u.jumlah_like) || 0;
-          if (isZeroPost) {
-            totalBelumLike += 1;
-            return;
-          }
-          if (jumlah >= totalIGPost * 0.5) {
-            totalSudahLike += 1;
-          } else if (jumlah > 0) {
-            totalKurangLike += 1;
-          } else {
-            totalBelumLike += 1;
-          }
-        });
-
-        setRekapSummary({
-          totalUser,
-          totalSudahLike,
-          totalKurangLike,
-          totalBelumLike,
-          totalTanpaUsername,
-          totalIGPost,
-        });
-        setChartData(enrichedUsers);
-      } catch (err) {
-        setError("Gagal mengambil data: " + (err.message || err));
-      } finally {
-        setLoading(false);
-      }
-    }
-
-    fetchData();
-  }, [viewBy, customDate, fromDate, toDate]);
-
   if (loading) return <Loader />;
   if (error)
     return (
@@ -506,65 +275,3 @@ export default function InstagramEngagementInsightPage() {
   );
 }
 
-// Komponen ChartBox di file yang sama
-function ChartBox({
-  title,
-  users,
-  orientation = "vertical",
-  totalPost,
-  narrative,
-  groupBy,
-  sortBy,
-}) {
-  return (
-    <div className="bg-white rounded-xl shadow p-4">
-      <div className="font-bold text-blue-700 mb-2 text-center">{title}</div>
-      {users && users.length > 0 ? (
-        <ChartDivisiAbsensi
-          users={users}
-          title={title}
-          orientation={orientation}
-          totalPost={totalPost}
-          fieldJumlah="jumlah_like"
-          labelSudah="User Sudah Like"
-          labelKurang="User Kurang Like"
-          labelBelum="User Belum Like"
-          labelTotal="Total Likes"
-          groupBy={groupBy}
-          showTotalUser
-          labelTotalUser="Jumlah User"
-          sortBy={sortBy}
-        />
-      ) : (
-        <div className="text-center text-gray-400 text-sm">Tidak ada data</div>
-      )}
-      {narrative && <Narrative>{narrative}</Narrative>}
-    </div>
-  );
-}
-
-function SummaryItem({ label, value, color = "gray", icon }) {
-  const colorMap = {
-    blue: "text-blue-700",
-    green: "text-green-600",
-    red: "text-red-500",
-    gray: "text-gray-700",
-    orange: "text-orange-500",
-  };
-  return (
-    <div className="flex-1 flex flex-col items-center justify-center py-2">
-      <div className="mb-1">{icon}</div>
-      <div className={`text-3xl md:text-4xl font-bold ${colorMap[color]}`}>
-        {value}
-      </div>
-      <div className="text-xs md:text-sm font-semibold text-gray-500 mt-1 uppercase tracking-wide text-center">
-        {label}
-      </div>
-    </div>
-  );
-}
-
-function Divider() {
-  // Vertical divider in desktop, horizontal in mobile
-  return <div className="hidden md:block w-px bg-gray-200 mx-2 my-2"></div>;
-}

--- a/cicero-dashboard/components/likes/instagram/ChartBox.jsx
+++ b/cicero-dashboard/components/likes/instagram/ChartBox.jsx
@@ -1,0 +1,39 @@
+"use client";
+import ChartDivisiAbsensi from "@/components/ChartDivisiAbsensi";
+import Narrative from "@/components/Narrative";
+
+export default function ChartBox({
+  title,
+  users,
+  orientation = "vertical",
+  totalPost,
+  narrative,
+  groupBy,
+  sortBy,
+}) {
+  return (
+    <div className="bg-white rounded-xl shadow p-4">
+      <div className="font-bold text-blue-700 mb-2 text-center">{title}</div>
+      {users && users.length > 0 ? (
+        <ChartDivisiAbsensi
+          users={users}
+          title={title}
+          orientation={orientation}
+          totalPost={totalPost}
+          fieldJumlah="jumlah_like"
+          labelSudah="User Sudah Like"
+          labelKurang="User Kurang Like"
+          labelBelum="User Belum Like"
+          labelTotal="Total Likes"
+          groupBy={groupBy}
+          showTotalUser
+          labelTotalUser="Jumlah User"
+          sortBy={sortBy}
+        />
+      ) : (
+        <div className="text-center text-gray-400 text-sm">Tidak ada data</div>
+      )}
+      {narrative && <Narrative>{narrative}</Narrative>}
+    </div>
+  );
+}

--- a/cicero-dashboard/components/likes/instagram/Divider.jsx
+++ b/cicero-dashboard/components/likes/instagram/Divider.jsx
@@ -1,0 +1,5 @@
+"use client";
+
+export default function Divider() {
+  return <div className="hidden md:block w-px bg-gray-200 mx-2 my-2"></div>;
+}

--- a/cicero-dashboard/components/likes/instagram/SummaryItem.jsx
+++ b/cicero-dashboard/components/likes/instagram/SummaryItem.jsx
@@ -1,0 +1,20 @@
+"use client";
+
+export default function SummaryItem({ label, value, color = "gray", icon }) {
+  const colorMap = {
+    blue: "text-blue-700",
+    green: "text-green-600",
+    red: "text-red-500",
+    gray: "text-gray-700",
+    orange: "text-orange-500",
+  };
+  return (
+    <div className="flex-1 flex flex-col items-center justify-center py-2">
+      <div className="mb-1">{icon}</div>
+      <div className={`text-3xl md:text-4xl font-bold ${colorMap[color]}`}>{value}</div>
+      <div className="text-xs md:text-sm font-semibold text-gray-500 mt-1 uppercase tracking-wide text-center">
+        {label}
+      </div>
+    </div>
+  );
+}

--- a/cicero-dashboard/hooks/useInstagramEngagement.ts
+++ b/cicero-dashboard/hooks/useInstagramEngagement.ts
@@ -1,0 +1,257 @@
+"use client";
+import { useEffect, useState } from "react";
+import {
+  getDashboardStats,
+  getRekapLikesIG,
+  getClientProfile,
+  getClientNames,
+  getUserDirectory,
+} from "@/utils/api";
+import { fetchDitbinmasAbsensiLikes } from "@/utils/absensiLikes";
+import { getPeriodeDateForView } from "@/components/ViewDataSelector";
+
+interface RekapSummary {
+  totalUser: number;
+  totalSudahLike: number;
+  totalKurangLike: number;
+  totalBelumLike: number;
+  totalTanpaUsername: number;
+  totalIGPost: number;
+}
+
+export default function useInstagramEngagement() {
+  const [chartData, setChartData] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [viewBy, setViewBy] = useState("today");
+  const today = new Date().toISOString().split("T")[0];
+  const [customDate, setCustomDate] = useState(today);
+  const [fromDate, setFromDate] = useState(today);
+  const [toDate, setToDate] = useState(today);
+  const [rekapSummary, setRekapSummary] = useState<RekapSummary>({
+    totalUser: 0,
+    totalSudahLike: 0,
+    totalKurangLike: 0,
+    totalBelumLike: 0,
+    totalTanpaUsername: 0,
+    totalIGPost: 0,
+  });
+  const [isDirectorate, setIsDirectorate] = useState(false);
+  const [clientName, setClientName] = useState("");
+
+  useEffect(() => {
+    setLoading(true);
+    setError("");
+    const token =
+      typeof window !== "undefined" ? localStorage.getItem("cicero_token") : null;
+    const userClientId =
+      typeof window !== "undefined" ? localStorage.getItem("client_id") : null;
+    const role =
+      typeof window !== "undefined" ? localStorage.getItem("user_role") : null;
+    if (!token || !userClientId) {
+      setError("Token / Client ID tidak ditemukan. Silakan login ulang.");
+      setLoading(false);
+      return;
+    }
+
+    const isDitbinmas = String(role).toLowerCase() === "ditbinmas";
+    const taskClientId = isDitbinmas ? "DITBINMAS" : userClientId;
+
+    async function fetchData() {
+      try {
+        const selectedDate =
+          viewBy === "custom_range"
+            ? { startDate: fromDate, endDate: toDate }
+            : customDate;
+        const { periode, date, startDate, endDate } = getPeriodeDateForView(
+          viewBy,
+          selectedDate,
+        );
+        if (isDitbinmas) {
+          const { users, summary } = await fetchDitbinmasAbsensiLikes(token, {
+            periode,
+            date,
+            startDate,
+            endDate,
+          });
+          setRekapSummary(summary);
+          setChartData(users);
+          setIsDirectorate(true);
+          return;
+        }
+
+        const statsData = await getDashboardStats(
+          token,
+          periode,
+          date,
+          startDate,
+          endDate,
+          taskClientId,
+        );
+
+        const client_id = userClientId;
+
+        const profileRes = await getClientProfile(token, client_id);
+        const profile = profileRes.client || profileRes.profile || profileRes || {};
+        const dir = (profile.client_type || "").toUpperCase() === "DIREKTORAT";
+        setIsDirectorate(dir);
+        setClientName(
+          profile.nama ||
+            profile.nama_client ||
+            profile.client_name ||
+            profile.client ||
+            "",
+        );
+
+        let users: any[] = [];
+        if (dir) {
+          const directoryRes = await getUserDirectory(token, client_id);
+          const dirData = directoryRes.data || directoryRes.users || directoryRes || [];
+          const expectedRole = String(client_id).toLowerCase();
+          const clientIds = Array.from(
+            new Set(
+              dirData
+                .filter(
+                  (u: any) =>
+                    String(
+                      u.role ||
+                        u.user_role ||
+                        u.userRole ||
+                        u.roleName ||
+                        "",
+                    ).toLowerCase() === expectedRole,
+                )
+                .map((u: any) =>
+                  String(
+                    u.client_id ||
+                      u.clientId ||
+                      u.clientID ||
+                      u.client ||
+                      "",
+                  ),
+                )
+                .filter(Boolean),
+            ),
+          );
+          if (!clientIds.includes(String(client_id))) {
+            clientIds.push(String(client_id));
+          }
+          const rekapAll = await Promise.all(
+            clientIds.map((cid: string) =>
+              getRekapLikesIG(token, cid, periode, date, startDate, endDate).catch(() => ({
+                data: [],
+              })),
+            ),
+          );
+          users = rekapAll.flatMap((res: any) =>
+            Array.isArray(res?.data)
+              ? res.data
+              : Array.isArray(res)
+              ? res
+              : [],
+          );
+        } else {
+          const rekapRes = await getRekapLikesIG(
+            token,
+            client_id,
+            periode,
+            date,
+            startDate,
+            endDate,
+          );
+          users = Array.isArray(rekapRes?.data)
+            ? rekapRes.data
+            : Array.isArray(rekapRes)
+            ? rekapRes
+            : [];
+        }
+
+        let enrichedUsers = users;
+        if (dir) {
+          const nameMap = await getClientNames(
+            token,
+            users.map((u: any) =>
+              String(u.client_id || u.clientId || u.clientID || u.client || ""),
+            ),
+          );
+          enrichedUsers = users.map((u: any) => {
+            const clientName =
+              nameMap[
+                String(
+                  u.client_id || u.clientId || u.clientID || u.client || "",
+                )
+              ] ||
+              u.nama_client ||
+              u.client_name ||
+              u.client;
+            return {
+              ...u,
+              nama_client: clientName,
+              client_name: clientName,
+            };
+          });
+        }
+
+        const totalUser = enrichedUsers.length;
+        const totalIGPost = Number(statsData.instagramPosts) || 0;
+        const isZeroPost = (totalIGPost || 0) === 0;
+        let totalSudahLike = 0;
+        let totalKurangLike = 0;
+        let totalBelumLike = 0;
+        let totalTanpaUsername = 0;
+        enrichedUsers.forEach((u: any) => {
+          const username = String(u.username || "").trim();
+          if (!username) {
+            totalTanpaUsername += 1;
+            return;
+          }
+          const jumlah = Number(u.jumlah_like) || 0;
+          if (isZeroPost) {
+            totalBelumLike += 1;
+            return;
+          }
+          if (jumlah >= totalIGPost * 0.5) {
+            totalSudahLike += 1;
+          } else if (jumlah > 0) {
+            totalKurangLike += 1;
+          } else {
+            totalBelumLike += 1;
+          }
+        });
+
+        setRekapSummary({
+          totalUser,
+          totalSudahLike,
+          totalKurangLike,
+          totalBelumLike,
+          totalTanpaUsername,
+          totalIGPost,
+        });
+        setChartData(enrichedUsers);
+      } catch (err: any) {
+        setError("Gagal mengambil data: " + (err.message || err));
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    fetchData();
+  }, [viewBy, customDate, fromDate, toDate]);
+
+  return {
+    chartData,
+    loading,
+    error,
+    viewBy,
+    setViewBy,
+    customDate,
+    setCustomDate,
+    fromDate,
+    setFromDate,
+    toDate,
+    setToDate,
+    rekapSummary,
+    isDirectorate,
+    clientName,
+  };
+}


### PR DESCRIPTION
## Summary
- extract ChartBox, SummaryItem, Divider into dedicated instagram likes components
- add useInstagramEngagement hook to encapsulate data fetching
- refactor instagram likes page to use new components and hook

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4f165e0a88327bffcdd2e80105dbf