### PR TITLE
Reorganize dashboard hero and platform layout

### DIFF
--- a/cicero-dashboard/app/dashboard/page.tsx
+++ b/cicero-dashboard/app/dashboard/page.tsx
@@ -450,31 +450,31 @@ export default function DashboardPage() {
         <div className="absolute right-1/3 top-1/2 h-64 w-64 -translate-y-1/2 rounded-full bg-blue-500/10 blur-3xl" />
       </div>
       <div className="relative z-10 mx-auto flex w-full max-w-7xl flex-col gap-10 px-6 py-12">
-        <section className="grid gap-8 lg:grid-cols-[1.15fr,0.85fr] xl:grid-cols-[1.1fr,0.9fr] lg:items-start">
-          <div className="space-y-6">
-            <span className="inline-flex items-center gap-2 rounded-full border border-slate-700/60 bg-slate-900/70 px-4 py-1 text-xs uppercase tracking-[0.3em] text-slate-300">
-              <span className="h-2 w-2 rounded-full bg-emerald-400 shadow-[0_0_0.6rem_rgba(52,211,153,0.7)]" />
-              Command Center
-            </span>
-            <h1 className="text-3xl font-semibold leading-tight text-slate-50 md:text-4xl">
-              Ikhtisar Data Keterlibatan Audiens Instagram & TikTok secara Real-time
-            </h1>
-            <p className="max-w-2xl text-base text-slate-300 md:text-lg">
-              Pantau detik demi detik perkembangan audiens, reaksi komunitas, dan percakapan yang
-              terjadi di Instagram serta TikTok melalui satu kanvas visual yang imersif.
-            </p>
-            <div className="grid gap-3 text-sm text-slate-300 sm:grid-cols-2">
-              <div className="flex items-center gap-2 rounded-full border border-slate-700/60 bg-slate-900/60 px-3 py-1.5">
-                <span className="text-emerald-300">◎</span>
-                <span>Data terintegrasi lintas platform</span>
-              </div>
-              <div className="flex items-center gap-2 rounded-full border border-slate-700/60 bg-slate-900/60 px-3 py-1.5">
-                <span className="text-cyan-300">◎</span>
-                <span>Visual responsif & mudah dipahami</span>
+        <section className="grid gap-10 xl:grid-cols-[1.2fr,0.8fr] xl:items-start">
+          <div className="space-y-8">
+            <div className="space-y-6">
+              <span className="inline-flex items-center gap-2 rounded-full border border-slate-700/60 bg-slate-900/70 px-4 py-1 text-xs uppercase tracking-[0.3em] text-slate-300">
+                <span className="h-2 w-2 rounded-full bg-emerald-400 shadow-[0_0_0.6rem_rgba(52,211,153,0.7)]" />
+                Command Center
+              </span>
+              <h1 className="text-3xl font-semibold leading-tight text-slate-50 md:text-4xl">
+                Ikhtisar Data Keterlibatan Audiens Instagram & TikTok secara Real-time
+              </h1>
+              <p className="max-w-2xl text-base text-slate-300 md:text-lg">
+                Pantau detik demi detik perkembangan audiens, reaksi komunitas, dan percakapan yang
+                terjadi di Instagram serta TikTok melalui satu kanvas visual yang imersif.
+              </p>
+              <div className="grid gap-3 text-sm text-slate-300 sm:grid-cols-2">
+                <div className="flex items-center gap-2 rounded-full border border-slate-700/60 bg-slate-900/60 px-3 py-1.5">
+                  <span className="text-emerald-300">◎</span>
+                  <span>Data terintegrasi lintas platform</span>
+                </div>
+                <div className="flex items-center gap-2 rounded-full border border-slate-700/60 bg-slate-900/60 px-3 py-1.5">
+                  <span className="text-cyan-300">◎</span>
+                  <span>Visual responsif & mudah dipahami</span>
+                </div>
               </div>
             </div>
-          </div>
-          <div className="space-y-6">
             <div className="relative overflow-hidden rounded-3xl border border-slate-700/60 bg-gradient-to-br from-slate-900/60 via-slate-900/40 to-slate-900/10 p-6 shadow-[0_0_2rem_rgba(56,189,248,0.25)]">
               <div className="absolute inset-x-10 top-4 h-24 rounded-full bg-gradient-to-b from-cyan-400/30 via-transparent to-transparent blur-2xl" />
               <div className="relative flex flex-col gap-6">
@@ -502,6 +502,8 @@ export default function DashboardPage() {
                 </div>
               </div>
             </div>
+          </div>
+          <div className="flex flex-col justify-center gap-6">
             <DashboardStats
               highlights={highlightCards}
               igProfile={igProfile}
@@ -521,7 +523,7 @@ export default function DashboardPage() {
               Bandingkan performa inti tiap kanal untuk melihat kontribusi terhadap interaksi keseluruhan.
             </p>
           </div>
-          <div className="grid gap-6 lg:grid-cols-2 xl:grid-cols-4">
+          <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
             {analytics.platforms.map((platform) => {
               const primaryMetrics = [
                 {


### PR DESCRIPTION
## Summary
- move the Snapshot Hari Ini card below the hero overview and adjust the surrounding grid to balance spacing
- keep dashboard highlights in a dedicated column with refined vertical alignment
- refresh the Rincian Kinerja Platform grid breakpoints to better fill available space

## Testing
- npm run lint *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68d3ba95fc8c8327b1e4a10965ea8838