### PR TITLE
Add empty state messages for TikTok comment recap

### DIFF
--- a/cicero-dashboard/components/RekapKomentarTiktok.jsx
+++ b/cicero-dashboard/components/RekapKomentarTiktok.jsx
@@ -59,6 +59,30 @@ export default function RekapKomentarTiktok({ users = [], totalTiktokPost = 0 })
   const [page, setPage] = usePersistentState("rekapKomentarTiktok_page", 1);
   const totalPages = Math.ceil(sorted.length / PAGE_SIZE);
   const currentRows = sorted.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
+  const trimmedSearch = search.trim();
+  const isInitialDataEmpty = totalUser === 0;
+  const showSearchEmptyState = !isInitialDataEmpty && filtered.length === 0;
+  const emptyState = isInitialDataEmpty
+    ? {
+        badge: "DATA SUMBER",
+        message: "Tidak ada data komentar TikTok yang tersedia untuk periode ini.",
+        description:
+          "Silakan cek kembali periode laporan atau pastikan sumber data sudah terhubung.",
+        containerClass: "bg-amber-50 border border-amber-200 text-amber-700",
+        badgeClass: "bg-amber-500/20 border border-amber-400/60 text-amber-700",
+      }
+    : showSearchEmptyState
+    ? {
+        badge: "HASIL PENCARIAN",
+        message:
+          trimmedSearch.length > 0
+            ? `Hasil pencarian untuk “${trimmedSearch}” tidak ditemukan.`
+            : "Tidak ada data yang cocok dengan filter saat ini.",
+        description: "Coba ubah kata kunci atau atur ulang filter pencarian.",
+        containerClass: "bg-indigo-50 border border-indigo-200 text-indigo-700",
+        badgeClass: "bg-indigo-500/10 border border-indigo-400/50 text-indigo-700",
+      }
+    : null;
   useEffect(() => setPage(1), [search, setPage]);
   useEffect(() => {
     if (page > totalPages) {
@@ -135,62 +159,81 @@ export default function RekapKomentarTiktok({ users = [], totalTiktokPost = 0 })
             </tr>
           </thead>
           <tbody>
-            {currentRows.map((u, i) => {
-              const sudahKomentar =
-                tidakAdaPost ? false : Number(u.jumlah_komentar) > 0;
-              const rowClass = tidakAdaPost
-                ? "bg-gray-50"
-                : sudahKomentar
-                ? "bg-green-50"
-                : "bg-red-50";
-              const statusClass = tidakAdaPost
-                ? "inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs bg-gray-400 text-white font-semibold"
-                : sudahKomentar
-                ? "inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs bg-green-500 text-white font-semibold"
-                : "inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs bg-red-500 text-white font-semibold";
-              return (
-                <tr
-                  key={u.user_id}
-                  className={rowClass}
-                >
-                  <td className="py-1 px-2">{(page - 1) * PAGE_SIZE + i + 1}</td>
-                  <td className="py-1 px-2">
-                    {u.nama_client || u.client_name || u.client || u.client_id || "-"}
-                  </td>
-                  <td className="py-1 px-2">
-                    {u.title ? `${u.title} ${u.nama}` : u.nama}
-                  </td>
-                  <td className="py-1 px-2 font-mono text-pink-700">{u.username}</td>
-                  <td className="py-1 px-2">
-                    <span className="inline-block px-2 py-0.5 rounded bg-sky-100 text-sky-800 font-medium">
-                      {bersihkanSatfung(u.divisi || "-")}
+            {currentRows.length === 0 && emptyState ? (
+              <tr>
+                <td colSpan={7} className="py-10 px-4">
+                  <div
+                    className={`mx-auto flex max-w-xl flex-col items-center gap-3 rounded-2xl px-6 py-6 text-center text-sm shadow-inner ${emptyState.containerClass}`}
+                  >
+                    <span
+                      className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide ${emptyState.badgeClass}`}
+                    >
+                      {emptyState.badge}
                     </span>
-                  </td>
-                  <td className="py-1 px-2 text-center">
-                    <span className={statusClass}>
-                      {tidakAdaPost ? (
-                        <>
-                          <Minus className="w-3 h-3" />
-                          Tidak ada posting hari ini
-                        </>
-                      ) : sudahKomentar ? (
-                        <>
-                          <Check className="w-3 h-3" />
-                          Sudah
-                        </>
-                      ) : (
-                        <>
-                          <X className="w-3 h-3" />
-                          Belum
-                        </>
-                      )}
-                    </span>
-                  </td>
-                  <td className="py-1 px-2 text-center font-bold">
-                    {tidakAdaPost ? "-" : u.jumlah_komentar}
-                  </td>
-                </tr>
-              );
+                    <p className="text-base font-semibold">{emptyState.message}</p>
+                    <p className="text-xs font-medium opacity-80">
+                      {emptyState.description}
+                    </p>
+                  </div>
+                </td>
+              </tr>
+            ) : (
+              currentRows.map((u, i) => {
+                const sudahKomentar =
+                  tidakAdaPost ? false : Number(u.jumlah_komentar) > 0;
+                const rowClass = tidakAdaPost
+                  ? "bg-gray-50"
+                  : sudahKomentar
+                  ? "bg-green-50"
+                  : "bg-red-50";
+                const statusClass = tidakAdaPost
+                  ? "inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs bg-gray-400 text-white font-semibold"
+                  : sudahKomentar
+                  ? "inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs bg-green-500 text-white font-semibold"
+                  : "inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs bg-red-500 text-white font-semibold";
+                return (
+                  <tr
+                    key={u.user_id}
+                    className={rowClass}
+                  >
+                    <td className="py-1 px-2">{(page - 1) * PAGE_SIZE + i + 1}</td>
+                    <td className="py-1 px-2">
+                      {u.nama_client || u.client_name || u.client || u.client_id || "-"}
+                    </td>
+                    <td className="py-1 px-2">
+                      {u.title ? `${u.title} ${u.nama}` : u.nama}
+                    </td>
+                    <td className="py-1 px-2 font-mono text-pink-700">{u.username}</td>
+                    <td className="py-1 px-2">
+                      <span className="inline-block px-2 py-0.5 rounded bg-sky-100 text-sky-800 font-medium">
+                        {bersihkanSatfung(u.divisi || "-")}
+                      </span>
+                    </td>
+                    <td className="py-1 px-2 text-center">
+                      <span className={statusClass}>
+                        {tidakAdaPost ? (
+                          <>
+                            <Minus className="w-3 h-3" />
+                            Tidak ada posting hari ini
+                          </>
+                        ) : sudahKomentar ? (
+                          <>
+                            <Check className="w-3 h-3" />
+                            Sudah
+                          </>
+                        ) : (
+                          <>
+                            <X className="w-3 h-3" />
+                            Belum
+                          </>
+                        )}
+                      </span>
+                    </td>
+                    <td className="py-1 px-2 text-center font-bold">
+                      {tidakAdaPost ? "-" : u.jumlah_komentar}
+                    </td>
+                  </tr>
+                );
             })}
           </tbody>
         </table>


### PR DESCRIPTION
## Summary
- add derived empty-state metadata to show appropriate messaging when the TikTok recap table has no rows
- render a full-width table row that differentiates between missing source data and empty search results
- polish table row formatting after introducing the empty state block

## Testing
- npm run lint *(fails: prompts for eslint configuration interactively)*

------
https://chatgpt.com/codex/tasks/task_e_68d2ac380f4c8327a77e612e7923e1b1