### PR TITLE
refactor: parallelize user insight data fetch

### DIFF
--- a/cicero-dashboard/app/user-insight/page.jsx
+++ b/cicero-dashboard/app/user-insight/page.jsx
@@ -57,8 +57,11 @@ export default function UserInsightPage() {
         return;
       }
       try {
-        const res = await getUserDirectory(token, clientId);
-        const raw = res.data || res.users || res;
+        const [usersRes, profileRes] = await Promise.all([
+          getUserDirectory(token, clientId),
+          getClientProfile(token, clientId),
+        ]);
+        const raw = usersRes.data || usersRes.users || usersRes;
         const users = Array.isArray(raw) ? raw : [];
 
         // helper untuk membuat data chart per divisi
@@ -89,9 +92,7 @@ export default function UserInsightPage() {
           const score = (o) => o.total + o.instagramFilled + o.tiktokFilled;
           return result.sort((a, b) => score(b) - score(a));
         };
-
         // Cek tipe client
-        const profileRes = await getClientProfile(token, clientId);
         const profile =
           profileRes.client || profileRes.profile || profileRes || {};
         const dir =


### PR DESCRIPTION
## Summary
- fetch user directory and client profile concurrently in user insight page

## Testing
- `cd cicero-dashboard && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5043189bc832790eb9605acb83adb