### PR TITLE
feat: centralize contact stats accumulation

### DIFF
--- a/cicero-dashboard/app/user-insight/page.jsx
+++ b/cicero-dashboard/app/user-insight/page.jsx
@@ -17,6 +17,7 @@ import {
   getClientNames,
 } from "@/utils/api";
 import { groupUsersByKelompok } from "@/utils/grouping";
+import { accumulateContactStats } from "@/utils/contactStats";
 import Loader from "@/components/Loader";
 import useRequireAuth from "@/hooks/useRequireAuth";
 import useAuth from "@/hooks/useAuth";
@@ -83,10 +84,7 @@ export default function UserInsightPage() {
             map[key].total += 1;
             const hasIG = u.insta && String(u.insta).trim() !== "";
             const hasTT = u.tiktok && String(u.tiktok).trim() !== "";
-            if (hasIG) map[key].instagramFilled += 1;
-            else map[key].instagramEmpty += 1;
-            if (hasTT) map[key].tiktokFilled += 1;
-            else map[key].tiktokEmpty += 1;
+            accumulateContactStats(map[key], hasIG, hasTT);
           });
           const result = Object.values(map);
           const score = (o) => o.total + o.instagramFilled + o.tiktokFilled;
@@ -167,10 +165,7 @@ export default function UserInsightPage() {
             clientMap[id].total += 1;
             const hasIG = u.insta && String(u.insta).trim() !== "";
             const hasTT = u.tiktok && String(u.tiktok).trim() !== "";
-            if (hasIG) clientMap[id].instagramFilled += 1;
-            else clientMap[id].instagramEmpty += 1;
-            if (hasTT) clientMap[id].tiktokFilled += 1;
-            else clientMap[id].tiktokEmpty += 1;
+            accumulateContactStats(clientMap[id], hasIG, hasTT);
           });
           const score = (o) => o.total + o.instagramFilled + o.tiktokFilled;
           setChartPolres(

--- a/cicero-dashboard/utils/contactStats.ts
+++ b/cicero-dashboard/utils/contactStats.ts
@@ -1,0 +1,18 @@
+export interface ContactStats {
+  instagramFilled: number;
+  instagramEmpty: number;
+  tiktokFilled: number;
+  tiktokEmpty: number;
+}
+
+export function accumulateContactStats(
+  target: ContactStats,
+  hasIG: boolean,
+  hasTT: boolean,
+): void {
+  if (hasIG) target.instagramFilled += 1;
+  else target.instagramEmpty += 1;
+
+  if (hasTT) target.tiktokFilled += 1;
+  else target.tiktokEmpty += 1;
+}


### PR DESCRIPTION
## Summary
- add accumulateContactStats utility for consistent IG/TikTok stats
- refactor User Insight page to use utility in chart generation and client map

## Testing
- `npm test`
- `npm run lint` *(fails: asks for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68c50e62b52c8327813a278e5ce34a49