### PR TITLE
fix: guard token and client ID retrieval

### DIFF
--- a/cicero-dashboard/hooks/useInstagramLikesData.ts
+++ b/cicero-dashboard/hooks/useInstagramLikesData.ts
@@ -52,11 +52,17 @@ export default function useInstagramLikesData({
     setLoading(true);
     setError("");
     const token =
-      typeof window !== "undefined" ? localStorage.getItem("cicero_token") : null;
+      typeof window !== "undefined"
+        ? localStorage.getItem("cicero_token") ?? ""
+        : "";
     const userClientId =
-      typeof window !== "undefined" ? localStorage.getItem("client_id") : null;
+      typeof window !== "undefined"
+        ? localStorage.getItem("client_id") ?? ""
+        : "";
     const role =
-      typeof window !== "undefined" ? localStorage.getItem("user_role") : null;
+      typeof window !== "undefined"
+        ? localStorage.getItem("user_role") ?? ""
+        : "";
     if (!token || !userClientId) {
       setError("Token / Client ID tidak ditemukan. Silakan login ulang.");
       setLoading(false);


### PR DESCRIPTION
## Summary
- ensure token and client ID default to strings before further processing to satisfy TS type expectations

## Testing
- `npm test`
- `npm run build` *(fails: Failed to fetch font file from `https://fonts.gstatic.com/s/geistmono/...`)*

------
https://chatgpt.com/codex/tasks/task_e_68c5003bc6c88327bd4d067fa7eac106