### PR TITLE
Refine Detak Interaksi layout on dashboard

### DIFF
--- a/cicero-dashboard/components/SocialCardsClient.tsx
+++ b/cicero-dashboard/components/SocialCardsClient.tsx
@@ -58,14 +58,29 @@ export default function SocialCardsClient({
     }));
   }, [platform, platformMetrics]);
 
+  const metricsWrapperClasses = ["grid grid-cols-1 gap-4", "auto-rows-fr"];
+
+  if (metrics.length === 1) {
+    metricsWrapperClasses.push("mx-auto", "max-w-md", "sm:max-w-xl");
+  } else if (metrics.length === 2) {
+    metricsWrapperClasses.push("sm:grid-cols-2", "xl:grid-cols-2");
+  } else {
+    metricsWrapperClasses.push("sm:grid-cols-2", "xl:grid-cols-3");
+  }
+
   const renderPlatform = (key: PlatformKey) => (
-    <div key={key} className="space-y-6">
+    <div
+      key={key}
+      className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,1fr)]"
+    >
       <SocialProfileCard
+        className="h-full"
         platform={key}
         profile={key === "instagram" ? igProfile : tiktokProfile}
         postCount={key === "instagram" ? igPosts.length : tiktokPosts.length}
       />
       <SocialPostsCard
+        className="h-full"
         platform={key}
         posts={key === "instagram" ? igPosts : tiktokPosts}
       />
