### PR TITLE
Use toast notifications for Instagram recap

### DIFF
--- a/cicero-dashboard/app/likes/instagram/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/page.jsx
@@ -10,6 +10,7 @@ import Narrative from "@/components/Narrative";
 import useRequireAuth from "@/hooks/useRequireAuth";
 import useInstagramEngagement from "@/hooks/useInstagramEngagement";
 import ViewDataSelector, { VIEW_OPTIONS } from "@/components/ViewDataSelector";
+import { showToast } from "@/utils/showToast";
 import {
   Camera,
   User,
@@ -115,10 +116,10 @@ export default function InstagramEngagementInsightPage() {
 
     if (navigator?.clipboard?.writeText) {
       navigator.clipboard.writeText(message).then(() => {
-        alert("Rekap disalin ke clipboard");
+        showToast("Rekap disalin ke clipboard", "success");
       });
     } else {
-      alert(message);
+      showToast(message, "info");
     }
   }
 


### PR DESCRIPTION
## Summary
- Import showToast utility and use toast notifications in Instagram likes page
- Replace alert dialogs with success/info toasts when copying recap

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c4f660f2388327a531b0eb714b0b40