### PR TITLE
Fix JSX closing for TikTok comment recap table

### DIFF
--- a/cicero-dashboard/components/RekapKomentarTiktok.jsx
+++ b/cicero-dashboard/components/RekapKomentarTiktok.jsx
@@ -192,8 +192,7 @@ export default function RekapKomentarTiktok({ users = [], totalTiktokPost = 0 })
                   </div>
                 </td>
               </tr>
-            ) : (
-              currentRows.map((u, i) => {
+            ) : currentRows.map((u, i) => {
                 const sudahKomentar =
                   tidakAdaPost ? false : Number(u.jumlah_komentar) > 0;
                 const rowClass = tidakAdaPost
@@ -249,7 +248,7 @@ export default function RekapKomentarTiktok({ users = [], totalTiktokPost = 0 })
                     </td>
                   </tr>
                 );
-            })}
+              })}
           </tbody>
         </table>
       </div>


### PR DESCRIPTION
## Summary
- fix the JSX ternary expression to correctly return the mapped TikTok comment rows

## Testing
- yarn lint *(fails: workspace package missing from lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68d2afc444b08327934d0395efd1ed21