### PR TITLE
Use toast notifications for user insight copy

### DIFF
--- a/cicero-dashboard/app/user-insight/page.jsx
+++ b/cicero-dashboard/app/user-insight/page.jsx
@@ -21,6 +21,7 @@ import { accumulateContactStats } from "@/utils/contactStats";
 import Loader from "@/components/Loader";
 import useRequireAuth from "@/hooks/useRequireAuth";
 import useAuth from "@/hooks/useAuth";
+import { showToast } from "@/utils/showToast";
 import { User, Instagram, Music, RefreshCw } from "lucide-react";
 
 export default function UserInsightPage() {
@@ -278,11 +279,16 @@ export default function UserInsightPage() {
     }
     const message = lines.join("\n");
     if (navigator?.clipboard?.writeText) {
-      navigator.clipboard.writeText(message).then(() => {
-        alert("Rekap disalin ke clipboard");
-      });
+      navigator.clipboard
+        .writeText(message)
+        .then(() => {
+          showToast("Rekap disalin ke clipboard", "success");
+        })
+        .catch(() => {
+          showToast("Gagal menyalin rekap ke clipboard", "error");
+        });
     } else {
-      alert(message);
+      showToast(message, "info");
     }
   }
 


### PR DESCRIPTION
## Summary
- import and use the shared showToast utility on the user insight page
- replace alert-based clipboard success and fallback messages with toast notifications
- add clipboard error handling to surface failures via toast

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d2643ee5148327830d087579cc1f5a