### PR TITLE
Improve TikTok rekap clipboard handling

### DIFF
--- a/cicero-dashboard/app/comments/tiktok/page.jsx
+++ b/cicero-dashboard/app/comments/tiktok/page.jsx
@@ -11,6 +11,7 @@ import Loader from "@/components/Loader";
 import ChartDivisiAbsensi from "@/components/ChartDivisiAbsensi";
 import ChartHorizontal from "@/components/ChartHorizontal";
 import { groupUsersByKelompok } from "@/utils/grouping";
+import { showToast } from "@/utils/showToast";
 import Link from "next/link";
 import Narrative from "@/components/Narrative";
 import useRequireAuth from "@/hooks/useRequireAuth";
@@ -301,7 +302,7 @@ export default function TiktokEngagementInsightPage() {
     return nextChar === "" || /[^a-z0-9]/.test(nextChar);
   };
 
-  function handleCopyRekap() {
+  async function handleCopyRekap() {
     const now = new Date();
     const hour = now.getHours();
     let greeting = "Selamat Pagi";
@@ -386,11 +387,24 @@ export default function TiktokEngagementInsightPage() {
     const message = `${greeting},\n\nRekap Akumulasi Komentar TikTok:\n${hari}, ${tanggal}\nJam: ${jam}\n\nJumlah TikTok Post: ${totalTiktokPost}\nJumlah User: ${totalUser}\n✅ Sudah Komentar: ${totalSudahKomentar} user\n⚠️ Kurang Komentar: ${totalKurangKomentar} user\n❌ Belum Komentar: ${totalBelumKomentar} user\n⁉️ Tanpa Username TikTok: ${totalTanpaUsername} user\n\nRekap per Client:\n${groupLines}`;
 
     if (navigator?.clipboard?.writeText) {
-      navigator.clipboard.writeText(message).then(() => {
-        alert("Rekap disalin ke clipboard");
-      });
-    } else {
-      alert(message);
+      try {
+        await navigator.clipboard.writeText(message);
+        showToast("Rekap disalin ke clipboard.", "success");
+        return;
+      } catch (error) {
+        showToast(
+          "Gagal menyalin rekap. Izinkan akses clipboard di browser Anda.",
+          "error",
+        );
+      }
+    }
+
+    if (typeof window !== "undefined") {
+      window.prompt("Salin rekap komentar secara manual:", message);
+      showToast(
+        "Clipboard tidak tersedia. Silakan salin rekap secara manual.",
+        "info",
+      );
     }
   }
 


### PR DESCRIPTION
## Summary
- import and use the shared toast utility for clipboard copy feedback
- update the TikTok rekap copy handler to await navigator.clipboard.writeText with error handling
- add a manual prompt fallback with informational toast when clipboard access is unavailable

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d2a580f5988327bbdad4954f6390f9