### PR TITLE
Use local date formatting for Instagram likes rekap

### DIFF
--- a/cicero-dashboard/app/likes/instagram/rekap/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/rekap/page.jsx
@@ -5,13 +5,22 @@ import RekapLikesIG from "@/components/RekapLikesIG";
 import Link from "next/link";
 import useRequireAuth from "@/hooks/useRequireAuth";
 import useInstagramLikesData from "@/hooks/useInstagramLikesData";
-import ViewDataSelector, { VIEW_OPTIONS } from "@/components/ViewDataSelector";
+import ViewDataSelector, {
+  VIEW_OPTIONS,
+} from "@/components/ViewDataSelector";
 import { ArrowLeft } from "lucide-react";
+
+function getLocalDateString(date = new Date()) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
 
 export default function RekapLikesIGPage() {
   useRequireAuth();
   const [viewBy, setViewBy] = useState("today");
-  const today = new Date().toISOString().split("T")[0];
+  const today = getLocalDateString();
   const [customDate, setCustomDate] = useState(today);
   const [fromDate, setFromDate] = useState(today);
   const [toDate, setToDate] = useState(today);


### PR DESCRIPTION
## Summary
- replace UTC-based ISO date initialization with a helper that formats local dates
- ensure the Instagram likes rekap page uses local dates for all initial filters to prevent early-morning shifts

## Testing
- npm run lint *(fails: requires interactive eslint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68d293d731448327bc8a604cd77328b5