### PR TITLE
Refine dashboard snapshot and platform cards layout

### DIFF
--- a/cicero-dashboard/app/dashboard/page.tsx
+++ b/cicero-dashboard/app/dashboard/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import DashboardStats from "@/components/DashboardStats";
 import SocialCardsClient from "@/components/SocialCardsClient";
 import useAuth from "@/hooks/useAuth";
+import { cn } from "@/lib/utils";
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "";
 
@@ -407,6 +408,40 @@ export default function DashboardPage() {
     ];
   }, [analytics]);
 
+  const snapshotMetrics = useMemo(
+    () => [
+      {
+        key: "views",
+        label: "Total Views",
+        value: formatCompactNumber(analytics.totals.views),
+        accent: "text-cyan-300",
+        helper: "Akumulasi views lintas platform",
+      },
+      {
+        key: "posts",
+        label: "Total Konten",
+        value: analytics.totals.posts,
+        accent: "text-emerald-300",
+        helper: "Konten dianalisis hari ini",
+      },
+      {
+        key: "followers",
+        label: "Followers Aktif",
+        value: formatCompactNumber(analytics.totals.followers),
+        accent: "text-fuchsia-300",
+        helper: "Audiens siap terlibat",
+      },
+      {
+        key: "engagement",
+        label: "Engagement Rate",
+        value: `${analytics.totals.engagementRate.toFixed(2)}%`,
+        accent: "text-amber-300",
+        helper: "Rasio interaksi terkini",
+      },
+    ],
+    [analytics]
+  );
+
   return (
     <div className="relative min-h-screen overflow-hidden bg-slate-950 text-slate-100">
       <div className="pointer-events-none absolute inset-0 overflow-hidden">
@@ -442,7 +477,7 @@ export default function DashboardPage() {
           <div className="space-y-6">
             <div className="relative overflow-hidden rounded-3xl border border-slate-700/60 bg-gradient-to-br from-slate-900/60 via-slate-900/40 to-slate-900/10 p-6 shadow-[0_0_2rem_rgba(56,189,248,0.25)]">
               <div className="absolute inset-x-10 top-4 h-24 rounded-full bg-gradient-to-b from-cyan-400/30 via-transparent to-transparent blur-2xl" />
-              <div className="relative space-y-5">
+              <div className="relative flex flex-col gap-6">
                 <h2 className="text-lg font-semibold text-slate-100">Snapshot Hari Ini</h2>
                 <p className="text-sm text-slate-300">
                   {analytics.totals.posts > 0
@@ -451,31 +486,19 @@ export default function DashboardPage() {
                       )} views per konten.`
                     : "Menunggu konten terbaru untuk dianalisis."}
                 </p>
-                <div className="grid grid-cols-2 gap-4 text-sm text-slate-200">
-                  <div>
-                    <span className="text-xs uppercase tracking-wide text-slate-400">Total Views</span>
-                    <p className="text-xl font-semibold text-cyan-300">
-                      {formatCompactNumber(analytics.totals.views)}
-                    </p>
-                  </div>
-                  <div>
-                    <span className="text-xs uppercase tracking-wide text-slate-400">Total Konten</span>
-                    <p className="text-xl font-semibold text-emerald-300">
-                      {analytics.totals.posts}
-                    </p>
-                  </div>
-                  <div>
-                    <span className="text-xs uppercase tracking-wide text-slate-400">Followers Aktif</span>
-                    <p className="text-xl font-semibold text-fuchsia-300">
-                      {formatCompactNumber(analytics.totals.followers)}
-                    </p>
-                  </div>
-                  <div>
-                    <span className="text-xs uppercase tracking-wide text-slate-400">Engagement Rate</span>
-                    <p className="text-xl font-semibold text-amber-300">
-                      {analytics.totals.engagementRate.toFixed(2)}%
-                    </p>
-                  </div>
+                <div className="grid gap-4 text-sm text-slate-200 sm:grid-cols-2 xl:grid-cols-4">
+                  {snapshotMetrics.map((metric) => (
+                    <div
+                      key={metric.key}
+                      className="group flex flex-col gap-2 rounded-2xl border border-slate-800/60 bg-slate-900/60 p-4 shadow-[0_0_1.5rem_rgba(56,189,248,0.12)] transition duration-200 hover:-translate-y-1 hover:border-cyan-400/40 hover:shadow-[0_0_2.5rem_rgba(56,189,248,0.25)]"
+                    >
+                      <span className="text-xs font-medium uppercase tracking-[0.2em] text-slate-400">
+                        {metric.label}
+                      </span>
+                      <p className={cn("text-2xl font-semibold", metric.accent)}>{metric.value}</p>
+                      <span className="text-xs text-slate-400">{metric.helper}</span>
+                    </div>
+                  ))}
                 </div>
               </div>
             </div>
@@ -499,84 +522,106 @@ export default function DashboardPage() {
             </p>
           </div>
           <div className="grid gap-6 lg:grid-cols-2 xl:grid-cols-4">
-            {analytics.platforms.map((platform) => (
-              <div
-                key={platform.key}
-                className="relative overflow-hidden rounded-3xl border border-slate-800/70 bg-slate-900/50 p-6 shadow-[0_0_30px_rgba(79,70,229,0.25)]"
-              >
-                <div className="absolute -top-12 right-4 h-32 w-32 rounded-full bg-gradient-to-br from-cyan-400/40 via-transparent to-transparent blur-2xl" />
-                <div className="relative space-y-4">
-                  <div className="flex items-center justify-between">
-                    <div>
-                      <p className="text-xs uppercase tracking-[0.25em] text-slate-400">Platform</p>
-                      <h3 className="text-xl font-semibold text-slate-50">{platform.label}</h3>
-                    </div>
-                    <div className="flex flex-col text-right text-xs text-slate-400">
-                      <span>Followers: {formatCompactNumber(platform.followers)}</span>
-                      <span>Posts: {platform.posts}</span>
-                    </div>
-                  </div>
-                  <div className="grid grid-cols-3 gap-3 text-sm text-slate-200">
-                    <div>
-                      <p className="text-xs uppercase tracking-wide text-slate-400">Likes</p>
-                      <p className="text-lg font-semibold text-cyan-300">
-                        {formatCompactNumber(platform.likes)}
-                      </p>
-                    </div>
-                    <div>
-                      <p className="text-xs uppercase tracking-wide text-slate-400">Komentar</p>
-                      <p className="text-lg font-semibold text-emerald-300">
-                        {formatCompactNumber(platform.comments)}
-                      </p>
-                    </div>
-                    <div>
-                      <p className="text-xs uppercase tracking-wide text-slate-400">Engagement</p>
-                      <p className="text-lg font-semibold text-fuchsia-300">
-                        {platform.engagementRate.toFixed(2)}%
-                      </p>
-                    </div>
-                  </div>
-                  <div className="space-y-3 text-xs text-slate-400">
-                    <div>
-                      <div className="mb-1 flex justify-between">
-                        <span>Share Followers</span>
-                        <span>{platform.shares.followers.toFixed(1)}%</span>
+            {analytics.platforms.map((platform) => {
+              const primaryMetrics = [
+                {
+                  key: "likes",
+                  label: "Likes",
+                  value: formatCompactNumber(platform.likes),
+                  accent: "text-cyan-300",
+                },
+                {
+                  key: "comments",
+                  label: "Komentar",
+                  value: formatCompactNumber(platform.comments),
+                  accent: "text-emerald-300",
+                },
+                {
+                  key: "engagement",
+                  label: "Engagement",
+                  value: `${platform.engagementRate.toFixed(2)}%`,
+                  accent: "text-fuchsia-300",
+                },
+              ];
+
+              const shareMetrics = [
+                {
+                  key: "followers",
+                  label: "Share Followers",
+                  value: platform.shares.followers,
+                  gradient: "from-violet-500 via-fuchsia-400 to-cyan-300",
+                },
+                {
+                  key: "likes",
+                  label: "Share Likes",
+                  value: platform.shares.likes,
+                  gradient: "from-sky-500 via-cyan-400 to-emerald-300",
+                },
+                {
+                  key: "comments",
+                  label: "Share Komentar",
+                  value: platform.shares.comments,
+                  gradient: "from-amber-400 via-orange-400 to-rose-400",
+                },
+              ];
+
+              return (
+                <div
+                  key={platform.key}
+                  className="group relative flex h-full flex-col overflow-hidden rounded-3xl border border-slate-800/70 bg-slate-900/50 p-6 shadow-[0_0_30px_rgba(79,70,229,0.25)] transition duration-200 hover:-translate-y-1 hover:border-cyan-400/40 hover:shadow-[0_0_45px_rgba(34,211,238,0.22)]"
+                >
+                  <div className="absolute -top-12 right-4 h-32 w-32 rounded-full bg-gradient-to-br from-cyan-400/40 via-transparent to-transparent blur-2xl transition group-hover:from-cyan-400/60" />
+                  <div className="relative flex h-full flex-col gap-6">
+                    <div className="flex items-start justify-between gap-4">
+                      <div>
+                        <p className="text-xs font-medium uppercase tracking-[0.25em] text-slate-400">Platform</p>
+                        <h3 className="text-xl font-semibold text-slate-50">{platform.label}</h3>
                       </div>
-                      <div className="h-2 rounded-full bg-slate-800">
+                      <div className="flex flex-col items-end rounded-2xl border border-slate-800/60 bg-slate-900/60 px-3 py-2 text-xs text-slate-300">
+                        <span className="font-medium text-slate-200">Followers</span>
+                        <span>{formatCompactNumber(platform.followers)}</span>
+                        <span className="mt-1 text-slate-400">Posts: {platform.posts}</span>
+                      </div>
+                    </div>
+                    <div className="grid grid-cols-1 gap-3 text-sm text-slate-200 sm:grid-cols-3">
+                      {primaryMetrics.map((metric) => (
                         <div
-                          className="h-full rounded-full bg-gradient-to-r from-violet-500 via-fuchsia-400 to-cyan-300"
-                          style={{ width: `${Math.min(platform.shares.followers, 100)}%` }}
-                        />
-                      </div>
+                          key={metric.key}
+                          className="flex flex-col gap-2 rounded-2xl border border-slate-800/60 bg-slate-900/60 p-4"
+                        >
+                          <span className="text-xs font-medium uppercase tracking-wide text-slate-400">
+                            {metric.label}
+                          </span>
+                          <span className={cn("text-lg font-semibold", metric.accent)}>{metric.value}</span>
+                        </div>
+                      ))}
                     </div>
-                    <div>
-                      <div className="mb-1 flex justify-between">
-                        <span>Share Likes</span>
-                        <span>{platform.shares.likes.toFixed(1)}%</span>
-                      </div>
-                      <div className="h-2 rounded-full bg-slate-800">
+                    <div className="mt-auto space-y-3 text-xs text-slate-300">
+                      {shareMetrics.map((share) => (
                         <div
-                          className="h-full rounded-full bg-gradient-to-r from-sky-500 via-cyan-400 to-emerald-300"
-                          style={{ width: `${Math.min(platform.shares.likes, 100)}%` }}
-                        />
-                      </div>
-                    </div>
-                    <div>
-                      <div className="mb-1 flex justify-between">
-                        <span>Share Komentar</span>
-                        <span>{platform.shares.comments.toFixed(1)}%</span>
-                      </div>
-                      <div className="h-2 rounded-full bg-slate-800">
-                        <div
-                          className="h-full rounded-full bg-gradient-to-r from-amber-400 via-orange-400 to-rose-400"
-                          style={{ width: `${Math.min(platform.shares.comments, 100)}%` }}
-                        />
-                      </div>
+                          key={share.key}
+                          className="rounded-2xl border border-slate-800/60 bg-slate-900/60 p-3"
+                        >
+                          <div className="mb-2 flex justify-between text-[0.7rem] font-medium uppercase tracking-wider text-slate-400">
+                            <span>{share.label}</span>
+                            <span>{share.value.toFixed(1)}%</span>
+                          </div>
+                          <div className="h-2 rounded-full bg-slate-800">
+                            <div
+                              className={cn(
+                                "h-full rounded-full bg-gradient-to-r",
+                                share.gradient
+                              )}
+                              style={{ width: `${Math.min(share.value, 100)}%` }}
+                            />
+                          </div>
+                        </div>
+                      ))}
                     </div>
                   </div>
                 </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
         </section>
 


### PR DESCRIPTION
## Summary
- create dedicated metric cards for the snapshot section to deliver a more balanced grid and clearer hierarchy
- refresh the platform performance cards with consistent structure, hover feedback, and grouped share bars for a tidier presentation

## Testing
- not run (local lint command prompts for configuration)


------
https://chatgpt.com/codex/tasks/task_e_68d3b7aac6848327ad24e238def7ccf6