### PR TITLE
feat: batch client name lookup

### DIFF
--- a/cicero-dashboard/app/api/clients/names/route.ts
+++ b/cicero-dashboard/app/api/clients/names/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "";
+
+export async function POST(req: NextRequest) {
+  try {
+    const { client_id } = await req.json();
+    const token = req.headers.get("authorization") || "";
+    const ids: string[] = Array.isArray(client_id) ? client_id : [];
+    const uniqueIds = Array.from(new Set(ids.filter(Boolean)));
+    const entries = await Promise.all(
+      uniqueIds.map(async (id) => {
+        try {
+          const params = new URLSearchParams({ client_id: id });
+          const res = await fetch(
+            `${API_BASE_URL}/api/clients/profile?${params.toString()}`,
+            {
+              headers: {
+                Authorization: token,
+                "Content-Type": "application/json",
+              },
+            },
+          );
+          if (!res.ok) throw new Error("Failed to fetch profile");
+          const json = await res.json();
+          const profile =
+            json?.data?.client ||
+            json?.data ||
+            json?.client ||
+            json?.profile ||
+            json ||
+            {};
+          const name =
+            profile.nama ||
+            profile.nama_client ||
+            profile.client_name ||
+            profile.client ||
+            id;
+          return [id, name] as [string, string];
+        } catch {
+          return [id, id] as [string, string];
+        }
+      }),
+    );
+    return NextResponse.json(Object.fromEntries(entries));
+  } catch (e: any) {
+    return NextResponse.json(
+      { error: e?.message || "Failed to get client names" },
+      { status: 500 },
+    );
+  }
+}
+

--- a/cicero-dashboard/app/user-insight/page.jsx
+++ b/cicero-dashboard/app/user-insight/page.jsx
@@ -14,7 +14,7 @@ import {
 import {
   getUserDirectory,
   getClientProfile,
-  getClientNames,
+  getClientNamesBatch,
 } from "@/utils/api";
 import { groupUsersByKelompok } from "@/utils/grouping";
 import { accumulateContactStats } from "@/utils/contactStats";
@@ -99,7 +99,7 @@ export default function UserInsightPage() {
 
         let processedUsers = users;
         if (dir) {
-          const nameMap = await getClientNames(
+          const nameMap = await getClientNamesBatch(
             token,
             users.map((u) =>
               String(

--- a/cicero-dashboard/utils/api.ts
+++ b/cicero-dashboard/utils/api.ts
@@ -146,6 +146,23 @@ export async function getClientNames(
   return Object.fromEntries(entries);
 }
 
+// Ambil nama-nama client secara batch lewat endpoint server
+export async function getClientNamesBatch(
+  token: string,
+  clientIds: string[],
+  signal?: AbortSignal,
+): Promise<Record<string, string>> {
+  const uniqueIds = Array.from(new Set(clientIds.filter(Boolean)));
+  if (uniqueIds.length === 0) return {};
+  const res = await fetchWithAuth(`/api/clients/names`, token, {
+    method: "POST",
+    body: JSON.stringify({ client_id: uniqueIds }),
+    signal,
+  });
+  if (!res.ok) throw new Error("Gagal fetch nama client");
+  return res.json();
+}
+
 // Ambil daftar user untuk User Directory
 export async function getUserDirectory(
   token: string,


### PR DESCRIPTION
## Summary
- add `/api/clients/names` endpoint to fetch many client names at once
- expose `getClientNamesBatch` util and use it in user insight page

## Testing
- `npm test`
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68c50fff81b4832785eed86ddcc70ef7