### PR TITLE
Filter Ditbinmas TikTok comment data to the matching role

### DIFF
--- a/cicero-dashboard/app/comments/tiktok/page.jsx
+++ b/cicero-dashboard/app/comments/tiktok/page.jsx
@@ -52,6 +52,16 @@ export default function TiktokEngagementInsightPage() {
 
   const viewOptions = VIEW_OPTIONS;
 
+  const getUserRole = (user) =>
+    String(
+      user?.role ||
+        user?.user_role ||
+        user?.userRole ||
+        user?.roleName ||
+        user?.role_name ||
+        "",
+    ).toLowerCase();
+
   useEffect(() => {
     setLoading(true);
     setError("");
@@ -177,6 +187,10 @@ export default function TiktokEngagementInsightPage() {
             : Array.isArray(rekapRes)
             ? rekapRes
             : [];
+        }
+
+        if (isDitbinmas) {
+          users = users.filter((u) => getUserRole(u) === "ditbinmas");
         }
 
         let enrichedUsers = users;


### PR DESCRIPTION
## Summary
- add a helper to normalize user role data on the TikTok comments page
- filter aggregated comment records to only include users with the Ditbinmas role when that role is active

## Testing
- npm run lint *(fails: prompts for new ESLint configuration, so the command was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68ca65018b4483278fe31e303a9912eb