@@ -110,18 +125,14 @@ export default function SocialCardsClient({
           </div>
         </div>
 
-        <div
-          className={`grid gap-4 ${
-            metrics.length > 1 ? "md:grid-cols-2 xl:grid-cols-3" : "md:grid-cols-2 lg:max-w-lg"
-          }`}
-        >
+        <div className={metricsWrapperClasses.join(" ")}>
           {metrics.map(({ key, metric }) => (
             <div
               key={key}
-              className="relative overflow-hidden rounded-2xl border border-slate-800/70 bg-slate-900/70 p-5"
+              className="relative flex h-full flex-col overflow-hidden rounded-2xl border border-slate-800/70 bg-slate-900/70 p-5"
             >
               <div className="absolute -top-12 right-0 h-28 w-28 rounded-full bg-cyan-500/10 blur-3xl" />
-              <div className="relative space-y-3">
+              <div className="relative flex flex-1 flex-col gap-4">
                 <div className="flex items-center justify-between">
                   <span className="text-xs uppercase tracking-[0.3em] text-slate-400">
                     {key}
@@ -155,13 +166,19 @@ export default function SocialCardsClient({
                   <span>{metric ? metric.engagementRate.toFixed(2) : "0.00"}%</span>
                 </div>
                 {metric?.shares && (
-                  <div className="grid grid-cols-3 gap-2 text-[0.65rem] text-slate-400">
-                    <span>Followers {metric.shares.followers.toFixed(1)}%</span>
-                    <span>Likes {metric.shares.likes.toFixed(1)}%</span>
-                    <span>Komentar {metric.shares.comments.toFixed(1)}%</span>
+                  <div className="flex flex-wrap gap-2 text-[0.65rem] text-slate-400">
+                    <span className="rounded-full bg-slate-800/60 px-2 py-1">
+                      Followers {metric.shares.followers.toFixed(1)}%
+                    </span>
+                    <span className="rounded-full bg-slate-800/60 px-2 py-1">
+                      Likes {metric.shares.likes.toFixed(1)}%
+                    </span>
+                    <span className="rounded-full bg-slate-800/60 px-2 py-1">
+                      Komentar {metric.shares.comments.toFixed(1)}%
+                    </span>
                   </div>
                 )}
-                <div className="h-1.5 overflow-hidden rounded-full bg-slate-800">
+                <div className="mt-auto h-1.5 overflow-hidden rounded-full bg-slate-800">
                   <div
                     className="h-full rounded-full bg-gradient-to-r from-sky-500 via-cyan-400 to-emerald-300"
                     style={{
@@ -176,9 +193,7 @@ export default function SocialCardsClient({
 
         <div
           className={`grid gap-6 ${
-            platform === "all"
-              ? "lg:grid-cols-2"
-              : "grid-cols-1"
+            platform === "all" ? "lg:grid-cols-2" : "grid-cols-1"
           }`}
         >
           {metrics.map(({ key }) => renderPlatform(key))}

--- a/cicero-dashboard/components/SocialPostsCard.tsx
+++ b/cicero-dashboard/components/SocialPostsCard.tsx
@@ -5,19 +5,25 @@ import TiktokPostsGrid from "./TiktokPostsGrid";
 interface SocialPostsCardProps {
   platform: string;
   posts: any[];
+  className?: string;
 }
 
 export default function SocialPostsCard({
   platform,
   posts,
+  className,
 }: SocialPostsCardProps) {
   const platformLabel = platform === "instagram" ? "Instagram" : "TikTok";
 
   return (
-    <div className="relative overflow-hidden rounded-3xl border border-slate-800/70 bg-slate-900/60 p-6 shadow-[0_0_32px_rgba(59,130,246,0.15)]">
+    <div
+      className={`relative flex h-full flex-col overflow-hidden rounded-3xl border border-slate-800/70 bg-slate-900/60 p-6 shadow-[0_0_32px_rgba(59,130,246,0.15)]${
+        className ? ` ${className}` : ""
+      }`}
+    >
       <div className="absolute inset-0 bg-gradient-to-br from-slate-800/40 via-transparent to-slate-900/40" />
       <div className="absolute -right-20 top-12 h-40 w-40 rounded-full bg-cyan-500/20 blur-3xl" />
-      <div className="relative space-y-4">
+      <div className="relative flex flex-1 flex-col gap-4">
         <div className="flex items-center justify-between">
           <h2 className="text-lg font-semibold text-slate-50">{platformLabel} Posts</h2>
           <span className="text-xs uppercase tracking-[0.3em] text-slate-400">

--- a/cicero-dashboard/components/SocialProfileCard.tsx
+++ b/cicero-dashboard/components/SocialProfileCard.tsx
@@ -7,6 +7,7 @@ interface SocialProfileCardProps {
   platform: PlatformKey;
   profile: any;
   postCount?: number;
+  className?: string;
 }
 
 const formatNumber = (value?: number) => {
@@ -22,6 +23,7 @@ export default function SocialProfileCard({
   platform,
   profile,
   postCount = 0,
+  className,
 }: SocialProfileCardProps) {
   const [showTooltip, setShowTooltip] = useState(false);
 
@@ -38,8 +40,11 @@ export default function SocialProfileCard({
       : "from-emerald-500/40 via-cyan-500/40 to-blue-500/40";
 
   if (!profile) {
+    const emptyStateClassName =
+      "relative overflow-hidden rounded-3xl border border-slate-800/70 bg-slate-900/60 p-6 text-center text-sm text-slate-300";
+
     return (
-      <div className="relative overflow-hidden rounded-3xl border border-slate-800/70 bg-slate-900/60 p-6 text-center text-sm text-slate-300">
+      <div className={`${emptyStateClassName}${className ? ` ${className}` : ""}`}>
         <div className="absolute inset-0 bg-gradient-to-br from-slate-800/40 to-transparent" />
         <div className="relative space-y-2">
           <span className="inline-flex items-center gap-2 rounded-full border border-slate-700/60 bg-slate-900/70 px-3 py-1 text-xs uppercase tracking-[0.3em] text-slate-300">
@@ -77,11 +82,14 @@ export default function SocialProfileCard({
     { label: "Posts", value: formatNumber(postCount) },
   ];
 
+  const baseClassName =
+    "relative flex h-full flex-col overflow-hidden rounded-3xl border border-slate-800/70 bg-slate-900/60 p-6 shadow-[0_0_32px_rgba(79,70,229,0.2)]";
+
   return (
-    <div className="relative overflow-hidden rounded-3xl border border-slate-800/70 bg-slate-900/60 p-6 shadow-[0_0_32px_rgba(79,70,229,0.2)]">
+    <div className={`${baseClassName}${className ? ` ${className}` : ""}`}>
       <div className={`absolute inset-0 bg-gradient-to-br ${platformGradient} opacity-40`} />
       <div className="absolute -right-16 top-10 h-32 w-32 rounded-full bg-white/5 blur-3xl" />
-      <div className="relative space-y-5">
+      <div className="relative flex flex-1 flex-col gap-5">
         <div className="flex flex-wrap items-center gap-4">
           <div className="relative">
             {avatarSrc ? (


### PR DESCRIPTION
## Summary
- balance the Detak Interaksi metrics grid with dynamic columns and compact share chips
- allow social profile and posts cards to stretch via optional className props and flex layouts
- render platform-specific cards in a responsive two-column grid to minimize empty space

## Testing
- npm run lint *(fails: prompts for ESLint configuration setup)*

------
https://chatgpt.com/codex/tasks/task_e_68d3aeaae8848327bf664f82adbd8866