### PR TITLE
Adjust directorate user insight sorting

### DIFF
--- a/cicero-dashboard/app/user-insight/page.jsx
+++ b/cicero-dashboard/app/user-insight/page.jsx
@@ -71,18 +71,32 @@ export default function UserInsightPage() {
   };
 
   const getDirectoratePriority = (entry) => {
-    const name = (entry.divisi || "").toString().trim();
-    if (name.toUpperCase().includes("DIREKTORAT BINMAS")) {
+    const name = (
+      entry.divisi || entry.nama_client || ""
+    )
+      .toString()
+      .trim()
+      .toUpperCase();
+    if (name.includes("DIREKTORAT BINMAS")) {
       return 0;
     }
-    const total = entry.total || 0;
-    if (total > 200) {
+    const total = Number(entry.total) || 0;
+    if (total > 250) {
       return 1;
     }
-    if (total >= 100) {
+    if (total >= 200) {
       return 2;
     }
-    return 3;
+    if (total >= 150) {
+      return 3;
+    }
+    if (total >= 100) {
+      return 4;
+    }
+    if (total >= 50) {
+      return 5;
+    }
+    return 6;
   };
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- ensure the Direktorat Binmas client always appears first in the user insight directorate chart
- order remaining clients by user-count buckets (>250, 200-250, 150-200, 100-150, 50-100, <50) and highest username fill ratio within each bucket

## Testing
- npm run lint *(fails: the command prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c9ff7c73488327b1a5e7c736b7a349