### PR TITLE
fix: ensure client IDs typed as strings

### DIFF
--- a/cicero-dashboard/hooks/useInstagramLikesData.ts
+++ b/cicero-dashboard/hooks/useInstagramLikesData.ts
@@ -172,9 +172,9 @@ export default function useInstagramLikesData({
                       "",
                   ),
                 )
-                .filter(Boolean),
+                .filter(Boolean) as string[],
             ),
-          );
+          ) as string[];
           if (!clientIds.includes(String(client_id))) {
             clientIds.push(String(client_id));
           }


### PR DESCRIPTION
## Summary
- enforce string typing for client IDs when gathering rekap data

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c501b8a6dc8327b41c6d918d28cca1