### PR TITLE
Add accessible data tables for chart components

### DIFF
--- a/cicero-dashboard/components/ChartDataTable.jsx
+++ b/cicero-dashboard/components/ChartDataTable.jsx
@@ -1,0 +1,106 @@
+"use client";
+
+const getAlignmentClass = (align) => {
+  if (align === "right") return "text-right";
+  if (align === "center") return "text-center";
+  return "text-left";
+};
+
+export default function ChartDataTable({
+  title,
+  columns = [],
+  rows = [],
+  summaryLabel = "Tampilkan data tabel",
+  initialOpen = false,
+}) {
+  if (!rows || rows.length === 0) {
+    return null;
+  }
+
+  const normalizedColumns = columns.map((column, index) => {
+    if (typeof column === "string") {
+      return {
+        key: column,
+        header: column,
+        isRowHeader: index === 0,
+      };
+    }
+    return {
+      ...column,
+      key: column.key ?? column.accessor ?? String(index),
+      header: column.header ?? column.title ?? column.label ?? column.key,
+      isRowHeader:
+        typeof column.isRowHeader === "boolean" ? column.isRowHeader : index === 0,
+    };
+  });
+
+  return (
+    <details className="group mt-4" open={initialOpen}>
+      <summary className="inline-flex cursor-pointer items-center gap-2 rounded px-2 py-1 text-sm font-semibold text-slate-700 transition hover:text-slate-900 focus:outline-none focus-visible:ring focus-visible:ring-blue-500 focus-visible:ring-offset-2">
+        <span
+          aria-hidden="true"
+          className="text-xs transition-transform duration-200 group-open:rotate-90"
+        >
+          ▶
+        </span>
+        {summaryLabel}
+      </summary>
+      <div className="mt-3 overflow-x-auto">
+        <table className="min-w-full border-collapse text-sm text-slate-700">
+          {title ? (
+            <caption className="mb-2 text-left text-base font-semibold text-slate-800">
+              {title}
+            </caption>
+          ) : null}
+          <thead className="bg-slate-100 text-xs font-semibold uppercase tracking-wide text-slate-900">
+            <tr>
+              {normalizedColumns.map((column) => (
+                <th
+                  key={column.key}
+                  scope="col"
+                  className={`px-3 py-2 ${getAlignmentClass(column.align)}`}
+                >
+                  {column.header}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-200 bg-white">
+            {rows.map((row, rowIndex) => (
+              <tr
+                key={row.id ?? row.key ?? rowIndex}
+                className={rowIndex % 2 === 0 ? "bg-white" : "bg-slate-50"}
+              >
+                {normalizedColumns.map((column, columnIndex) => {
+                  const cellValue = row[column.key];
+                  const alignmentClass = getAlignmentClass(column.align);
+                  const baseClass = `px-3 py-2 ${alignmentClass}`;
+                  const content = cellValue ?? "-";
+
+                  if (column.isRowHeader || columnIndex === 0) {
+                    return (
+                      <th
+                        key={column.key}
+                        scope="row"
+                        className={`${baseClass} font-semibold text-slate-900`}
+                      >
+                        {content}
+                      </th>
+                    );
+                  }
+
+                  return (
+                    <td key={column.key} className={`${baseClass} whitespace-nowrap`}>
+                      {content}
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </details>
+  );
+}
+

--- a/cicero-dashboard/components/ChartDivisiAbsensi.jsx
+++ b/cicero-dashboard/components/ChartDivisiAbsensi.jsx
@@ -12,6 +12,7 @@ import {
 } from "recharts";
 import { useEffect, useState } from "react";
 import { getClientNames } from "@/utils/api";
+import ChartDataTable from "@/components/ChartDataTable";
 
 // Bersihkan "POLSEK" dan awalan angka pada nama divisi/satfung
 function bersihkanSatfung(divisi = "") {
@@ -238,6 +239,55 @@ export default function ChartDivisiAbsensi({
     Math.max(minHeight, barHeight * dataChart.length),
   );
 
+  const numberFormatter = new Intl.NumberFormat("id-ID");
+  const percentFormatter = new Intl.NumberFormat("id-ID", {
+    style: "percent",
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1,
+  });
+  const entityColumnLabel =
+    groupBy === "client_id" ? "Client" : "Divisi/Client";
+  const tableColumns = [
+    { key: "entity", header: entityColumnLabel, isRowHeader: true },
+    { key: "total_user", header: labelTotalUser, align: "right" },
+    { key: "user_sudah", header: labelSudah, align: "right" },
+    {
+      key: "user_sudah_pct",
+      header: `${labelSudah} (%)`,
+      align: "right",
+    },
+    { key: "user_kurang", header: labelKurang, align: "right" },
+    {
+      key: "user_kurang_pct",
+      header: `${labelKurang} (%)`,
+      align: "right",
+    },
+    { key: "user_belum", header: labelBelum, align: "right" },
+    {
+      key: "user_belum_pct",
+      header: `${labelBelum} (%)`,
+      align: "right",
+    },
+    { key: "total_value", header: labelTotal, align: "right" },
+  ];
+  const tableRows = dataChart.map((entry) => {
+    const totalUser = entry.total_user ?? 0;
+    const safeRatio = (value) =>
+      totalUser ? Number(value || 0) / totalUser : 0;
+    return {
+      id: entry[labelKey] || entry.divisi,
+      entity: entry[labelKey] || entry.divisi || "-",
+      total_user: numberFormatter.format(entry.total_user ?? 0),
+      user_sudah: numberFormatter.format(entry.user_sudah ?? 0),
+      user_sudah_pct: percentFormatter.format(safeRatio(entry.user_sudah)),
+      user_kurang: numberFormatter.format(entry.user_kurang ?? 0),
+      user_kurang_pct: percentFormatter.format(safeRatio(entry.user_kurang)),
+      user_belum: numberFormatter.format(entry.user_belum ?? 0),
+      user_belum_pct: percentFormatter.format(safeRatio(entry.user_belum)),
+      total_value: numberFormatter.format(entry.total_value ?? 0),
+    };
+  });
+
   return (
     <div className="w-full bg-white rounded-xl shadow p-0 md:p-0 mt-8">
       <div className="w-full px-2 pb-4">
@@ -378,6 +428,11 @@ export default function ChartDivisiAbsensi({
             </Bar>
           </BarChart>
         </ResponsiveContainer>
+        <ChartDataTable
+          title={title}
+          columns={tableColumns}
+          rows={tableRows}
+        />
       </div>
     </div>
   );

--- a/cicero-dashboard/components/ChartHorizontal.jsx
+++ b/cicero-dashboard/components/ChartHorizontal.jsx
@@ -10,6 +10,7 @@ import {
   LabelList,
   Legend,
 } from "recharts";
+import ChartDataTable from "@/components/ChartDataTable";
 function bersihkanSatfung(divisi = "") {
   return divisi
     .replace(/polsek\s*/i, "")
@@ -77,6 +78,53 @@ export default function ChartHorizontal({
   // Tinggi chart proporsional
   const barHeight = 34;
   const chartHeight = Math.max(50, barHeight * dataChart.length);
+
+  const numberFormatter = new Intl.NumberFormat("id-ID");
+  const percentFormatter = new Intl.NumberFormat("id-ID", {
+    style: "percent",
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1,
+  });
+  const tableColumns = [
+    { key: "divisi", header: "Divisi/Client", isRowHeader: true },
+    { key: "total_user", header: labelTotalUser, align: "right" },
+    { key: "user_sudah", header: labelSudah, align: "right" },
+    {
+      key: "user_sudah_pct",
+      header: `${labelSudah} (%)`,
+      align: "right",
+    },
+    { key: "user_kurang", header: labelKurang, align: "right" },
+    {
+      key: "user_kurang_pct",
+      header: `${labelKurang} (%)`,
+      align: "right",
+    },
+    { key: "user_belum", header: labelBelum, align: "right" },
+    {
+      key: "user_belum_pct",
+      header: `${labelBelum} (%)`,
+      align: "right",
+    },
+    { key: "total_value", header: labelTotal, align: "right" },
+  ];
+  const tableRows = dataChart.map((entry) => {
+    const totalUser = entry.total_user ?? 0;
+    const safeRatio = (value) =>
+      totalUser ? Number(value || 0) / totalUser : 0;
+    return {
+      id: entry.divisi,
+      divisi: entry.divisi || "-",
+      total_user: numberFormatter.format(entry.total_user ?? 0),
+      user_sudah: numberFormatter.format(entry.user_sudah ?? 0),
+      user_sudah_pct: percentFormatter.format(safeRatio(entry.user_sudah)),
+      user_kurang: numberFormatter.format(entry.user_kurang ?? 0),
+      user_kurang_pct: percentFormatter.format(safeRatio(entry.user_kurang)),
+      user_belum: numberFormatter.format(entry.user_belum ?? 0),
+      user_belum_pct: percentFormatter.format(safeRatio(entry.user_belum)),
+      total_value: numberFormatter.format(entry.total_value ?? 0),
+    };
+  });
 
   return (
     <div className="w-full bg-white rounded-xl shadow p-0 md:p-0 mt-8">
@@ -165,6 +213,11 @@ export default function ChartHorizontal({
             </Bar>
           </BarChart>
         </ResponsiveContainer>
+        <ChartDataTable
+          title={title}
+          columns={tableColumns}
+          rows={tableRows}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add a reusable ChartDataTable component with accessible markup and a collapsible summary toggle
- render accompanying data tables for ChartDivisiAbsensi and ChartHorizontal, including formatted totals and percentage columns

## Testing
- npm run lint *(fails: command prompts for ESLint configuration and cannot run non-interactively)*

------
https://chatgpt.com/codex/tasks/task_e_68d2a6753c20832794e15230021ddfd3