### PR TITLE
Add view label above summary cards on TikTok comments and Instagram likes pages

### DIFF
--- a/cicero-dashboard/app/comments/tiktok/page.jsx
+++ b/cicero-dashboard/app/comments/tiktok/page.jsx
@@ -433,70 +433,75 @@ export default function TiktokEngagementInsightPage() {
               TikTok Engagement Insight
             </h1>
 
-            <div className="bg-gradient-to-tr from-fuchsia-50 to-white rounded-2xl shadow flex flex-col md:flex-row items-stretch justify-between p-3 md:p-5 gap-2 md:gap-4 border">
-              <SummaryItem
-                label="Jumlah TikTok Post"
-                value={rekapSummary.totalTiktokPost}
-                color="fuchsia"
-                icon={<Music className="text-fuchsia-400" />}
-              />
-              <Divider />
-              <SummaryItem
-                label="Total User"
-                value={rekapSummary.totalUser}
-                color="gray"
-                icon={<User className="text-gray-400" />}
-              />
-              <Divider />
-              <SummaryItem
-                label="Sudah Komentar"
-                value={rekapSummary.totalSudahKomentar}
-                color="green"
-                icon={<MessageCircle className="text-green-500" />}
-              />
-              <Divider />
-              <SummaryItem
-                label="Kurang Komentar"
-                value={rekapSummary.totalKurangKomentar}
-                color="orange"
-                icon={<MessageCircle className="text-orange-500" />}
-              />
-              <Divider />
-              <SummaryItem
-                label="Belum Komentar"
-                value={rekapSummary.totalBelumKomentar}
-                color="red"
-                icon={<X className="text-red-500" />}
-              />
-              <Divider />
-              <SummaryItem
-                label="Tanpa Username"
-                value={rekapSummary.totalTanpaUsername}
-                color="gray"
-                icon={<UserX className="text-gray-400" />}
-              />
-            </div>
-
-            <div className="flex flex-wrap items-center justify-end gap-3 mb-2 w-full">
-              <ViewDataSelector
-                value={viewBy}
-                onChange={setViewBy}
-                options={viewOptions}
-                date={
-                  viewBy === "custom_range"
-                    ? { startDate: fromDate, endDate: toDate }
-                    : customDate
-                }
-                onDateChange={(val) => {
-                  if (viewBy === "custom_range") {
-                    setFromDate(val.startDate || "");
-                    setToDate(val.endDate || "");
-                  } else {
-                    setCustomDate(val);
+            <div className="flex flex-col gap-3">
+              <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+                <span className="text-sm font-semibold text-gray-600">
+                  View Data By:
+                </span>
+                <ViewDataSelector
+                  value={viewBy}
+                  onChange={setViewBy}
+                  options={viewOptions}
+                  date={
+                    viewBy === "custom_range"
+                      ? { startDate: fromDate, endDate: toDate }
+                      : customDate
                   }
-                }}
-                disabled={isRefreshing}
-              />
+                  onDateChange={(val) => {
+                    if (viewBy === "custom_range") {
+                      setFromDate(val.startDate || "");
+                      setToDate(val.endDate || "");
+                    } else {
+                      setCustomDate(val);
+                    }
+                  }}
+                  disabled={isRefreshing}
+                />
+              </div>
+
+              <div className="bg-gradient-to-tr from-fuchsia-50 to-white rounded-2xl shadow flex flex-col md:flex-row items-stretch justify-between p-3 md:p-5 gap-2 md:gap-4 border">
+                <SummaryItem
+                  label="Jumlah TikTok Post"
+                  value={rekapSummary.totalTiktokPost}
+                  color="fuchsia"
+                  icon={<Music className="text-fuchsia-400" />}
+                />
+                <Divider />
+                <SummaryItem
+                  label="Total User"
+                  value={rekapSummary.totalUser}
+                  color="gray"
+                  icon={<User className="text-gray-400" />}
+                />
+                <Divider />
+                <SummaryItem
+                  label="Sudah Komentar"
+                  value={rekapSummary.totalSudahKomentar}
+                  color="green"
+                  icon={<MessageCircle className="text-green-500" />}
+                />
+                <Divider />
+                <SummaryItem
+                  label="Kurang Komentar"
+                  value={rekapSummary.totalKurangKomentar}
+                  color="orange"
+                  icon={<MessageCircle className="text-orange-500" />}
+                />
+                <Divider />
+                <SummaryItem
+                  label="Belum Komentar"
+                  value={rekapSummary.totalBelumKomentar}
+                  color="red"
+                  icon={<X className="text-red-500" />}
+                />
+                <Divider />
+                <SummaryItem
+                  label="Tanpa Username"
+                  value={rekapSummary.totalTanpaUsername}
+                  color="gray"
+                  icon={<UserX className="text-gray-400" />}
+                />
+              </div>
             </div>
 
             {isDirectorate ? (

--- a/cicero-dashboard/app/likes/instagram/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/page.jsx
@@ -77,69 +77,73 @@ export default function InstagramEngagementInsightPage() {
             </h1>
 
             {/* Card Ringkasan */}
-            <div className="bg-gradient-to-tr from-blue-50 to-white rounded-2xl shadow flex flex-col md:flex-row items-stretch justify-between p-3 md:p-5 gap-2 md:gap-4 border">
-              <SummaryItem
-                label="Jumlah IG Post"
-                value={rekapSummary.totalIGPost}
-                color="blue"
-                icon={<Camera className="text-blue-400" />}
-              />
-              <Divider />
-              <SummaryItem
-                label="Total User"
-                value={rekapSummary.totalUser}
-                color="gray"
-                icon={<User className="text-gray-400" />}
-              />
-              <Divider />
-              <SummaryItem
-                label="Sudah Likes"
-                value={rekapSummary.totalSudahLike}
-                color="green"
-                icon={<ThumbsUp className="text-green-500" />}
-              />
-              <Divider />
-              <SummaryItem
-                label="Kurang Likes"
-                value={rekapSummary.totalKurangLike}
-                color="orange"
-                icon={<ThumbsDown className="text-orange-500" />}
-              />
-              <Divider />
-              <SummaryItem
-                label="Belum Likes"
-                value={rekapSummary.totalBelumLike}
-                color="red"
-                icon={<ThumbsDown className="text-red-500" />}
-              />
-              <Divider />
-              <SummaryItem
-                label="Tanpa Username"
-                value={rekapSummary.totalTanpaUsername}
-                color="gray"
-                icon={<UserX className="text-gray-400" />}
-              />
-            </div>
+            <div className="flex flex-col gap-3">
+              <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+                <span className="text-sm font-semibold text-gray-600">
+                  View Data By:
+                </span>
+                <ViewDataSelector
+                  value={viewBy}
+                  onChange={setViewBy}
+                  options={viewOptions}
+                  date=
+                    {viewBy === "custom_range"
+                      ? { startDate: fromDate, endDate: toDate }
+                      : customDate}
+                  onDateChange={(val) => {
+                    if (viewBy === "custom_range") {
+                      setFromDate(val.startDate || "");
+                      setToDate(val.endDate || "");
+                    } else {
+                      setCustomDate(val);
+                    }
+                  }}
+                />
+              </div>
 
-            {/* Switch Periode */}
-            <div className="flex items-center justify-end gap-3 mb-2">
-              <ViewDataSelector
-                value={viewBy}
-                onChange={setViewBy}
-                options={viewOptions}
-                date=
-                  {viewBy === "custom_range"
-                    ? { startDate: fromDate, endDate: toDate }
-                    : customDate}
-                onDateChange={(val) => {
-                  if (viewBy === "custom_range") {
-                    setFromDate(val.startDate || "");
-                    setToDate(val.endDate || "");
-                  } else {
-                    setCustomDate(val);
-                  }
-                }}
-              />
+              <div className="bg-gradient-to-tr from-blue-50 to-white rounded-2xl shadow flex flex-col md:flex-row items-stretch justify-between p-3 md:p-5 gap-2 md:gap-4 border">
+                <SummaryItem
+                  label="Jumlah IG Post"
+                  value={rekapSummary.totalIGPost}
+                  color="blue"
+                  icon={<Camera className="text-blue-400" />}
+                />
+                <Divider />
+                <SummaryItem
+                  label="Total User"
+                  value={rekapSummary.totalUser}
+                  color="gray"
+                  icon={<User className="text-gray-400" />}
+                />
+                <Divider />
+                <SummaryItem
+                  label="Sudah Likes"
+                  value={rekapSummary.totalSudahLike}
+                  color="green"
+                  icon={<ThumbsUp className="text-green-500" />}
+                />
+                <Divider />
+                <SummaryItem
+                  label="Kurang Likes"
+                  value={rekapSummary.totalKurangLike}
+                  color="orange"
+                  icon={<ThumbsDown className="text-orange-500" />}
+                />
+                <Divider />
+                <SummaryItem
+                  label="Belum Likes"
+                  value={rekapSummary.totalBelumLike}
+                  color="red"
+                  icon={<ThumbsDown className="text-red-500" />}
+                />
+                <Divider />
+                <SummaryItem
+                  label="Tanpa Username"
+                  value={rekapSummary.totalTanpaUsername}
+                  color="gray"
+                  icon={<UserX className="text-gray-400" />}
+                />
+              </div>
             </div>
 
             {/* Chart per kelompok / polres */}


### PR DESCRIPTION
## Summary
- add a "View Data By:" label and pair the selector with the summary cards on the TikTok comments insight page
- mirror the new label and layout for the Instagram likes insight page so both dashboards share the same structure

## Testing
- npm run lint *(fails: command prompts for ESLint configuration and cannot run non-interactively)*

------
https://chatgpt.com/codex/tasks/task_e_68d334aa8d38832786c56e0547ecf0f7