### PR TITLE
Adjust view selector layout for TikTok recap

### DIFF
--- a/cicero-dashboard/app/comments/tiktok/rekap/page.jsx
+++ b/cicero-dashboard/app/comments/tiktok/rekap/page.jsx
@@ -251,7 +251,7 @@ export default function RekapKomentarTiktokPage() {
               Kembali
             </Link>
           </div>
-          <div className="flex items-center justify-end gap-3 mb-2">
+          <div className="flex flex-wrap items-center justify-start md:justify-end gap-3 mb-2">
             <ViewDataSelector
               value={viewBy}
               onChange={handleViewChange}


### PR DESCRIPTION
## Summary
- allow the Rekap TikTok view selector container to wrap on smaller screens
- default to left-aligned controls on small viewports while keeping right alignment on larger screens

## Testing
- npm run lint *(fails: command requires interactive configuration and exits without running lint)*

------
https://chatgpt.com/codex/tasks/task_e_68d2b6547f508327aed3b40fe49b1dbb