### PR TITLE
refactor: remove unused stats state

### DIFF
--- a/cicero-dashboard/app/comments/tiktok/page.jsx
+++ b/cicero-dashboard/app/comments/tiktok/page.jsx
@@ -30,7 +30,6 @@ import {
 
 export default function TiktokEngagementInsightPage() {
   useRequireAuth();
-  const [stats, setStats] = useState(null);
   const [chartData, setChartData] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
@@ -94,7 +93,6 @@ export default function TiktokEngagementInsightPage() {
           endDate,
           taskClientId,
         );
-        setStats(statsData);
 
         const client_id = userClientId;
 


### PR DESCRIPTION
## Summary
- remove unused `stats` state on TikTok engagement page
- compute total post counts directly from local `statsData`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c4f7536240832784db80d4bc0af441