### PR TITLE
Fix DashboardStats props usage

### DIFF
--- a/cicero-dashboard/app/dashboard/page.tsx
+++ b/cicero-dashboard/app/dashboard/page.tsx
@@ -481,7 +481,13 @@ export default function DashboardPage() {
         </section>
 
         <section className="space-y-6">
-          <DashboardStats highlights={highlightCards} />
+          <DashboardStats
+            highlights={highlightCards}
+            igProfile={igProfile}
+            igPosts={igPosts}
+            tiktokProfile={tiktokProfile}
+            tiktokPosts={tiktokPosts}
+          />
           <div className="grid gap-6 lg:grid-cols-2 xl:grid-cols-4">
             {analytics.platforms.map((platform) => (
               <div


### PR DESCRIPTION
## Summary
- pass Instagram and TikTok data props when rendering DashboardStats so the component receives the full dataset it expects

## Testing
- npm run build *(fails: Next.js build cannot download required Geist fonts in the sandboxed environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d36f76dabc8327b98d168035b96a78