### PR TITLE
Reset pagination when RekapLikes data changes

### DIFF
--- a/cicero-dashboard/components/RekapLikesIG.jsx
+++ b/cicero-dashboard/components/RekapLikesIG.jsx
@@ -95,6 +95,11 @@ const RekapLikesIG = forwardRef(function RekapLikesIG(
   const totalPages = Math.ceil(sorted.length / PAGE_SIZE);
   const currentRows = sorted.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
 
+  // Reset ke halaman 1 ketika data pengguna berubah dari parent
+  useEffect(() => {
+    setPage(1);
+  }, [users, setPage]);
+
   // Reset ke halaman 1 jika search berubah
   useEffect(() => setPage(1), [search, setPage]);
 


### PR DESCRIPTION
## Summary
- reset RekapLikes pagination to the first page whenever parent user data changes
- preserve existing search reset behaviour by only targeting prop-driven updates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3301bde148327810f288a5ea24d24