### PR TITLE
Revamp dashboard with futuristic analytics layout

### DIFF
--- a/cicero-dashboard/components/DashboardStats.jsx
+++ b/cicero-dashboard/components/DashboardStats.jsx
@@ -1,29 +1,99 @@
-import CardStat from "./CardStat";
+import { useMemo } from "react";
 
-export default function DashboardStats({ igProfile, igPosts, tiktokProfile, tiktokPosts }) {
-  const stats = [
-    {
-      title: "IG Followers",
-      value: igProfile?.follower_count ?? igProfile?.followers ?? 0,
-    },
-    {
-      title: "IG Posts",
-      value: igProfile?.post_count ?? igPosts?.length ?? 0,
-    },
-    {
-      title: "TikTok Followers",
-      value: tiktokProfile?.follower_count ?? tiktokProfile?.followers ?? 0,
-    },
-    {
-      title: "TikTok Posts",
-      value: tiktokProfile?.video_count ?? tiktokPosts?.length ?? 0,
-    },
-  ];
+const formatValue = (value) => {
+  if (typeof value === "number") {
+    const formatter = new Intl.NumberFormat("id-ID", {
+      notation: value >= 1000 ? "compact" : "standard",
+      maximumFractionDigits: value >= 1000 ? 1 : 0,
+    });
+    return formatter.format(value);
+  }
+  return value ?? "-";
+};
+
+const extractCount = (source, keys) => {
+  if (!source) return 0;
+  for (const key of keys) {
+    const segments = key.split(".");
+    let current = source;
+    for (const segment of segments) {
+      if (current == null) break;
+      current = current[segment];
+    }
+    if (current == null) continue;
+    if (typeof current === "number" && Number.isFinite(current)) {
+      return current;
+    }
+    if (typeof current === "string") {
+      const parsed = Number(current.replace(/[^0-9.-]+/g, ""));
+      if (!Number.isNaN(parsed)) {
+        return parsed;
+      }
+    }
+  }
+  return 0;
+};
+
+export default function DashboardStats({
+  highlights,
+  igProfile,
+  igPosts,
+  tiktokProfile,
+  tiktokPosts,
+}) {
+  const fallbackHighlights = useMemo(() => {
+    if (!igProfile && !tiktokProfile && !igPosts?.length && !tiktokPosts?.length) {
+      return [];
+    }
+    const igFollowers = extractCount(igProfile, [
+      "followers",
+      "follower_count",
+      "edge_followed_by.count",
+    ]);
+    const igPostsCount = igProfile?.post_count ?? igPosts?.length ?? 0;
+    const tiktokFollowers = extractCount(tiktokProfile, [
+      "followers",
+      "follower_count",
+      "stats.followerCount",
+    ]);
+    const tiktokPostsCount = tiktokProfile?.video_count ?? tiktokPosts?.length ?? 0;
+
+    return [
+      { key: "ig-followers", title: "IG Followers", value: igFollowers },
+      { key: "ig-posts", title: "IG Posts", value: igPostsCount },
+      { key: "tiktok-followers", title: "TikTok Followers", value: tiktokFollowers },
+      { key: "tiktok-posts", title: "TikTok Posts", value: tiktokPostsCount },
+    ];
+  }, [igProfile, igPosts, tiktokProfile, tiktokPosts]);
+
+  const cards = highlights?.length ? highlights : fallbackHighlights;
+
+  if (!cards.length) return null;
 
   return (
-    <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-      {stats.map((s) => (
-        <CardStat key={s.title} title={s.title} value={s.value} />
+    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+      {cards.map((item) => (
+        <div
+          key={item.key || item.title}
+          className="group relative overflow-hidden rounded-3xl border border-slate-800/70 bg-slate-900/60 p-5 shadow-[0_0_32px_rgba(14,165,233,0.15)] transition duration-300 hover:border-cyan-400/60 hover:shadow-[0_0_40px_rgba(34,211,238,0.35)]"
+        >
+          <div className="absolute -right-10 top-0 h-32 w-32 rounded-full bg-cyan-500/10 blur-3xl transition duration-300 group-hover:bg-cyan-400/20" />
+          <div className="absolute inset-x-6 top-8 h-16 rounded-full bg-gradient-to-b from-slate-100/10 to-transparent blur-2xl" />
+          <div className="relative space-y-3">
+            <div className="flex items-center gap-3">
+              <span className="text-xl">{item.icon ?? "◎"}</span>
+              <span className="text-xs uppercase tracking-[0.3em] text-slate-400">
+                {item.title}
+              </span>
+            </div>
+            <p className="text-3xl font-semibold text-slate-50">
+              {formatValue(item.value)}
+            </p>
+            {item.subtitle && (
+              <p className="text-xs text-slate-300">{item.subtitle}</p>
+            )}
+          </div>
+        </div>
       ))}
     </div>
   );

--- a/cicero-dashboard/components/SocialCardsClient.tsx
+++ b/cicero-dashboard/components/SocialCardsClient.tsx
@@ -1,68 +1,189 @@
 "use client";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import SocialProfileCard from "./SocialProfileCard";
 import SocialPostsCard from "./SocialPostsCard";
+
+type PlatformKey = "instagram" | "tiktok";
+
+type PlatformMetric = {
+  key: PlatformKey;
+  label?: string;
+  followers: number;
+  following?: number;
+  likes: number;
+  comments: number;
+  views: number;
+  posts: number;
+  engagementRate: number;
+  shares?: {
+    followers: number;
+    likes: number;
+    comments: number;
+  };
+};
 
 interface Props {
   igProfile: any;
   igPosts: any[];
   tiktokProfile: any;
   tiktokPosts: any[];
+  platformMetrics?: Record<string, PlatformMetric>;
 }
+
+const formatNumber = (value?: number) => {
+  if (!value || Number.isNaN(value)) return "0";
+  const formatter = new Intl.NumberFormat("id-ID", {
+    notation: value >= 1000 ? "compact" : "standard",
+    maximumFractionDigits: value >= 1000 ? 1 : 0,
+  });
+  return formatter.format(value);
+};
 
 export default function SocialCardsClient({
   igProfile,
   igPosts,
   tiktokProfile,
   tiktokPosts,
+  platformMetrics,
 }: Props) {
-  const [platform, setPlatform] = useState<"all" | "instagram" | "tiktok">(
-    "all"
+  const [platform, setPlatform] = useState<"all" | PlatformKey>("all");
+
+  const metrics = useMemo(() => {
+    const selectedPlatforms: PlatformKey[] =
+      platform === "all" ? ["instagram", "tiktok"] : [platform as PlatformKey];
+
+    return selectedPlatforms.map((key) => ({
+      key,
+      metric: platformMetrics?.[key],
+    }));
+  }, [platform, platformMetrics]);
+
+  const renderPlatform = (key: PlatformKey) => (
+    <div key={key} className="space-y-6">
+      <SocialProfileCard
+        platform={key}
+        profile={key === "instagram" ? igProfile : tiktokProfile}
+        postCount={key === "instagram" ? igPosts.length : tiktokPosts.length}
+      />
+      <SocialPostsCard
+        platform={key}
+        posts={key === "instagram" ? igPosts : tiktokPosts}
+      />
+    </div>
   );
 
   const buttons = [
-    { key: "all", label: "Semua" },
-    { key: "instagram", label: "Instagram" },
-    { key: "tiktok", label: "TikTok" },
-  ] as const;
+    { key: "all" as const, label: "Semua" },
+    { key: "instagram" as const, label: "Instagram" },
+    { key: "tiktok" as const, label: "TikTok" },
+  ];
 
   return (
-    <>
-      <div className="flex gap-2 mb-4">
-        {buttons.map((b) => (
-          <button
-            key={b.key}
-            className={`px-3 py-1 rounded ${
-              platform === b.key ? "bg-blue-500 text-white" : "bg-gray-200"
-            }`}
-            onClick={() => setPlatform(b.key)}
-          >
-            {b.label}
-          </button>
-        ))}
+    <div className="relative overflow-hidden rounded-3xl border border-slate-800/70 bg-slate-900/60 p-6 shadow-[0_0_36px_rgba(14,165,233,0.15)]">
+      <div className="absolute -left-16 top-20 h-48 w-48 rounded-full bg-violet-500/20 blur-3xl" />
+      <div className="absolute -right-12 bottom-0 h-44 w-44 rounded-full bg-cyan-500/20 blur-3xl" />
+      <div className="relative space-y-6">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <h3 className="text-xl font-semibold text-slate-50">Radar Interaksi</h3>
+            <p className="text-sm text-slate-300">
+              Bandingkan performa audiens, likes, dan komentar antar platform.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {buttons.map((b) => (
+              <button
+                key={b.key}
+                className={`relative overflow-hidden rounded-full border px-4 py-1.5 text-sm transition ${
+                  platform === b.key
+                    ? "border-cyan-400/60 bg-cyan-500/20 text-cyan-200 shadow-[0_0_20px_rgba(34,211,238,0.45)]"
+                    : "border-slate-700 bg-slate-900/60 text-slate-400 hover:text-slate-200"
+                }`}
+                onClick={() => setPlatform(b.key)}
+              >
+                <span className="relative z-10">{b.label}</span>
+                {platform === b.key && (
+                  <span className="absolute inset-0 rounded-full bg-gradient-to-r from-cyan-500/20 to-slate-900/0" />
+                )}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div
+          className={`grid gap-4 ${
+            metrics.length > 1 ? "md:grid-cols-2 xl:grid-cols-3" : "md:grid-cols-2 lg:max-w-lg"
+          }`}
+        >
+          {metrics.map(({ key, metric }) => (
+            <div
+              key={key}
+              className="relative overflow-hidden rounded-2xl border border-slate-800/70 bg-slate-900/70 p-5"
+            >
+              <div className="absolute -top-12 right-0 h-28 w-28 rounded-full bg-cyan-500/10 blur-3xl" />
+              <div className="relative space-y-3">
+                <div className="flex items-center justify-between">
+                  <span className="text-xs uppercase tracking-[0.3em] text-slate-400">
+                    {key}
+                  </span>
+                  <span className="text-xs text-slate-400">
+                    {metric?.posts ?? 0} posts
+                  </span>
+                </div>
+                <div className="grid grid-cols-3 gap-3 text-sm">
+                  <div>
+                    <p className="text-[0.65rem] uppercase tracking-wide text-slate-400">Likes</p>
+                    <p className="text-lg font-semibold text-cyan-300">
+                      {formatNumber(metric?.likes)}
+                    </p>
+                  </div>
+                  <div>
+                    <p className="text-[0.65rem] uppercase tracking-wide text-slate-400">Komentar</p>
+                    <p className="text-lg font-semibold text-emerald-300">
+                      {formatNumber(metric?.comments)}
+                    </p>
+                  </div>
+                  <div>
+                    <p className="text-[0.65rem] uppercase tracking-wide text-slate-400">Followers</p>
+                    <p className="text-lg font-semibold text-fuchsia-300">
+                      {formatNumber(metric?.followers)}
+                    </p>
+                  </div>
+                </div>
+                <div className="flex items-center justify-between text-xs text-slate-300">
+                  <span>Engagement</span>
+                  <span>{metric ? metric.engagementRate.toFixed(2) : "0.00"}%</span>
+                </div>
+                {metric?.shares && (
+                  <div className="grid grid-cols-3 gap-2 text-[0.65rem] text-slate-400">
+                    <span>Followers {metric.shares.followers.toFixed(1)}%</span>
+                    <span>Likes {metric.shares.likes.toFixed(1)}%</span>
+                    <span>Komentar {metric.shares.comments.toFixed(1)}%</span>
+                  </div>
+                )}
+                <div className="h-1.5 overflow-hidden rounded-full bg-slate-800">
+                  <div
+                    className="h-full rounded-full bg-gradient-to-r from-sky-500 via-cyan-400 to-emerald-300"
+                    style={{
+                      width: `${Math.min(metric ? metric.engagementRate : 0, 100)}%`,
+                    }}
+                  />
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div
+          className={`grid gap-6 ${
+            platform === "all"
+              ? "lg:grid-cols-2"
+              : "grid-cols-1"
+          }`}
+        >
+          {metrics.map(({ key }) => renderPlatform(key))}
+        </div>
       </div>
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        {(platform === "all" || platform === "instagram") && (
-          <>
-            <SocialProfileCard
-              platform="instagram"
-              profile={igProfile}
-              postCount={igPosts.length}
-            />
-            <SocialPostsCard platform="instagram" posts={igPosts} />
-          </>
-        )}
-        {(platform === "all" || platform === "tiktok") && (
-          <>
-            <SocialProfileCard
-              platform="tiktok"
-              profile={tiktokProfile}
-              postCount={tiktokPosts.length}
-            />
-            <SocialPostsCard platform="tiktok" posts={tiktokPosts} />
-          </>
-        )}
-      </div>
-    </>
+    </div>
   );
 }

--- a/cicero-dashboard/components/SocialPostsCard.tsx
+++ b/cicero-dashboard/components/SocialPostsCard.tsx
@@ -11,20 +11,33 @@ export default function SocialPostsCard({
   platform,
   posts,
 }: SocialPostsCardProps) {
+  const platformLabel = platform === "instagram" ? "Instagram" : "TikTok";
+
   return (
-    <div className="bg-white rounded-xl shadow p-4 flex flex-col">
-      <h2 className="font-semibold capitalize mb-2">{platform} Posts</h2>
-      {posts && posts.length > 0 ? (
-        <div>
-          {platform === "instagram" ? (
-            <InstagramPostsGrid posts={posts.slice(0, 3)} />
-          ) : (
-            <TiktokPostsGrid posts={posts.slice(0, 3)} />
-          )}
+    <div className="relative overflow-hidden rounded-3xl border border-slate-800/70 bg-slate-900/60 p-6 shadow-[0_0_32px_rgba(59,130,246,0.15)]">
+      <div className="absolute inset-0 bg-gradient-to-br from-slate-800/40 via-transparent to-slate-900/40" />
+      <div className="absolute -right-20 top-12 h-40 w-40 rounded-full bg-cyan-500/20 blur-3xl" />
+      <div className="relative space-y-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-slate-50">{platformLabel} Posts</h2>
+          <span className="text-xs uppercase tracking-[0.3em] text-slate-400">
+            Highlights
+          </span>
         </div>
-      ) : (
-        <div className="text-sm text-gray-500">No posts available</div>
-      )}
+        {posts && posts.length > 0 ? (
+          <div className="rounded-2xl border border-slate-800/60 bg-slate-900/80 p-4">
+            {platform === "instagram" ? (
+              <InstagramPostsGrid posts={posts.slice(0, 3)} />
+            ) : (
+              <TiktokPostsGrid posts={posts.slice(0, 3)} />
+            )}
+          </div>
+        ) : (
+          <div className="rounded-2xl border border-dashed border-slate-700/60 bg-slate-900/60 p-6 text-center text-sm text-slate-300">
+            Belum ada posting untuk ditampilkan.
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/cicero-dashboard/components/SocialProfileCard.tsx
+++ b/cicero-dashboard/components/SocialProfileCard.tsx
@@ -1,11 +1,22 @@
 "use client";
 import { useState } from "react";
 
+type PlatformKey = "instagram" | "tiktok" | string;
+
 interface SocialProfileCardProps {
-  platform: string;
+  platform: PlatformKey;
   profile: any;
   postCount?: number;
 }
+
+const formatNumber = (value?: number) => {
+  if (!value || Number.isNaN(value)) return "0";
+  const formatter = new Intl.NumberFormat("id-ID", {
+    notation: value >= 1000 ? "compact" : "standard",
+    maximumFractionDigits: value >= 1000 ? 1 : 0,
+  });
+  return formatter.format(value);
+};
 
 export default function SocialProfileCard({
   platform,
@@ -19,10 +30,23 @@ export default function SocialProfileCard({
     return url.replace(/\.heic(\?|$)/, ".jpg$1");
   };
 
+  const platformLabel =
+    platform === "instagram" ? "Instagram" : platform === "tiktok" ? "TikTok" : platform;
+  const platformGradient =
+    platform === "instagram"
+      ? "from-pink-500/40 via-purple-500/40 to-sky-500/40"
+      : "from-emerald-500/40 via-cyan-500/40 to-blue-500/40";
+
   if (!profile) {
     return (
-      <div className="bg-white rounded-xl shadow p-4 flex items-center justify-center">
-        <h2 className="font-semibold capitalize">{platform} Profile</h2>
+      <div className="relative overflow-hidden rounded-3xl border border-slate-800/70 bg-slate-900/60 p-6 text-center text-sm text-slate-300">
+        <div className="absolute inset-0 bg-gradient-to-br from-slate-800/40 to-transparent" />
+        <div className="relative space-y-2">
+          <span className="inline-flex items-center gap-2 rounded-full border border-slate-700/60 bg-slate-900/70 px-3 py-1 text-xs uppercase tracking-[0.3em] text-slate-300">
+            {platformLabel} Profile
+          </span>
+          <p>Data profil belum tersedia.</p>
+        </div>
       </div>
     );
   }
@@ -45,54 +69,85 @@ export default function SocialProfileCard({
   const followers = profile.followers ?? profile.follower_count ?? 0;
   const following = profile.following ?? profile.following_count ?? 0;
   const bio = profile.bio ?? profile.biography;
-  const name = profile.full_name ?? profile.nickname;
+  const name = profile.full_name ?? profile.nickname ?? profile.name;
+
+  const badges = [
+    { label: "Followers", value: formatNumber(followers) },
+    { label: "Following", value: formatNumber(following) },
+    { label: "Posts", value: formatNumber(postCount) },
+  ];
 
   return (
-    <div className="bg-white rounded-xl shadow p-4 flex flex-col">
-      <h2 className="font-semibold capitalize mb-2">{platform} Profile</h2>
-      <div className="flex items-center gap-3 flex-wrap">
-        {avatarSrc && (
-          <img
-            src={avatarSrc}
-            alt="avatar"
-            loading="lazy"
-            className="w-12 h-12 rounded-full object-cover"
-            onError={(e) => {
-              e.currentTarget.style.display = "none";
-            }}
-          />
-        )}
-        <div className="flex flex-col">
-          {name && <span className="font-semibold">{name}</span>}
-          <a
-            href={link}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-blue-600 hover:underline"
-          >
-            @{profile.username}
-          </a>
-        </div>
-        <span
-          className="text-sm text-gray-500 relative"
-          onMouseEnter={() => setShowTooltip(true)}
-          onMouseLeave={() => setShowTooltip(false)}
-        >
-          {followers} followers
-          {showTooltip && (
-            <span className="absolute left-0 top-full mt-1 w-max bg-black text-white text-xs rounded px-2 py-1">
-              Total pengikut akun
+    <div className="relative overflow-hidden rounded-3xl border border-slate-800/70 bg-slate-900/60 p-6 shadow-[0_0_32px_rgba(79,70,229,0.2)]">
+      <div className={`absolute inset-0 bg-gradient-to-br ${platformGradient} opacity-40`} />
+      <div className="absolute -right-16 top-10 h-32 w-32 rounded-full bg-white/5 blur-3xl" />
+      <div className="relative space-y-5">
+        <div className="flex flex-wrap items-center gap-4">
+          <div className="relative">
+            {avatarSrc ? (
+              <img
+                src={avatarSrc}
+                alt="avatar"
+                loading="lazy"
+                className="h-16 w-16 rounded-full border border-white/20 object-cover shadow-[0_0_20px_rgba(255,255,255,0.15)]"
+                onError={(e) => {
+                  e.currentTarget.style.display = "none";
+                }}
+              />
+            ) : (
+              <div className="flex h-16 w-16 items-center justify-center rounded-full border border-slate-700 bg-slate-900 text-lg text-slate-400">
+                {platformLabel[0] ?? "?"}
+              </div>
+            )}
+            <span className="absolute -bottom-1 -right-1 inline-flex items-center rounded-full bg-slate-900/90 px-2 py-0.5 text-[0.6rem] uppercase tracking-[0.3em] text-slate-300">
+              {platformLabel}
             </span>
-          )}
-        </span>
-        <span className="text-sm text-gray-500">{following} following</span>
-        <span className="text-sm text-gray-500">{postCount} posts</span>
-      </div>
-      {bio && (
-        <div className="text-sm text-gray-500 whitespace-pre-line mt-2">
-          {bio}
+          </div>
+          <div className="flex flex-col">
+            {name && <span className="text-lg font-semibold text-slate-50">{name}</span>}
+            <a
+              href={link}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-sm text-cyan-300 hover:text-cyan-200"
+            >
+              @{profile.username}
+            </a>
+            <div className="flex items-center gap-2 text-xs text-slate-300">
+              <span
+                className="relative"
+                onMouseEnter={() => setShowTooltip(true)}
+                onMouseLeave={() => setShowTooltip(false)}
+              >
+                {formatNumber(followers)} followers
+                {showTooltip && (
+                  <span className="absolute left-0 top-full mt-1 w-max rounded-md bg-slate-900/95 px-3 py-1 text-[0.65rem] text-slate-200 shadow-lg">
+                    Total pengikut akun
+                  </span>
+                )}
+              </span>
+              <span className="text-slate-500">•</span>
+              <span>{formatNumber(following)} following</span>
+            </div>
+          </div>
         </div>
-      )}
+        <div className="flex flex-wrap gap-2">
+          {badges.map((badge) => (
+            <span
+              key={badge.label}
+              className="inline-flex items-center gap-2 rounded-full border border-slate-700/60 bg-slate-900/70 px-3 py-1 text-xs text-slate-200"
+            >
+              <span className="text-slate-400">{badge.label}</span>
+              <span className="font-semibold text-slate-100">{badge.value}</span>
+            </span>
+          ))}
+        </div>
+        {bio && (
+          <div className="text-sm text-slate-200 whitespace-pre-line">
+            {bio}
+          </div>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- overhaul the /dashboard page with immersive hero, futuristic styling, and aggregated analytics for Instagram and TikTok
- compute platform metrics (followers, likes, comments, engagement, top posts) and feed them into redesigned stat, breakdown, and content highlight sections
- refresh social profile/posts cards with neon-inspired layouts, metric chips, and platform sharing insights

## Testing
- CI=1 npm run lint *(fails: command prompts for ESLint configuration and cannot run non-interactively)*

------
https://chatgpt.com/codex/tasks/task_e_68d36c754d6c8327840990d2015eab37