### PR TITLE
Improve TikTok comments loading states

### DIFF
--- a/cicero-dashboard/components/ViewDataSelector.jsx
+++ b/cicero-dashboard/components/ViewDataSelector.jsx
@@ -56,6 +56,7 @@ export default function ViewDataSelector({
   date,
   onDateChange,
   options = VIEW_OPTIONS,
+  disabled = false,
 }) {
   const id = useId();
   const showDateInput = value === "date";
@@ -66,7 +67,10 @@ export default function ViewDataSelector({
   const rangeStartId = `${id}-start`;
   const rangeEndId = `${id}-end`;
   return (
-    <div className="flex items-center gap-2">
+    <div
+      className={`flex items-center gap-2 ${disabled ? "opacity-60" : ""}`}
+      aria-disabled={disabled}
+    >
       <label htmlFor={id} className="text-sm font-semibold">
         View Data By:
       </label>
@@ -75,6 +79,7 @@ export default function ViewDataSelector({
         className="border rounded px-2 py-1 text-sm"
         value={value}
         onChange={(e) => onChange(e.target.value)}
+        disabled={disabled}
       >
         {options.map((opt) => (
           <option key={opt.value} value={opt.value}>
@@ -93,6 +98,7 @@ export default function ViewDataSelector({
             className="border rounded px-2 py-1 text-sm"
             value={date}
             onChange={(e) => onDateChange?.(e.target.value)}
+            disabled={disabled}
           />
         </>
       )}
@@ -107,6 +113,7 @@ export default function ViewDataSelector({
             className="border rounded px-2 py-1 text-sm"
             value={date}
             onChange={(e) => onDateChange?.(e.target.value)}
+            disabled={disabled}
           />
         </>
       )}
@@ -123,6 +130,7 @@ export default function ViewDataSelector({
             onChange={(e) =>
               onDateChange?.({ ...date, startDate: e.target.value })
             }
+            disabled={disabled}
           />
           <label htmlFor={rangeEndId} className="sr-only">
             Selesai
@@ -135,6 +143,7 @@ export default function ViewDataSelector({
             onChange={(e) =>
               onDateChange?.({ ...date, endDate: e.target.value })
             }
+            disabled={disabled}
           />
         </>
       )}


### PR DESCRIPTION
## Summary
- split TikTok comments page loading into initial and refresh phases so existing data remains visible during updates
- add a non-blocking refresh overlay, aria-busy state, and disable the filter selector while data is refreshing
- extend the shared ViewDataSelector component to support a disabled mode for dependent inputs

## Testing
- npm run lint *(fails: prompts for ESLint configuration and cannot be completed non-interactively)*

------
https://chatgpt.com/codex/tasks/task_e_68d2a45d5a708327bed95492efc03980