### PR TITLE
feat: centralize Instagram likes data fetching

### DIFF
--- a/cicero-dashboard/app/likes/instagram/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/page.jsx
@@ -1,4 +1,5 @@
 "use client";
+import { useState } from "react";
 import Loader from "@/components/Loader";
 import ChartBox from "@/components/likes/instagram/ChartBox";
 import SummaryItem from "@/components/likes/instagram/SummaryItem";
@@ -8,7 +9,7 @@ import { groupUsersByKelompok } from "@/utils/grouping"; // pastikan path benar
 import Link from "next/link";
 import Narrative from "@/components/Narrative";
 import useRequireAuth from "@/hooks/useRequireAuth";
-import useInstagramEngagement from "@/hooks/useInstagramEngagement";
+import useInstagramLikesData from "@/hooks/useInstagramLikesData";
 import ViewDataSelector, { VIEW_OPTIONS } from "@/components/ViewDataSelector";
 import { showToast } from "@/utils/showToast";
 import {
@@ -27,22 +28,20 @@ const LIKE_THRESHOLD = Number(
 
 export default function InstagramEngagementInsightPage() {
   useRequireAuth();
+  const [viewBy, setViewBy] = useState("today");
+  const today = new Date().toISOString().split("T")[0];
+  const [customDate, setCustomDate] = useState(today);
+  const [fromDate, setFromDate] = useState(today);
+  const [toDate, setToDate] = useState(today);
+
   const {
     chartData,
     loading,
     error,
-    viewBy,
-    setViewBy,
-    customDate,
-    setCustomDate,
-    fromDate,
-    setFromDate,
-    toDate,
-    setToDate,
     rekapSummary,
     isDirectorate,
     clientName,
-  } = useInstagramEngagement();
+  } = useInstagramLikesData({ viewBy, customDate, fromDate, toDate });
 
   const viewOptions = VIEW_OPTIONS;
   if (loading) return <Loader />;

--- a/cicero-dashboard/app/likes/instagram/rekap/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/rekap/page.jsx
@@ -1,277 +1,33 @@
 "use client";
-import { useEffect, useState, useRef } from "react";
-import {
-  getDashboardStats,
-  getRekapLikesIG,
-  getClientProfile,
-  getClientNames,
-  getUserDirectory,
-} from "@/utils/api";
-import { fetchDitbinmasAbsensiLikes } from "@/utils/absensiLikes";
+import { useState, useRef } from "react";
 import Loader from "@/components/Loader";
 import RekapLikesIG from "@/components/RekapLikesIG";
 import Link from "next/link";
 import useRequireAuth from "@/hooks/useRequireAuth";
-import ViewDataSelector, {
-  getPeriodeDateForView,
-  VIEW_OPTIONS,
-} from "@/components/ViewDataSelector";
+import useInstagramLikesData from "@/hooks/useInstagramLikesData";
+import ViewDataSelector, { VIEW_OPTIONS } from "@/components/ViewDataSelector";
 import { ArrowLeft } from "lucide-react";
 
 export default function RekapLikesIGPage() {
   useRequireAuth();
-  const [chartData, setChartData] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState("");
   const [viewBy, setViewBy] = useState("today");
   const today = new Date().toISOString().split("T")[0];
   const [customDate, setCustomDate] = useState(today);
   const [fromDate, setFromDate] = useState(today);
   const [toDate, setToDate] = useState(today);
-  const [rekapSummary, setRekapSummary] = useState({
-    totalUser: 0,
-    totalSudahLike: 0,
-    totalKurangLike: 0,
-    totalBelumLike: 0,
-    totalTanpaUsername: 0,
-    totalIGPost: 0,
-  });
 
-  const [igPosts, setIgPosts] = useState([]);
-  const [clientName, setClientName] = useState("");
+  const {
+    chartData,
+    loading,
+    error,
+    rekapSummary,
+    igPosts,
+    clientName,
+  } = useInstagramLikesData({ viewBy, customDate, fromDate, toDate });
+
   const rekapRef = useRef(null);
 
   const viewOptions = VIEW_OPTIONS;
-
-
-  useEffect(() => {
-    setLoading(true);
-    setError("");
-    const token =
-      typeof window !== "undefined"
-        ? localStorage.getItem("cicero_token")
-        : null;
-    const userClientId =
-      typeof window !== "undefined"
-        ? localStorage.getItem("client_id")
-        : null;
-    const role =
-      typeof window !== "undefined"
-        ? localStorage.getItem("user_role")
-        : null;
-    if (!token || !userClientId) {
-      setError("Token / Client ID tidak ditemukan. Silakan login ulang.");
-      setLoading(false);
-      return;
-    }
-
-    const isDitbinmas = String(role).toLowerCase() === "ditbinmas";
-    const taskClientId = isDitbinmas ? "DITBINMAS" : userClientId;
-
-    async function fetchData() {
-      try {
-        const selectedDate =
-          viewBy === "custom_range"
-            ? { startDate: fromDate, endDate: toDate }
-            : customDate;
-        const { periode, date, startDate, endDate } =
-          getPeriodeDateForView(viewBy, selectedDate);
-        if (isDitbinmas) {
-          const { users, summary, posts, clientName } =
-            await fetchDitbinmasAbsensiLikes(token, {
-              periode,
-              date,
-              startDate,
-              endDate,
-            });
-          setRekapSummary(summary);
-          setChartData(users);
-          setIgPosts(posts);
-          setClientName(clientName);
-          return;
-        }
-
-        const statsData = await getDashboardStats(
-          token,
-          periode,
-          date,
-          startDate,
-          endDate,
-          taskClientId,
-        );
-        const posts = Array.isArray(statsData.ig_posts)
-          ? statsData.ig_posts
-          : Array.isArray(statsData.igPosts)
-          ? statsData.igPosts
-          : Array.isArray(statsData.instagram_posts)
-          ? statsData.instagram_posts
-          : [];
-        setIgPosts(posts);
-        const client_id = userClientId;
-
-        const [profileRes, directoryRes, rekapRes] = await Promise.all([
-          getClientProfile(token, client_id).catch((err) => {
-            console.error("Error fetching client profile:", err);
-            return {};
-          }),
-          getUserDirectory(token, client_id).catch((err) => {
-            console.error("Error fetching user directory:", err);
-            return { data: [] };
-          }),
-          getRekapLikesIG(
-            token,
-            client_id,
-            periode,
-            date,
-            startDate,
-            endDate,
-          ).catch((err) => {
-            console.error("Error fetching rekap likes:", err);
-            return { data: [] };
-          }),
-        ]);
-
-        const profile =
-          profileRes.client || profileRes.profile || profileRes || {};
-        const dir =
-          (profile.client_type || "").toUpperCase() === "DIREKTORAT";
-        setClientName(
-          profile.nama ||
-            profile.nama_client ||
-            profile.client_name ||
-            profile.client ||
-            "",
-        );
-
-        let users = [];
-        if (dir) {
-          const dirData =
-            directoryRes.data || directoryRes.users || directoryRes || [];
-          const expectedRole = String(client_id).toLowerCase();
-          const clientIds = Array.from(
-            new Set(
-              dirData
-                .filter(
-                  (u) =>
-                    String(
-                      u.role ||
-                        u.user_role ||
-                        u.userRole ||
-                        u.roleName ||
-                        "",
-                    ).toLowerCase() === expectedRole,
-                )
-                .map((u) =>
-                  String(
-                    u.client_id ||
-                      u.clientId ||
-                      u.clientID ||
-                      u.client ||
-                      "",
-                  ),
-                )
-                .filter(Boolean),
-            ),
-          );
-          if (!clientIds.includes(String(client_id))) {
-            clientIds.push(String(client_id));
-          }
-
-          const rekapPromises = clientIds.map((cid) =>
-            cid === String(client_id)
-              ? Promise.resolve(rekapRes)
-              : getRekapLikesIG(
-                  token,
-                  cid,
-                  periode,
-                  date,
-                  startDate,
-                  endDate,
-                ).catch(() => ({ data: [] })),
-          );
-
-          const rekapAll = await Promise.all(rekapPromises);
-          users = rekapAll.flatMap((res) =>
-            Array.isArray(res?.data)
-              ? res.data
-              : Array.isArray(res)
-              ? res
-              : [],
-          );
-          const nameMap = await getClientNames(
-            token,
-            users.map((u) =>
-              String(
-                u.client_id || u.clientId || u.clientID || u.client || "",
-              ),
-            ),
-          );
-          users = users.map((u) => ({
-            ...u,
-            nama_client:
-              nameMap[
-                String(
-                  u.client_id || u.clientId || u.clientID || u.client || "",
-                )
-              ] ||
-              u.nama_client ||
-              u.client_name ||
-              u.client,
-          }));
-        } else {
-          users = Array.isArray(rekapRes?.data)
-            ? rekapRes.data
-            : Array.isArray(rekapRes)
-            ? rekapRes
-            : [];
-        }
-
-        // Hitung jumlah IG post dari stats dan klasifikasi user
-        const totalIGPost = Number(statsData.instagramPosts) || 0;
-        const isZeroPost = (totalIGPost || 0) === 0;
-        const totalUser = users.length;
-        let totalSudahLike = 0;
-        let totalKurangLike = 0;
-        let totalBelumLike = 0;
-        let totalTanpaUsername = 0;
-        users.forEach((u) => {
-          const username = String(u.username || "").trim();
-          if (!username) {
-            totalTanpaUsername += 1;
-            return;
-          }
-          const jumlah = Number(u.jumlah_like) || 0;
-          if (isZeroPost) {
-            totalBelumLike += 1;
-            return;
-          }
-          if (jumlah >= totalIGPost * 0.5) {
-            totalSudahLike += 1;
-          } else if (jumlah > 0) {
-            totalKurangLike += 1;
-          } else {
-            totalBelumLike += 1;
-          }
-        });
-
-        setRekapSummary({
-          totalUser,
-          totalSudahLike,
-          totalKurangLike,
-          totalBelumLike,
-          totalTanpaUsername,
-          totalIGPost,
-        });
-        setChartData(users);
-      } catch (err) {
-        setError("Gagal mengambil data: " + (err.message || err));
-      } finally {
-        setLoading(false);
-      }
-    }
-
-    fetchData();
-  }, [viewBy, customDate, fromDate, toDate]);
 
   if (loading) return <Loader />;
   if (error)
@@ -282,7 +38,6 @@ export default function RekapLikesIGPage() {
         </div>
       </div>
     );
-
   return (
     <div className="min-h-screen bg-gray-100">
       <div className="p-4 md:p-8 max-w-6xl mx-auto w-full">


### PR DESCRIPTION
## Summary
- add `useInstagramLikesData` hook to encapsulate token, client, role, and API requests
- use new hook in Instagram likes insight and rekap pages
- remove old `useInstagramEngagement` hook

## Testing
- `npm test`
- `npm run lint` *(fails: interactive prompt prevented completion)*

------
https://chatgpt.com/codex/tasks/task_e_68c4fc5a2cac83278bbb0998c1d3413a