### PR TITLE
Refine Instagram rekap CTA layout

### DIFF
--- a/cicero-dashboard/app/likes/instagram/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/page.jsx
@@ -202,7 +202,7 @@ export default function InstagramEngagementInsightPage() {
                 className="bg-green-600 hover:bg-green-700 text-white font-bold px-6 py-3 rounded-xl shadow transition-all duration-150 text-lg flex items-center gap-2"
               >
                 <Copy className="w-5 h-5" />
-                Rekap Likes
+                Salin Rekap
               </button>
               <Link
                 href="/likes/instagram/rekap"

--- a/cicero-dashboard/app/likes/instagram/rekap/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/rekap/page.jsx
@@ -111,6 +111,13 @@ export default function RekapLikesIGPage() {
 
   const rekapRef = useRef(null);
 
+  const selectorDateValue =
+    viewBy === "custom_range"
+      ? dateRange
+      : viewBy === "month"
+        ? monthlyDate
+        : dailyDate;
+
   const viewOptions = VIEW_OPTIONS;
 
   if (loading) return <Loader />;
@@ -139,37 +146,26 @@ export default function RekapLikesIGPage() {
             </Link>
           </div>
           <div className="flex flex-wrap items-center justify-end gap-3 mb-2">
-            <button
-              onClick={() => rekapRef.current?.copyRekap()}
-              className="px-3 py-2 bg-green-600 hover:bg-green-700 text-white rounded-lg text-sm"
-            >
-              Rekap Likes
-            </button>
             <ViewDataSelector
               value={viewBy}
               onChange={handleViewChange}
               options={viewOptions}
-              date=
-                {viewBy === "custom_range"
-                  ? dateRange
-                  : viewBy === "month"
-                  ? monthlyDate
-                  : dailyDate}
+              date={selectorDateValue}
               onDateChange={handleDateChange}
             />
           </div>
 
           {/* Kirim data dari fetch ke komponen rekap likes */}
-            <RekapLikesIG
-              ref={rekapRef}
-              users={chartData}
-              totalIGPost={rekapSummary.totalIGPost}
-              posts={igPosts}
-              showRekapButton
-              clientName={clientName}
-            />
-          </div>
+          <RekapLikesIG
+            ref={rekapRef}
+            users={chartData}
+            totalIGPost={rekapSummary.totalIGPost}
+            posts={igPosts}
+            showRekapButton
+            clientName={clientName}
+          />
         </div>
       </div>
-    );
-  }
+    </div>
+  );
+}

--- a/cicero-dashboard/components/RekapLikesIG.jsx
+++ b/cicero-dashboard/components/RekapLikesIG.jsx
@@ -323,7 +323,7 @@ const RekapLikesIG = forwardRef(function RekapLikesIG(
   }));
 
   return (
-    <div className="flex flex-col gap-6 mt-8 min-h-screen">
+    <div className="flex flex-col gap-6 mt-8 min-h-screen pb-24">
       {/* Ringkasan */}
       <div className="grid grid-cols-1 md:grid-cols-6 gap-4">
         <SummaryCard
@@ -489,19 +489,21 @@ const RekapLikesIG = forwardRef(function RekapLikesIG(
       )}
 
       {showRekapButton && (
-        <div className="mt-auto flex justify-end gap-2 pt-4">
-          <button
-            onClick={handleDownloadRekap}
-            className="px-4 py-2 bg-green-600 hover:bg-green-700 text-white rounded-lg shadow"
-          >
-            Download Rekap
-          </button>
-          <button
-            onClick={handleCopyRekap}
-            className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg shadow"
-          >
-            Salin Rekap
-          </button>
+        <div className="sticky bottom-4 z-20 flex w-full justify-end px-4">
+          <div className="flex w-full max-w-xl flex-col gap-2 rounded-2xl border border-slate-200 bg-white/95 p-3 shadow-xl backdrop-blur-sm sm:flex-row sm:items-center">
+            <button
+              onClick={handleDownloadRekap}
+              className="w-full px-4 py-2 bg-green-600 hover:bg-green-700 text-white rounded-lg shadow sm:w-auto"
+            >
+              Download Rekap
+            </button>
+            <button
+              onClick={handleCopyRekap}
+              className="w-full px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg shadow sm:w-auto"
+            >
+              Salin Rekap
+            </button>
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- remove the redundant header CTA on the Instagram likes rekap page and reuse a helper for the date selector value
- keep the download/copy actions visible by adding a sticky action bar in the RekapLikesIG component
- harmonize the CTA copy to “Salin Rekap” across related Instagram likes views

## Testing
- npm run lint *(fails: prompts for interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68d29f53dbac832786dc4d506ee82542