### PR TITLE
Ensure Direktorat Binmas sorted first by likes

### DIFF
--- a/cicero-dashboard/components/ChartDivisiAbsensi.jsx
+++ b/cicero-dashboard/components/ChartDivisiAbsensi.jsx
@@ -191,6 +191,12 @@ export default function ChartDivisiAbsensi({
           return isBinmasA ? -1 : 1;
         }
 
+        const totalLikesA = Number(a.total_value) || 0;
+        const totalLikesB = Number(b.total_value) || 0;
+        if (totalLikesA !== totalLikesB) {
+          return totalLikesB - totalLikesA;
+        }
+
         const bucketA = getUserBucket(a.total_user);
         const bucketB = getUserBucket(b.total_user);
         if (bucketA !== bucketB) {


### PR DESCRIPTION
## Summary
- ensure Direktorat Binmas entries are always ordered first on the Instagram likes charts
- sort the remaining directorate rows by their accumulated like totals for clearer ranking

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68ca3858a7d08327aa9b8071eae7b4d9