### PR TITLE
Update dashboard hero heading text

### DIFF
--- a/cicero-dashboard/app/dashboard/page.tsx
+++ b/cicero-dashboard/app/dashboard/page.tsx
@@ -422,7 +422,7 @@ export default function DashboardPage() {
               Command Center
             </span>
             <h1 className="text-3xl font-semibold leading-tight text-slate-50 md:text-4xl">
-              Panorama Interaksi Sosial yang Futuristik & Real-time
+              Ikhtisar Data Keterlibatan Audiens Instagram & TikTok secara Real-time
             </h1>
             <p className="max-w-2xl text-base text-slate-300 md:text-lg">
               Pantau detik demi detik perkembangan audiens, reaksi komunitas, dan percakapan yang


### PR DESCRIPTION
## Summary
- replace the dashboard hero heading to emphasize the real-time Instagram and TikTok engagement data shown on the page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d374578d088327a9a1bda9842f0fa9