### PR TITLE
Add percentage indicators to Instagram and TikTok summary cards

### DIFF
--- a/cicero-dashboard/app/comments/tiktok/page.jsx
+++ b/cicero-dashboard/app/comments/tiktok/page.jsx
@@ -54,6 +54,16 @@ export default function TiktokEngagementInsightPage() {
 
   const viewOptions = VIEW_OPTIONS;
 
+  const totalUser = Number(rekapSummary.totalUser) || 0;
+  const totalTanpaUsername = Number(rekapSummary.totalTanpaUsername) || 0;
+  const validUserCount = Math.max(0, totalUser - totalTanpaUsername);
+  const getPercentage = (value, base = validUserCount) => {
+    const denominator = Number(base);
+    if (!denominator) return undefined;
+    const numerator = Number(value) || 0;
+    return (numerator / denominator) * 100;
+  };
+
   useEffect(() => {
     setError("");
     const token =
@@ -476,6 +486,7 @@ export default function TiktokEngagementInsightPage() {
                   value={rekapSummary.totalSudahKomentar}
                   color="green"
                   icon={<MessageCircle className="text-green-500" />}
+                  percentage={getPercentage(rekapSummary.totalSudahKomentar)}
                 />
                 <Divider />
                 <SummaryItem
@@ -483,6 +494,7 @@ export default function TiktokEngagementInsightPage() {
                   value={rekapSummary.totalKurangKomentar}
                   color="orange"
                   icon={<MessageCircle className="text-orange-500" />}
+                  percentage={getPercentage(rekapSummary.totalKurangKomentar)}
                 />
                 <Divider />
                 <SummaryItem
@@ -490,6 +502,7 @@ export default function TiktokEngagementInsightPage() {
                   value={rekapSummary.totalBelumKomentar}
                   color="red"
                   icon={<X className="text-red-500" />}
+                  percentage={getPercentage(rekapSummary.totalBelumKomentar)}
                 />
                 <Divider />
                 <SummaryItem
@@ -497,6 +510,10 @@ export default function TiktokEngagementInsightPage() {
                   value={rekapSummary.totalTanpaUsername}
                   color="gray"
                   icon={<UserX className="text-gray-400" />}
+                  percentage={getPercentage(
+                    rekapSummary.totalTanpaUsername,
+                    totalUser,
+                  )}
                 />
               </div>
             </div>
@@ -617,23 +634,50 @@ function ChartBox({
   );
 }
 
-function SummaryItem({ label, value, color = "gray", icon }) {
+function SummaryItem({ label, value, color = "gray", icon, percentage }) {
   const colorMap = {
-    fuchsia: "text-fuchsia-700",
-    green: "text-green-600",
-    red: "text-red-500",
-    gray: "text-gray-700",
-    orange: "text-orange-500",
+    fuchsia: { text: "text-fuchsia-700", bar: "bg-fuchsia-500" },
+    green: { text: "text-green-600", bar: "bg-green-500" },
+    red: { text: "text-red-500", bar: "bg-red-500" },
+    gray: { text: "text-gray-700", bar: "bg-gray-500" },
+    orange: { text: "text-orange-500", bar: "bg-orange-500" },
   };
+  const displayColor = colorMap[color] || colorMap.gray;
+  const formattedPercentage =
+    typeof percentage === "number" && !Number.isNaN(percentage)
+      ? `${percentage.toFixed(1).replace(".0", "")} %`
+      : null;
+  const progressWidth =
+    typeof percentage === "number"
+      ? `${Math.min(100, Math.max(0, percentage))}%`
+      : "0%";
   return (
     <div className="flex-1 flex flex-col items-center justify-center py-2">
       <div className="mb-1">{icon}</div>
-      <div className={`text-3xl md:text-4xl font-bold ${colorMap[color]}`}>
+      <div className={`text-3xl md:text-4xl font-bold ${displayColor.text}`}>
         {value}
       </div>
       <div className="text-xs md:text-sm font-semibold text-gray-500 mt-1 uppercase tracking-wide text-center">
         {label}
       </div>
+      {formattedPercentage && (
+        <div className="mt-1 flex flex-col items-center gap-1 w-full max-w-[160px]">
+          <span className="text-[11px] md:text-xs font-medium text-gray-600">
+            {formattedPercentage}
+          </span>
+          <div className="h-1.5 w-full rounded-full bg-gray-200">
+            <div
+              className={`h-full rounded-full transition-all duration-300 ease-out ${displayColor.bar}`}
+              style={{ width: progressWidth }}
+              role="progressbar"
+              aria-valuenow={Math.round(Number(percentage) || 0)}
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-label={`${label} ${formattedPercentage}`}
+            />
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/cicero-dashboard/app/likes/instagram/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/page.jsx
@@ -54,6 +54,16 @@ export default function InstagramEngagementInsightPage() {
   // Group chartData by kelompok jika bukan direktorat
   const kelompok = isDirectorate ? null : groupUsersByKelompok(chartData);
 
+  const totalUser = Number(rekapSummary.totalUser) || 0;
+  const totalTanpaUsername = Number(rekapSummary.totalTanpaUsername) || 0;
+  const validUserCount = Math.max(0, totalUser - totalTanpaUsername);
+  const getPercentage = (value, base = validUserCount) => {
+    const denominator = Number(base);
+    if (!denominator) return undefined;
+    const numerator = Number(value) || 0;
+    return (numerator / denominator) * 100;
+  };
+
   function handleCopyRekap() {
     const message = buildInstagramRekap(rekapSummary, chartData, clientName);
 
@@ -118,6 +128,7 @@ export default function InstagramEngagementInsightPage() {
                   value={rekapSummary.totalSudahLike}
                   color="green"
                   icon={<ThumbsUp className="text-green-500" />}
+                  percentage={getPercentage(rekapSummary.totalSudahLike)}
                 />
                 <Divider />
                 <SummaryItem
@@ -125,6 +136,7 @@ export default function InstagramEngagementInsightPage() {
                   value={rekapSummary.totalKurangLike}
                   color="orange"
                   icon={<ThumbsDown className="text-orange-500" />}
+                  percentage={getPercentage(rekapSummary.totalKurangLike)}
                 />
                 <Divider />
                 <SummaryItem
@@ -132,6 +144,7 @@ export default function InstagramEngagementInsightPage() {
                   value={rekapSummary.totalBelumLike}
                   color="red"
                   icon={<ThumbsDown className="text-red-500" />}
+                  percentage={getPercentage(rekapSummary.totalBelumLike)}
                 />
                 <Divider />
                 <SummaryItem
@@ -139,6 +152,10 @@ export default function InstagramEngagementInsightPage() {
                   value={rekapSummary.totalTanpaUsername}
                   color="gray"
                   icon={<UserX className="text-gray-400" />}
+                  percentage={getPercentage(
+                    rekapSummary.totalTanpaUsername,
+                    totalUser,
+                  )}
                 />
               </div>
             </div>

--- a/cicero-dashboard/components/RekapKomentarTiktok.jsx
+++ b/cicero-dashboard/components/RekapKomentarTiktok.jsx
@@ -62,6 +62,14 @@ export default function RekapKomentarTiktok({ users = [], totalTiktokPost = 0 })
     totalTanpaUsername,
   } = summary;
   const tidakAdaPost = totalTiktokPostCount === 0;
+  const validUserCount = Math.max(0, totalUser - totalTanpaUsername);
+
+  const getPercentage = (value, base = validUserCount) => {
+    const denominator = Number(base);
+    if (!denominator) return undefined;
+    const numerator = Number(value) || 0;
+    return (numerator / denominator) * 100;
+  };
 
   const hasSatker = useMemo(
     () =>
@@ -376,24 +384,28 @@ export default function RekapKomentarTiktok({ users = [], totalTiktokPost = 0 })
           value={totalSudahKomentar}
           color="bg-gradient-to-r from-green-400 via-green-500 to-lime-400 text-white"
           icon={<Check className="h-7 w-7" />}
+          percentage={getPercentage(totalSudahKomentar)}
         />
         <SummaryCard
           title="Kurang Komentar"
           value={totalKurangKomentar}
           color="bg-gradient-to-r from-yellow-400 via-orange-500 to-orange-600 text-white"
           icon={<AlertTriangle className="h-7 w-7" />}
+          percentage={getPercentage(totalKurangKomentar)}
         />
         <SummaryCard
           title="Belum Komentar"
           value={totalBelumKomentar}
           color="bg-gradient-to-r from-red-400 via-pink-500 to-yellow-400 text-white"
           icon={<X className="h-7 w-7" />}
+          percentage={getPercentage(totalBelumKomentar)}
         />
         <SummaryCard
           title="Tanpa Username"
           value={totalTanpaUsername}
           color="bg-gradient-to-r from-gray-300 via-gray-400 to-gray-500 text-gray-800"
           icon={<UserX className="h-7 w-7" />}
+          percentage={getPercentage(totalTanpaUsername, totalUser)}
         />
       </div>
       {tidakAdaPost && (
@@ -572,7 +584,21 @@ export default function RekapKomentarTiktok({ users = [], totalTiktokPost = 0 })
   );
 }
 
-function SummaryCard({ title, value, color, icon }) {
+function SummaryCard({ title, value, color, icon, percentage }) {
+  const formattedPercentage =
+    typeof percentage === "number" && !Number.isNaN(percentage)
+      ? `${percentage.toFixed(1).replace(".0", "")}%`
+      : null;
+  const clampedPercentage =
+    typeof percentage === "number"
+      ? Math.min(100, Math.max(0, percentage))
+      : 0;
+  const hasDarkText = /text-(gray|slate|zinc)-(8|9)00/.test(color);
+  const labelTextClass = hasDarkText ? "text-gray-900" : "text-white";
+  const percentageTextClass = hasDarkText ? "text-gray-900/80" : "text-white/80";
+  const progressBackground = hasDarkText ? "bg-gray-300/80" : "bg-white/30";
+  const progressFill = hasDarkText ? "bg-gray-700" : "bg-white";
+
   return (
     <div
       className={`rounded-2xl shadow-md p-6 flex flex-col items-center gap-2 text-center ${color}`}
@@ -581,9 +607,29 @@ function SummaryCard({ title, value, color, icon }) {
         {icon}
         <span>{value}</span>
       </div>
-      <div className="text-xs mt-1 text-white font-semibold uppercase tracking-wider">
+      <div
+        className={`text-xs mt-1 font-semibold uppercase tracking-wider ${labelTextClass}`}
+      >
         {title}
       </div>
+      {formattedPercentage && (
+        <div className="mt-1 flex flex-col items-center gap-1 w-full max-w-[180px]">
+          <span className={`text-[11px] font-medium ${percentageTextClass}`}>
+            {formattedPercentage}
+          </span>
+          <div className={`h-1.5 w-full rounded-full ${progressBackground}`}>
+            <div
+              className={`h-full rounded-full transition-all duration-300 ease-out ${progressFill}`}
+              style={{ width: `${clampedPercentage}%` }}
+              role="progressbar"
+              aria-valuenow={Math.round(Number(percentage) || 0)}
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-label={`${title} ${formattedPercentage}`}
+            />
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/cicero-dashboard/components/RekapLikesIG.jsx
+++ b/cicero-dashboard/components/RekapLikesIG.jsx
@@ -73,6 +73,14 @@ const RekapLikesIG = forwardRef(function RekapLikesIG(
       ? validUsers.length
       : validUsers.filter((u) => Number(u.jumlah_like) === 0).length;
   const totalTanpaUsername = tanpaUsernameUsers.length;
+  const validUserCount = validUsers.length;
+
+  const getPercentage = (value, base = validUserCount) => {
+    const denominator = Number(base);
+    if (!denominator) return undefined;
+    const numerator = Number(value) || 0;
+    return (numerator / denominator) * 100;
+  };
 
   // Search/filter
   const [search, setSearch] = useState("");
@@ -348,24 +356,28 @@ const RekapLikesIG = forwardRef(function RekapLikesIG(
           value={totalSudahLike}
           color="bg-gradient-to-r from-green-400 via-green-500 to-lime-400 text-white"
           icon={<Check />}
+          percentage={getPercentage(totalSudahLike)}
         />
         <SummaryCard
           title="Kurang Like"
           value={totalKurangLike}
           color="bg-gradient-to-r from-yellow-400 via-orange-500 to-orange-600 text-white"
           icon={<AlertTriangle />}
+          percentage={getPercentage(totalKurangLike)}
         />
         <SummaryCard
           title="Belum Like"
           value={totalBelumLike}
           color="bg-gradient-to-r from-red-400 via-pink-500 to-yellow-400 text-white"
           icon={<X />}
+          percentage={getPercentage(totalBelumLike)}
         />
         <SummaryCard
           title="Tanpa Username"
           value={totalTanpaUsername}
           color="bg-gradient-to-r from-gray-300 via-gray-400 to-gray-500 text-gray-800"
           icon={<UserX />}
+          percentage={getPercentage(totalTanpaUsername, totalUser)}
         />
       </div>
 
@@ -542,14 +554,52 @@ const RekapLikesIG = forwardRef(function RekapLikesIG(
 export default RekapLikesIG;
 
 // Semua card mengikuti style IG Post Hari Ini
-function SummaryCard({ title, value, color, icon }) {
+function SummaryCard({ title, value, color, icon, percentage }) {
+  const formattedPercentage =
+    typeof percentage === "number" && !Number.isNaN(percentage)
+      ? `${percentage.toFixed(1).replace(".0", "")}%`
+      : null;
+  const clampedPercentage =
+    typeof percentage === "number"
+      ? Math.min(100, Math.max(0, percentage))
+      : 0;
+  const hasDarkText = /text-(gray|slate|zinc)-(8|9)00/.test(color);
+  const labelTextClass = hasDarkText ? "text-gray-900" : "text-white";
+  const percentageTextClass = hasDarkText ? "text-gray-900/80" : "text-white/80";
+  const progressBackground = hasDarkText ? "bg-gray-300/80" : "bg-white/30";
+  const progressFill = hasDarkText ? "bg-gray-700" : "bg-white";
+
   return (
-    <div className={`rounded-2xl shadow-md p-6 flex flex-col items-center gap-2 ${color}`}>
+    <div
+      className={`rounded-2xl shadow-md p-6 flex flex-col items-center gap-2 text-center ${color}`}
+    >
       <div className="flex items-center gap-2 text-3xl font-bold">
         {icon}
         <span>{value}</span>
       </div>
-      <div className="text-xs mt-1 text-white font-semibold uppercase tracking-wider">{title}</div>
+      <div
+        className={`text-xs mt-1 font-semibold uppercase tracking-wider ${labelTextClass}`}
+      >
+        {title}
+      </div>
+      {formattedPercentage && (
+        <div className="mt-1 flex flex-col items-center gap-1 w-full max-w-[180px]">
+          <span className={`text-[11px] font-medium ${percentageTextClass}`}>
+            {formattedPercentage}
+          </span>
+          <div className={`h-1.5 w-full rounded-full ${progressBackground}`}>
+            <div
+              className={`h-full rounded-full transition-all duration-300 ease-out ${progressFill}`}
+              style={{ width: `${clampedPercentage}%` }}
+              role="progressbar"
+              aria-valuenow={Math.round(Number(percentage) || 0)}
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-label={`${title} ${formattedPercentage}`}
+            />
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/cicero-dashboard/components/likes/instagram/SummaryItem.jsx
+++ b/cicero-dashboard/components/likes/instagram/SummaryItem.jsx
@@ -1,20 +1,55 @@
 "use client";
 
-export default function SummaryItem({ label, value, color = "gray", icon }) {
+export default function SummaryItem({
+  label,
+  value,
+  color = "gray",
+  icon,
+  percentage,
+}) {
   const colorMap = {
-    blue: "text-blue-700",
-    green: "text-green-600",
-    red: "text-red-500",
-    gray: "text-gray-700",
-    orange: "text-orange-500",
+    blue: { text: "text-blue-700", bar: "bg-blue-500" },
+    green: { text: "text-green-600", bar: "bg-green-500" },
+    red: { text: "text-red-500", bar: "bg-red-500" },
+    gray: { text: "text-gray-700", bar: "bg-gray-500" },
+    orange: { text: "text-orange-500", bar: "bg-orange-500" },
   };
+  const displayColor = colorMap[color] || colorMap.gray;
+  const formattedPercentage =
+    typeof percentage === "number" && !Number.isNaN(percentage)
+      ? `${percentage.toFixed(1).replace(".0", "")} %`
+      : null;
+  const progressWidth =
+    typeof percentage === "number"
+      ? `${Math.min(100, Math.max(0, percentage))}%`
+      : "0%";
   return (
     <div className="flex-1 flex flex-col items-center justify-center py-2">
       <div className="mb-1">{icon}</div>
-      <div className={`text-3xl md:text-4xl font-bold ${colorMap[color]}`}>{value}</div>
+      <div className={`text-3xl md:text-4xl font-bold ${displayColor.text}`}>
+        {value}
+      </div>
       <div className="text-xs md:text-sm font-semibold text-gray-500 mt-1 uppercase tracking-wide text-center">
         {label}
       </div>
+      {formattedPercentage && (
+        <div className="mt-1 flex flex-col items-center gap-1 w-full max-w-[160px]">
+          <span className="text-[11px] md:text-xs font-medium text-gray-600">
+            {formattedPercentage}
+          </span>
+          <div className="h-1.5 w-full rounded-full bg-gray-200">
+            <div
+              className={`h-full rounded-full transition-all duration-300 ease-out ${displayColor.bar}`}
+              style={{ width: progressWidth }}
+              role="progressbar"
+              aria-valuenow={Math.round(Number(percentage) || 0)}
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-label={`${label} ${formattedPercentage}`}
+            />
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- display percentage breakdowns for Instagram likes and TikTok comment summary cards on insight and rekap pages
- enhance shared summary components with optional progress indicators for visualizing proportions
- add helper calculations to ensure percentages use valid user totals and avoid divide-by-zero issues

## Testing
- npm run lint *(fails: prompts for ESLint configuration in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d35c1681748327a3884be9f3c2f07f