### PR TITLE
Add percentage summary insights with progress display

### DIFF
--- a/cicero-dashboard/app/user-insight/page.jsx
+++ b/cicero-dashboard/app/user-insight/page.jsx
@@ -36,6 +36,10 @@ export default function UserInsightPage() {
     instagramEmpty: 0,
     tiktokFilled: 0,
     tiktokEmpty: 0,
+    instagramFilledPercent: 0,
+    instagramEmptyPercent: 0,
+    tiktokFilledPercent: 0,
+    tiktokEmptyPercent: 0,
   });
 
   const [chartKelompok, setChartKelompok] = useState({
@@ -190,7 +194,16 @@ export default function UserInsightPage() {
             tiktokEmpty: 0,
           },
         );
-        setSummary(summaryCounts);
+        const totalUsers = summaryCounts.total || 0;
+        const safeRatio = (count) =>
+          totalUsers > 0 ? Math.min(100, Math.max(0, (count / totalUsers) * 100)) : 0;
+        setSummary({
+          ...summaryCounts,
+          instagramFilledPercent: safeRatio(summaryCounts.instagramFilled),
+          instagramEmptyPercent: safeRatio(summaryCounts.instagramEmpty),
+          tiktokFilledPercent: safeRatio(summaryCounts.tiktokFilled),
+          tiktokEmptyPercent: safeRatio(summaryCounts.tiktokEmpty),
+        });
 
         if (dir) {
           const clientMap = {};
@@ -351,6 +364,8 @@ export default function UserInsightPage() {
                 value={summary.instagramFilled}
                 color="red"
                 icon={<Instagram className="text-red-500" />}
+                percentage={summary.instagramFilledPercent}
+                showProgress
               />
               <Divider />
               <SummaryItem
@@ -358,6 +373,7 @@ export default function UserInsightPage() {
                 value={summary.instagramEmpty}
                 color="gray"
                 icon={<Instagram className="text-gray-500" />}
+                percentage={summary.instagramEmptyPercent}
               />
               <Divider />
               <SummaryItem
@@ -365,6 +381,8 @@ export default function UserInsightPage() {
                 value={summary.tiktokFilled}
                 color="green"
                 icon={<Music className="text-green-500" />}
+                percentage={summary.tiktokFilledPercent}
+                showProgress
               />
               <Divider />
               <SummaryItem
@@ -372,6 +390,7 @@ export default function UserInsightPage() {
                 value={summary.tiktokEmpty}
                 color="gray"
                 icon={<Music className="text-gray-500" />}
+                percentage={summary.tiktokEmptyPercent}
               />
             </div>
 
@@ -708,22 +727,55 @@ function CustomAxisTick({
   );
 }
 
-function SummaryItem({ label, value, color = "gray", icon }) {
+function SummaryItem({
+  label,
+  value,
+  color = "gray",
+  icon,
+  percentage,
+  showProgress = false,
+}) {
   const colorMap = {
-    blue: "text-blue-700",
-    green: "text-green-600",
-    red: "text-red-500",
-    gray: "text-gray-700",
+    blue: { text: "text-blue-700", bar: "bg-blue-500" },
+    green: { text: "text-green-600", bar: "bg-green-500" },
+    red: { text: "text-red-500", bar: "bg-red-500" },
+    gray: { text: "text-gray-700", bar: "bg-gray-500" },
   };
+  const displayColor = colorMap[color] || colorMap.gray;
+  const formattedPercentage =
+    typeof percentage === "number"
+      ? `${percentage.toFixed(1).replace(".0", "")} %`
+      : null;
+  const progressWidth =
+    typeof percentage === "number" ? `${Math.min(100, Math.max(0, percentage))}%` : "0%";
+
   return (
-    <div className="flex-1 flex flex-col items-center justify-center py-2">
-      <div className="mb-1">{icon}</div>
-      <div className={`text-3xl md:text-4xl font-bold ${colorMap[color]}`}>
-        {value}
-      </div>
+    <div className="flex-1 flex flex-col items-center justify-center py-2 px-2 w-full">
+      <div className="mb-1 flex items-center justify-center text-xl">{icon}</div>
+      <div className={`text-3xl md:text-4xl font-bold ${displayColor.text}`}>{value}</div>
       <div className="text-xs md:text-sm font-semibold text-gray-500 mt-1 uppercase tracking-wide text-center">
         {label}
       </div>
+      {formattedPercentage && (
+        <div className="mt-1 flex flex-col items-center gap-1 w-full max-w-[160px]">
+          <span className="text-[11px] md:text-xs font-medium text-gray-600">
+            {formattedPercentage}
+          </span>
+          {showProgress && (
+            <div className="h-1.5 w-full rounded-full bg-gray-200">
+              <div
+                className={`h-full rounded-full transition-all duration-300 ease-out ${displayColor.bar}`}
+                style={{ width: progressWidth }}
+                role="progressbar"
+                aria-valuenow={Math.round(Number(percentage) || 0)}
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-label={`${label} ${formattedPercentage}`}
+              />
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- calculate Instagram and TikTok completion ratios when building the user insight summary
- extend summary tiles to show formatted percentages and optional progress bars for filled metrics
- pass percentage data into the summary components to improve readability on all breakpoints

## Testing
- npm run lint *(fails: requires interactive configuration prompt from Next.js)*

------
https://chatgpt.com/codex/tasks/task_e_68d33b3f72b8832780fe08a3b982f0a3