### PR TITLE
Handle aborts in TikTok recap fetch

### DIFF
--- a/cicero-dashboard/utils/api.ts
+++ b/cicero-dashboard/utils/api.ts
@@ -232,7 +232,8 @@ export async function getRekapKomentarTiktok(
   periode: string = "harian",
   tanggal?: string,
   startDate?: string,
-  endDate?: string
+  endDate?: string,
+  signal?: AbortSignal,
 ): Promise<any> {
   const params = new URLSearchParams({ client_id, periode });
   if (tanggal) params.append("tanggal", tanggal);
@@ -240,7 +241,7 @@ export async function getRekapKomentarTiktok(
   if (endDate) params.append("end_date", endDate);
   const url = `${API_BASE_URL}/api/tiktok/rekap-komentar?${params.toString()}`;
 
-  const res = await fetchWithAuth(url, token);
+  const res = await fetchWithAuth(url, token, { signal });
   if (!res.ok) {
     const errText = await res.text();
     throw new Error(`Failed to fetch rekap komentar tiktok: ${errText}`);


### PR DESCRIPTION
## Summary
- add AbortController logic to the TikTok recap page to cancel in-flight requests when filters change and ignore abort errors
- pass the abort signal into dashboard stats, TikTok recap, and client name API calls and ensure the TikTok recap API helper accepts an AbortSignal

## Testing
- npm test -- --runTestsByPath __tests__/api.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d2b9df50988327a41e902893c23dbd