### PR TITLE
Ensure custom date ranges are ordered before use

### DIFF
--- a/cicero-dashboard/app/likes/instagram/rekap/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/rekap/page.jsx
@@ -72,6 +72,16 @@ export default function RekapLikesIGPage() {
         if (!nextRange.endDate) {
           nextRange.endDate = nextRange.startDate;
         }
+        if (nextRange.startDate && nextRange.endDate) {
+          const start = new Date(nextRange.startDate);
+          const end = new Date(nextRange.endDate);
+          if (start > end) {
+            return {
+              startDate: nextRange.endDate,
+              endDate: nextRange.startDate,
+            };
+          }
+        }
         return nextRange;
       });
       return;


### PR DESCRIPTION
## Summary
- add safeguards when updating custom date ranges to ensure the start date is not after the end date

## Testing
- npm run lint (fails: command requires interactive selection)

------
https://chatgpt.com/codex/tasks/task_e_68d32f3534688327a56096eb80856228