### PR TITLE
Refine Instagram likes pages with futuristic styling

### DIFF
--- a/cicero-dashboard/app/likes/instagram/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/page.jsx
@@ -3,7 +3,6 @@ import { useState } from "react";
 import Loader from "@/components/Loader";
 import ChartBox from "@/components/likes/instagram/ChartBox";
 import SummaryItem from "@/components/likes/instagram/SummaryItem";
-import Divider from "@/components/likes/instagram/Divider";
 import ChartHorizontal from "@/components/ChartHorizontal";
 import { groupUsersByKelompok } from "@/utils/grouping"; // pastikan path benar
 import Link from "next/link";
@@ -44,8 +43,8 @@ export default function InstagramEngagementInsightPage() {
   if (loading) return <Loader />;
   if (error)
     return (
-      <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100 p-4">
-        <div className="bg-white rounded-lg shadow-md p-6 text-center text-red-500 font-bold">
+      <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 p-6 text-slate-100">
+        <div className="rounded-3xl border border-red-500/40 bg-slate-900/70 px-8 py-6 text-center text-red-200 shadow-[0_0_35px_rgba(248,113,113,0.25)]">
           {error}
         </div>
       </div>
@@ -77,86 +76,103 @@ export default function InstagramEngagementInsightPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-100 flex flex-col">
-      <div className="flex-1 flex items-start justify-center">
-        <div className="w-full max-w-5xl px-2 md:px-8 py-8">
-          <div className="flex flex-col gap-8">
-            {/* Header */}
-            <h1 className="text-2xl md:text-3xl font-bold text-blue-700 mb-2">
-              Instagram Engagement Insight
-            </h1>
-
-            {/* Card Ringkasan */}
-            <div className="flex flex-col gap-3">
-              <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
-                <ViewDataSelector
-                  value={viewBy}
-                  onChange={setViewBy}
-                  options={viewOptions}
-                  date=
-                    {viewBy === "custom_range"
-                      ? { startDate: fromDate, endDate: toDate }
-                      : customDate}
-                  onDateChange={(val) => {
-                    if (viewBy === "custom_range") {
-                      setFromDate(val.startDate || "");
-                      setToDate(val.endDate || "");
-                    } else {
-                      setCustomDate(val);
+    <div className="relative min-h-screen overflow-hidden bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 text-slate-100">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.18),_transparent_60%)]" />
+      <div className="pointer-events-none absolute inset-y-0 right-0 w-1/2 bg-[radial-gradient(circle_at_center,_rgba(14,165,233,0.12),_transparent_70%)]" />
+      <div className="relative flex min-h-screen items-start justify-center">
+        <div className="w-full max-w-6xl px-4 py-12 md:px-10">
+          <div className="flex flex-col gap-10">
+            <div className="relative overflow-hidden rounded-3xl border border-slate-800/80 bg-slate-900/60 p-6 shadow-[0_0_48px_rgba(56,189,248,0.12)] backdrop-blur">
+              <div className="pointer-events-none absolute -top-10 left-8 h-32 w-32 rounded-full bg-sky-500/20 blur-3xl" />
+              <div className="pointer-events-none absolute -bottom-14 right-10 h-36 w-36 rounded-full bg-indigo-500/20 blur-3xl" />
+              <div className="relative flex flex-col gap-6">
+                <header className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                  <div>
+                    <h1 className="text-3xl font-semibold tracking-tight text-sky-100">
+                      Instagram Engagement Insight
+                    </h1>
+                    <p className="mt-1 max-w-2xl text-sm text-slate-300">
+                      Pantau performa likes harian secara futuristik dengan visualisasi
+                      yang selaras dengan dashboard utama.
+                    </p>
+                  </div>
+                </header>
+                <div className="rounded-2xl border border-white/10 bg-white/5 p-4 shadow-inner backdrop-blur">
+                  <ViewDataSelector
+                    value={viewBy}
+                    onChange={setViewBy}
+                    options={viewOptions}
+                    date=
+                      {viewBy === "custom_range"
+                        ? { startDate: fromDate, endDate: toDate }
+                        : customDate}
+                    onDateChange={(val) => {
+                      if (viewBy === "custom_range") {
+                        setFromDate(val.startDate || "");
+                        setToDate(val.endDate || "");
+                      } else {
+                        setCustomDate(val);
+                      }
+                    }}
+                  />
+                </div>
+                <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+                  <SummaryItem
+                    label="Jumlah IG Post"
+                    value={rekapSummary.totalIGPost}
+                    color="blue"
+                    icon={
+                      <Camera className="h-7 w-7 text-sky-300 drop-shadow-[0_0_12px_rgba(56,189,248,0.55)]" />
                     }
-                  }}
-                />
-              </div>
-
-              <div className="bg-gradient-to-tr from-blue-50 to-white rounded-2xl shadow flex flex-col md:flex-row items-stretch justify-between p-3 md:p-5 gap-2 md:gap-4 border">
-                <SummaryItem
-                  label="Jumlah IG Post"
-                  value={rekapSummary.totalIGPost}
-                  color="blue"
-                  icon={<Camera className="text-blue-400" />}
-                />
-                <Divider />
-                <SummaryItem
-                  label="Total User"
-                  value={rekapSummary.totalUser}
-                  color="gray"
-                  icon={<User className="text-gray-400" />}
-                />
-                <Divider />
-                <SummaryItem
-                  label="Sudah Likes"
-                  value={rekapSummary.totalSudahLike}
-                  color="green"
-                  icon={<ThumbsUp className="text-green-500" />}
-                  percentage={getPercentage(rekapSummary.totalSudahLike)}
-                />
-                <Divider />
-                <SummaryItem
-                  label="Kurang Likes"
-                  value={rekapSummary.totalKurangLike}
-                  color="orange"
-                  icon={<ThumbsDown className="text-orange-500" />}
-                  percentage={getPercentage(rekapSummary.totalKurangLike)}
-                />
-                <Divider />
-                <SummaryItem
-                  label="Belum Likes"
-                  value={rekapSummary.totalBelumLike}
-                  color="red"
-                  icon={<ThumbsDown className="text-red-500" />}
-                  percentage={getPercentage(rekapSummary.totalBelumLike)}
-                />
-                <Divider />
-                <SummaryItem
-                  label="Tanpa Username"
-                  value={rekapSummary.totalTanpaUsername}
-                  color="gray"
-                  icon={<UserX className="text-gray-400" />}
-                  percentage={getPercentage(
-                    rekapSummary.totalTanpaUsername,
-                    totalUser,
-                  )}
-                />
+                  />
+                  <SummaryItem
+                    label="Total User"
+                    value={rekapSummary.totalUser}
+                    color="gray"
+                    icon={
+                      <User className="h-7 w-7 text-slate-200 drop-shadow-[0_0_12px_rgba(148,163,184,0.45)]" />
+                    }
+                  />
+                  <SummaryItem
+                    label="Sudah Likes"
+                    value={rekapSummary.totalSudahLike}
+                    color="green"
+                    icon={
+                      <ThumbsUp className="h-7 w-7 text-emerald-300 drop-shadow-[0_0_12px_rgba(16,185,129,0.55)]" />
+                    }
+                    percentage={getPercentage(rekapSummary.totalSudahLike)}
+                  />
+                  <SummaryItem
+                    label="Kurang Likes"
+                    value={rekapSummary.totalKurangLike}
+                    color="orange"
+                    icon={
+                      <ThumbsDown className="h-7 w-7 text-amber-300 drop-shadow-[0_0_12px_rgba(251,191,36,0.55)]" />
+                    }
+                    percentage={getPercentage(rekapSummary.totalKurangLike)}
+                  />
+                  <SummaryItem
+                    label="Belum Likes"
+                    value={rekapSummary.totalBelumLike}
+                    color="red"
+                    icon={
+                      <ThumbsDown className="h-7 w-7 text-rose-300 drop-shadow-[0_0_12px_rgba(244,63,94,0.55)]" />
+                    }
+                    percentage={getPercentage(rekapSummary.totalBelumLike)}
+                  />
+                  <SummaryItem
+                    label="Tanpa Username"
+                    value={rekapSummary.totalTanpaUsername}
+                    color="gray"
+                    icon={
+                      <UserX className="h-7 w-7 text-slate-200 drop-shadow-[0_0_12px_rgba(148,163,184,0.45)]" />
+                    }
+                    percentage={getPercentage(
+                      rekapSummary.totalTanpaUsername,
+                      totalUser,
+                    )}
+                  />
+                </div>
               </div>
             </div>
 
@@ -214,19 +230,19 @@ export default function InstagramEngagementInsightPage() {
               </div>
             )}
 
-            <div className="flex justify-end gap-2 my-2">
+            <div className="flex justify-end gap-3">
               <button
                 onClick={handleCopyRekap}
-                className="bg-green-600 hover:bg-green-700 text-white font-bold px-6 py-3 rounded-xl shadow transition-all duration-150 text-lg flex items-center gap-2"
+                className="group inline-flex items-center gap-2 rounded-2xl border border-emerald-400/40 bg-emerald-500/20 px-6 py-3 text-lg font-semibold text-emerald-200 shadow-[0_0_25px_rgba(16,185,129,0.35)] transition-colors hover:border-emerald-300/60 hover:bg-emerald-400/30"
               >
-                <Copy className="w-5 h-5" />
+                <Copy className="h-5 w-5" />
                 Salin Rekap
               </button>
               <Link
                 href="/likes/instagram/rekap"
-                className="bg-blue-700 hover:bg-blue-800 text-white font-bold px-6 py-3 rounded-xl shadow transition-all duration-150 text-lg flex items-center gap-2"
+                className="inline-flex items-center gap-2 rounded-2xl border border-sky-400/40 bg-sky-500/20 px-6 py-3 text-lg font-semibold text-sky-200 shadow-[0_0_25px_rgba(56,189,248,0.35)] transition-colors hover:border-sky-300/60 hover:bg-sky-400/30"
               >
-                <ArrowRight className="w-5 h-5 inline" />
+                <ArrowRight className="h-5 w-5" />
                 Lihat Rekap Detail
               </Link>
             </div>

--- a/cicero-dashboard/app/likes/instagram/rekap/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/rekap/page.jsx
@@ -133,39 +133,51 @@ export default function RekapLikesIGPage() {
   if (loading) return <Loader />;
   if (error)
     return (
-      <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100 p-4">
-        <div className="bg-white rounded-lg shadow-md p-6 text-center text-red-500 font-bold">
+      <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 p-6 text-slate-100">
+        <div className="rounded-3xl border border-red-500/40 bg-slate-900/70 px-8 py-6 text-center text-red-200 shadow-[0_0_35px_rgba(248,113,113,0.25)]">
           {error}
         </div>
       </div>
     );
   return (
-    <div className="min-h-screen bg-gray-100">
-      <div className="p-4 md:p-8 max-w-6xl mx-auto w-full">
-        <div className="flex flex-col gap-6">
-          <div className="flex items-center justify-between mb-2">
-            <h1 className="text-2xl md:text-3xl font-bold text-blue-700">
-              Rekapitulasi Likes Instagram
-            </h1>
-            <Link
-              href="/likes/instagram"
-              className="inline-block bg-gray-100 hover:bg-blue-50 text-blue-700 border border-blue-300 font-semibold px-4 py-2 rounded-lg transition-all duration-150 shadow flex items-center gap-2"
-            >
-              <ArrowLeft className="w-4 h-4" />
-              Kembali
-            </Link>
-          </div>
-          <div className="flex flex-wrap items-center justify-end gap-3 mb-2">
-            <ViewDataSelector
-              value={viewBy}
-              onChange={handleViewChange}
-              options={viewOptions}
-              date={selectorDateValue}
-              onDateChange={handleDateChange}
-            />
+    <div className="relative min-h-screen overflow-hidden bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 text-slate-100">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.16),_transparent_60%)]" />
+      <div className="pointer-events-none absolute bottom-0 left-1/2 h-96 w-96 -translate-x-1/2 rounded-full bg-[radial-gradient(circle,_rgba(129,140,248,0.18)_0%,_transparent_70%)]" />
+      <div className="relative mx-auto flex min-h-screen w-full max-w-6xl flex-col px-4 py-12 md:px-10">
+        <div className="flex flex-col gap-10">
+          <div className="relative overflow-hidden rounded-3xl border border-slate-800/80 bg-slate-900/60 p-6 shadow-[0_0_48px_rgba(56,189,248,0.12)] backdrop-blur">
+            <div className="pointer-events-none absolute -top-16 left-0 h-40 w-40 rounded-full bg-sky-500/20 blur-3xl" />
+            <div className="pointer-events-none absolute -bottom-20 right-8 h-48 w-48 rounded-full bg-indigo-500/20 blur-3xl" />
+            <div className="relative flex flex-col gap-6">
+              <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                <div>
+                  <h1 className="text-3xl font-semibold tracking-tight text-sky-100">
+                    Rekapitulasi Likes Instagram
+                  </h1>
+                  <p className="mt-1 max-w-2xl text-sm text-slate-300">
+                    Lihat rekap detail keterlibatan likes dari seluruh personel dengan nuansa futuristik yang senada dengan dashboard utama.
+                  </p>
+                </div>
+                <Link
+                  href="/likes/instagram"
+                  className="inline-flex items-center gap-2 rounded-2xl border border-slate-400/40 bg-white/5 px-4 py-2 text-sm font-semibold text-slate-100 shadow-[0_0_25px_rgba(56,189,248,0.15)] transition hover:border-sky-400/60 hover:bg-sky-500/20"
+                >
+                  <ArrowLeft className="h-4 w-4" />
+                  Kembali
+                </Link>
+              </div>
+              <div className="rounded-2xl border border-white/10 bg-white/5 p-4 shadow-inner backdrop-blur">
+                <ViewDataSelector
+                  value={viewBy}
+                  onChange={handleViewChange}
+                  options={viewOptions}
+                  date={selectorDateValue}
+                  onDateChange={handleDateChange}
+                />
+              </div>
+            </div>
           </div>
 
-          {/* Kirim data dari fetch ke komponen rekap likes */}
           <RekapLikesIG
             ref={rekapRef}
             users={chartData}

--- a/cicero-dashboard/components/ChartDataTable.jsx
+++ b/cicero-dashboard/components/ChartDataTable.jsx
@@ -35,24 +35,27 @@ export default function ChartDataTable({
   });
 
   return (
-    <details className="group mt-4" open={initialOpen}>
-      <summary className="inline-flex cursor-pointer items-center gap-2 rounded px-2 py-1 text-sm font-semibold text-slate-700 transition hover:text-slate-900 focus:outline-none focus-visible:ring focus-visible:ring-blue-500 focus-visible:ring-offset-2">
+    <details
+      className="group mt-4 rounded-2xl border border-white/10 bg-slate-950/30 p-4 text-slate-200 shadow-inner backdrop-blur"
+      open={initialOpen}
+    >
+      <summary className="inline-flex cursor-pointer items-center gap-2 rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-sm font-semibold text-slate-100 transition hover:bg-white/10 focus:outline-none focus-visible:ring focus-visible:ring-sky-500/60 focus-visible:ring-offset-0">
         <span
           aria-hidden="true"
-          className="text-xs transition-transform duration-200 group-open:rotate-90"
+          className="text-xs text-cyan-300 transition-transform duration-200 group-open:rotate-90"
         >
           ▶
         </span>
         {summaryLabel}
       </summary>
       <div className="mt-3 overflow-x-auto">
-        <table className="min-w-full border-collapse text-sm text-slate-700">
+        <table className="min-w-full border-collapse text-sm text-slate-100">
           {title ? (
-            <caption className="mb-2 text-left text-base font-semibold text-slate-800">
+            <caption className="mb-2 text-left text-base font-semibold text-sky-200">
               {title}
             </caption>
           ) : null}
-          <thead className="bg-slate-100 text-xs font-semibold uppercase tracking-wide text-slate-900">
+          <thead className="bg-slate-900/80 text-xs font-semibold uppercase tracking-[0.2em] text-slate-200">
             <tr>
               {normalizedColumns.map((column) => (
                 <th
@@ -65,11 +68,11 @@ export default function ChartDataTable({
               ))}
             </tr>
           </thead>
-          <tbody className="divide-y divide-slate-200 bg-white">
+          <tbody className="divide-y divide-white/10 bg-slate-950/50">
             {rows.map((row, rowIndex) => (
               <tr
                 key={row.id ?? row.key ?? rowIndex}
-                className={rowIndex % 2 === 0 ? "bg-white" : "bg-slate-50"}
+                className={rowIndex % 2 === 0 ? "bg-slate-950/40" : "bg-slate-900/40"}
               >
                 {normalizedColumns.map((column, columnIndex) => {
                   const cellValue = row[column.key];
@@ -82,7 +85,7 @@ export default function ChartDataTable({
                       <th
                         key={column.key}
                         scope="row"
-                        className={`${baseClass} font-semibold text-slate-900`}
+                        className={`${baseClass} font-semibold text-sky-100`}
                       >
                         {content}
                       </th>
@@ -90,7 +93,7 @@ export default function ChartDataTable({
                   }
 
                   return (
-                    <td key={column.key} className={`${baseClass} whitespace-nowrap`}>
+                    <td key={column.key} className={`${baseClass} whitespace-nowrap text-slate-200`}>
                       {content}
                     </td>
                   );

--- a/cicero-dashboard/components/ChartHorizontal.jsx
+++ b/cicero-dashboard/components/ChartHorizontal.jsx
@@ -127,18 +127,28 @@ export default function ChartHorizontal({
   });
 
   return (
-    <div className="w-full bg-white rounded-xl shadow p-0 md:p-0 mt-8">
-      <h3 className="font-bold text-lg mb-2 px-6 pt-6">{title}</h3>
-      <div className="w-full px-2 pb-4">
-        <ResponsiveContainer width="100%" height={chartHeight}>
-          <BarChart
-            data={dataChart}
-            layout="vertical"
-            margin={{ top: 4, right: 20, left: 4, bottom: 4 }} // left besar!
-            barCategoryGap="16%"
-          >
-            <CartesianGrid strokeDasharray="3 3" />
-            <XAxis type="number" fontSize={12} />
+    <div className="relative mt-8 w-full overflow-hidden rounded-3xl border border-slate-800/60 bg-slate-900/60 p-6 shadow-[0_0_32px_rgba(56,189,248,0.08)] backdrop-blur">
+      <div className="pointer-events-none absolute -right-16 top-8 h-40 w-40 rounded-full bg-sky-500/15 blur-3xl" />
+      <div className="pointer-events-none absolute inset-x-12 top-0 h-16 bg-gradient-to-b from-white/10 to-transparent blur-2xl" />
+      <div className="relative flex flex-col gap-6">
+        <h3 className="text-center text-sm font-semibold uppercase tracking-[0.4em] text-cyan-200/80">
+          {title}
+        </h3>
+        <div className="w-full">
+          <ResponsiveContainer width="100%" height={chartHeight}>
+            <BarChart
+              data={dataChart}
+              layout="vertical"
+              margin={{ top: 8, right: 24, left: 0, bottom: 8 }}
+              barCategoryGap="16%"
+            >
+            <CartesianGrid strokeDasharray="3 3" stroke="rgba(148,163,184,0.25)" />
+            <XAxis
+              type="number"
+              tick={{ fill: "#cbd5f5", fontSize: 12 }}
+              axisLine={{ stroke: "rgba(148,163,184,0.3)" }}
+              tickLine={{ stroke: "rgba(148,163,184,0.3)" }}
+            />
             <YAxis
               dataKey="divisi"
               type="category"
@@ -151,7 +161,7 @@ export default function ChartHorizontal({
                     x={x - 160} // mundur sedikit agar makin lepas dari bar
                     y={y + 10}
                     fontSize={12}
-                    fill="#444"
+                    fill="#cbd5f5"
                     style={{ fontWeight: 500 }}
                     textAnchor="start"
                   >
@@ -177,9 +187,22 @@ export default function ChartHorizontal({
                     : name,
                 ]
               }
-              labelFormatter={label => `Divisi: ${label}`}
+              labelFormatter={(label) => `Divisi: ${label}`}
+              wrapperStyle={{ outline: "none" }}
+              contentStyle={{
+                backgroundColor: "rgba(15,23,42,0.92)",
+                borderRadius: 16,
+                borderColor: "rgba(148,163,184,0.4)",
+                boxShadow: "0 20px 45px rgba(15,118,110,0.2)",
+                color: "#e2e8f0",
+              }}
             />
-            <Legend />
+            <Legend
+              wrapperStyle={{
+                color: "#cbd5f5",
+                paddingTop: 8,
+              }}
+            />
             {showTotalUser && (
               <Bar
                 dataKey="total_user"
@@ -212,7 +235,8 @@ export default function ChartHorizontal({
               <LabelList dataKey="user_belum" position="right" fontSize={10} />
             </Bar>
           </BarChart>
-        </ResponsiveContainer>
+          </ResponsiveContainer>
+        </div>
         <ChartDataTable
           title={title}
           columns={tableColumns}

--- a/cicero-dashboard/components/Narrative.jsx
+++ b/cicero-dashboard/components/Narrative.jsx
@@ -1,7 +1,7 @@
 "use client";
 export default function Narrative({ children }) {
   return (
-    <p className="mt-2 text-sm text-gray-500 italic leading-snug">
+    <p className="mt-2 text-sm italic leading-snug text-slate-300">
       {children}
     </p>
   );

--- a/cicero-dashboard/components/RekapLikesIG.jsx
+++ b/cicero-dashboard/components/RekapLikesIG.jsx
@@ -336,211 +336,240 @@ const RekapLikesIG = forwardRef(function RekapLikesIG(
   }));
 
   return (
-    <div className="flex flex-col gap-6 mt-8 min-h-screen pb-24">
-      {/* Ringkasan */}
-      <div className="grid grid-cols-1 md:grid-cols-6 gap-4">
+    <div className="mt-10 flex flex-col gap-10 pb-32">
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-3 xl:grid-cols-6">
         <SummaryCard
           title="IG Post Hari Ini"
           value={totalIGPost}
-          color="bg-gradient-to-r from-pink-400 via-fuchsia-400 to-blue-400 text-white"
-          icon={<Camera />}
+          accent="sky"
+          icon={
+            <Camera className="h-6 w-6 text-sky-200 drop-shadow-[0_0_12px_rgba(56,189,248,0.55)]" />
+          }
         />
         <SummaryCard
           title="Total User"
           value={totalUser}
-          color="bg-gradient-to-r from-blue-400 via-blue-500 to-sky-400 text-white"
-          icon={<Users />}
+          accent="slate"
+          icon={
+            <Users className="h-6 w-6 text-slate-200 drop-shadow-[0_0_12px_rgba(148,163,184,0.45)]" />
+          }
         />
         <SummaryCard
           title="Sudah Like"
           value={totalSudahLike}
-          color="bg-gradient-to-r from-green-400 via-green-500 to-lime-400 text-white"
-          icon={<Check />}
+          accent="emerald"
+          icon={
+            <Check className="h-6 w-6 text-emerald-200 drop-shadow-[0_0_12px_rgba(16,185,129,0.55)]" />
+          }
           percentage={getPercentage(totalSudahLike)}
         />
         <SummaryCard
           title="Kurang Like"
           value={totalKurangLike}
-          color="bg-gradient-to-r from-yellow-400 via-orange-500 to-orange-600 text-white"
-          icon={<AlertTriangle />}
+          accent="amber"
+          icon={
+            <AlertTriangle className="h-6 w-6 text-amber-100 drop-shadow-[0_0_12px_rgba(251,191,36,0.5)]" />
+          }
           percentage={getPercentage(totalKurangLike)}
         />
         <SummaryCard
           title="Belum Like"
           value={totalBelumLike}
-          color="bg-gradient-to-r from-red-400 via-pink-500 to-yellow-400 text-white"
-          icon={<X />}
+          accent="rose"
+          icon={
+            <X className="h-6 w-6 text-rose-200 drop-shadow-[0_0_12px_rgba(244,63,94,0.55)]" />
+          }
           percentage={getPercentage(totalBelumLike)}
         />
         <SummaryCard
           title="Tanpa Username"
           value={totalTanpaUsername}
-          color="bg-gradient-to-r from-gray-300 via-gray-400 to-gray-500 text-gray-800"
-          icon={<UserX />}
+          accent="violet"
+          icon={
+            <UserX className="h-6 w-6 text-violet-200 drop-shadow-[0_0_12px_rgba(139,92,246,0.55)]" />
+          }
           percentage={getPercentage(totalTanpaUsername, totalUser)}
         />
       </div>
 
-      {/* Search bar */}
-      <div className="flex justify-end mb-2">
-        <label
-          className="flex flex-col items-end gap-1 w-full md:w-auto"
-          htmlFor="rekap-likes-ig-search"
-        >
-          <span className="text-sm font-medium text-gray-700">
-            Cari personel Instagram
-          </span>
-          <input
-            id="rekap-likes-ig-search"
-            type="text"
-            placeholder="Cari nama, username, divisi, atau client"
-            className="px-3 py-2 border rounded-lg text-sm w-full md:w-64 shadow focus:outline-none focus:ring-2 focus:ring-blue-300"
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-          />
-        </label>
-      </div>
+      <div className="relative overflow-hidden rounded-3xl border border-slate-800/60 bg-slate-900/60 p-6 shadow-[0_0_32px_rgba(56,189,248,0.08)] backdrop-blur">
+        <div className="pointer-events-none absolute -left-24 top-0 h-48 w-48 rounded-full bg-indigo-500/20 blur-3xl" />
+        <div className="pointer-events-none absolute -right-16 bottom-0 h-56 w-56 rounded-full bg-emerald-500/20 blur-3xl" />
+        <div className="relative flex flex-col gap-6">
+          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div className="space-y-1">
+              <h2 className="text-lg font-semibold text-sky-100">
+                Rekap Personel Instagram
+              </h2>
+              <p className="text-sm text-slate-300">
+                Filter dan telusuri status likes setiap personel pada periode terpilih.
+              </p>
+            </div>
+            <label
+              className="flex w-full max-w-xs flex-col gap-2 text-slate-200 md:max-w-sm"
+              htmlFor="rekap-likes-ig-search"
+            >
+              <span className="text-[11px] uppercase tracking-[0.35em] text-slate-400">
+                Cari personel Instagram
+              </span>
+              <input
+                id="rekap-likes-ig-search"
+                type="text"
+                placeholder="Cari nama, username, divisi, atau client"
+                className="w-full rounded-xl border border-white/10 bg-slate-950/60 px-3 py-2 text-sm text-slate-100 shadow-inner transition focus:border-sky-400/60 focus:outline-none focus:ring-2 focus:ring-sky-500/30"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+              />
+            </label>
+          </div>
 
-      {/* Tabel */}
-      <div className="relative overflow-x-auto rounded-xl shadow">
-        <table className="w-full text-sm text-left">
-          <thead className="sticky top-0 bg-gray-50 z-10">
-            <tr>
-              <th className="py-2 px-2">No</th>
-              {hasClient && <th className="py-2 px-2">Client</th>}
-              <th className="py-2 px-2">Nama</th>
-              <th className="py-2 px-2">Username IG</th>
-              <th className="py-2 px-2">Divisi/Satfung</th>
-              <th className="py-2 px-2 text-center">Status</th>
-              <th className="py-2 px-2 text-center">Jumlah Like</th>
-            </tr>
-          </thead>
-          <tbody>
-            {currentRows.length === 0 ? (
-              <tr>
-                <td
-                  colSpan={hasClient ? 7 : 6}
-                  className="h-48 py-12 px-4 text-center text-sm text-gray-500"
-                >
-                  <div className="flex flex-col items-center gap-3">
-                    <p className="font-medium">
-                      Data tidak ditemukan untuk filter saat ini.
-                    </p>
-                    {search && (
-                      <button
-                        type="button"
-                        onClick={() => setSearch("")}
-                        className="rounded-lg border border-blue-200 bg-blue-50 px-4 py-1.5 text-sm font-semibold text-blue-700 shadow-sm transition hover:bg-blue-100"
-                      >
-                        Reset pencarian
-                      </button>
-                    )}
-                  </div>
-                </td>
-              </tr>
-            ) : (
-              currentRows.map((u, i) => {
-                const username = String(u.username || "").trim();
-                let rowClass = "bg-red-50";
-                let statusEl = (
-                  <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs bg-red-500 text-white font-semibold">
-                    <X className="w-3 h-3" /> Belum
-                  </span>
-                );
-                let jumlahDisplay = u.jumlah_like;
-                if (!username) {
-                  rowClass = "bg-gray-50";
-                  statusEl = (
-                    <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs bg-gray-500 text-white font-semibold">
-                      <UserX className="w-3 h-3" /> Tanpa Username
-                    </span>
-                  );
-                  jumlahDisplay = 0;
-                } else if (totalIGPost !== 0) {
-                  const likes = Number(u.jumlah_like) || 0;
-                  if (likes >= totalIGPost * 0.5) {
-                    rowClass = "bg-green-50";
-                    statusEl = (
-                      <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs bg-green-500 text-white font-semibold">
-                        <Check className="w-3 h-3" /> Sudah
-                      </span>
-                    );
-                  } else if (likes > 0) {
-                    rowClass = "bg-yellow-50";
-                    statusEl = (
-                      <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs bg-yellow-500 text-white font-semibold">
-                        <AlertTriangle className="w-3 h-3" /> Kurang
-                      </span>
-                    );
-                  }
-                }
-
-                return (
-                  <tr key={u.user_id} className={rowClass}>
-                    <td className="py-1 px-2">{(page - 1) * PAGE_SIZE + i + 1}</td>
-                    {hasClient && (
-                      <td className="py-1 px-2">
-                        {u.nama_client || u.client_name || u.client || "-"}
-                      </td>
-                    )}
-                    <td className="py-1 px-2">
-                      {u.title ? `${u.title} ${u.nama}` : u.nama}
+          <div className="overflow-hidden rounded-2xl border border-white/10">
+            <table className="w-full border-collapse text-left text-sm text-slate-200">
+              <thead className="sticky top-0 z-10 bg-slate-950/80 text-xs uppercase tracking-[0.3em] text-slate-300">
+                <tr>
+                  <th className="px-3 py-3">No</th>
+                  {hasClient && <th className="px-3 py-3">Client</th>}
+                  <th className="px-3 py-3">Nama</th>
+                  <th className="px-3 py-3">Username IG</th>
+                  <th className="px-3 py-3">Divisi/Satfung</th>
+                  <th className="px-3 py-3 text-center">Status</th>
+                  <th className="px-3 py-3 text-center">Jumlah Like</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-white/10 bg-slate-950/40">
+                {currentRows.length === 0 ? (
+                  <tr>
+                    <td
+                      colSpan={hasClient ? 7 : 6}
+                      className="h-48 px-4 text-center text-sm text-slate-300"
+                    >
+                      <div className="flex flex-col items-center gap-3">
+                        <p className="font-semibold text-slate-100">
+                          Data tidak ditemukan untuk filter saat ini.
+                        </p>
+                        {search && (
+                          <button
+                            type="button"
+                            onClick={() => setSearch("")}
+                            className="rounded-xl border border-sky-400/40 bg-sky-500/20 px-4 py-1.5 text-sm font-semibold text-sky-200 shadow-[0_0_18px_rgba(56,189,248,0.25)] transition hover:border-sky-300/60 hover:bg-sky-400/30"
+                          >
+                            Reset pencarian
+                          </button>
+                        )}
+                      </div>
                     </td>
-                    <td className="py-1 px-2 font-mono text-blue-700">@{u.username}</td>
-                    <td className="py-1 px-2">
-                      <span className="inline-block px-2 py-0.5 rounded bg-sky-100 text-sky-800 font-medium">
-                        {u.divisi || "-"}
-                      </span>
-                    </td>
-                    <td className="py-1 px-2 text-center">{statusEl}</td>
-                    <td className="py-1 px-2 text-center font-bold">{jumlahDisplay}</td>
                   </tr>
-                );
-              })
-            )}
-          </tbody>
-        </table>
-      </div>
-      <p className="mt-2 text-sm text-gray-500 italic">
-        Tabel ini menampilkan status like Instagram setiap user serta jumlah
-        like yang berhasil dihimpun.
-      </p>
+                ) : (
+                  currentRows.map((u, i) => {
+                    const username = String(u.username || "").trim();
+                    let rowClass = "bg-rose-500/10";
+                    let statusEl = (
+                      <span className="inline-flex items-center gap-1 rounded-full border border-rose-400/40 bg-rose-500/20 px-2 py-0.5 text-xs font-semibold text-rose-200 shadow-[0_0_14px_rgba(244,63,94,0.35)]">
+                        <X className="h-3 w-3" /> Belum
+                      </span>
+                    );
+                    let jumlahDisplay = u.jumlah_like;
+                    if (!username) {
+                      rowClass = "bg-slate-500/10";
+                      statusEl = (
+                        <span className="inline-flex items-center gap-1 rounded-full border border-slate-400/40 bg-slate-500/20 px-2 py-0.5 text-xs font-semibold text-slate-200 shadow-[0_0_12px_rgba(148,163,184,0.35)]">
+                          <UserX className="h-3 w-3" /> Tanpa Username
+                        </span>
+                      );
+                      jumlahDisplay = 0;
+                    } else if (totalIGPost !== 0) {
+                      const likes = Number(u.jumlah_like) || 0;
+                      if (likes >= totalIGPost * 0.5) {
+                        rowClass = "bg-emerald-500/10";
+                        statusEl = (
+                          <span className="inline-flex items-center gap-1 rounded-full border border-emerald-400/40 bg-emerald-500/20 px-2 py-0.5 text-xs font-semibold text-emerald-200 shadow-[0_0_14px_rgba(16,185,129,0.35)]">
+                            <Check className="h-3 w-3" /> Sudah
+                          </span>
+                        );
+                      } else if (likes > 0) {
+                        rowClass = "bg-amber-500/10";
+                        statusEl = (
+                          <span className="inline-flex items-center gap-1 rounded-full border border-amber-400/40 bg-amber-500/20 px-2 py-0.5 text-xs font-semibold text-amber-100 shadow-[0_0_14px_rgba(251,191,36,0.35)]">
+                            <AlertTriangle className="h-3 w-3" /> Kurang
+                          </span>
+                        );
+                      }
+                    }
 
-      {/* Pagination Controls */}
-      {totalPages > 1 && (
-        <div className="flex items-center justify-between mt-4">
-          <button
-            className="px-3 py-1 rounded bg-gray-200 hover:bg-gray-300 text-gray-700 font-semibold disabled:opacity-50"
-            disabled={page === 1}
-            onClick={() => setPage(p => Math.max(1, p - 1))}
-          >
-            Prev
-          </button>
-          <span className="text-sm text-gray-600">
-            Halaman <b>{page}</b> dari <b>{totalPages}</b>
-          </span>
-          <button
-            className="px-3 py-1 rounded bg-gray-200 hover:bg-gray-300 text-gray-700 font-semibold disabled:opacity-50"
-            disabled={page === totalPages}
-            onClick={() => setPage(p => Math.min(totalPages, p + 1))}
-          >
-            Next
-          </button>
+                    return (
+                      <tr
+                        key={u.user_id}
+                        className={`${rowClass} text-slate-100 transition-colors`}
+                      >
+                        <td className="px-3 py-2">{(page - 1) * PAGE_SIZE + i + 1}</td>
+                        {hasClient && (
+                          <td className="px-3 py-2">
+                            {u.nama_client || u.client_name || u.client || "-"}
+                          </td>
+                        )}
+                        <td className="px-3 py-2">
+                          {u.title ? `${u.title} ${u.nama}` : u.nama}
+                        </td>
+                        <td className="px-3 py-2 font-mono text-sky-300">
+                          @{u.username}
+                        </td>
+                        <td className="px-3 py-2">
+                          <span className="inline-block rounded-full border border-sky-400/40 bg-sky-500/20 px-2 py-0.5 text-xs font-semibold text-sky-200">
+                            {u.divisi || "-"}
+                          </span>
+                        </td>
+                        <td className="px-3 py-2 text-center">{statusEl}</td>
+                        <td className="px-3 py-2 text-center font-semibold text-sky-100">
+                          {jumlahDisplay}
+                        </td>
+                      </tr>
+                    );
+                  })
+                )}
+              </tbody>
+            </table>
+          </div>
+          <p className="text-sm italic text-slate-300">
+            Tabel ini menampilkan status like Instagram setiap user serta jumlah like yang berhasil dihimpun.
+          </p>
+
+          {totalPages > 1 && (
+            <div className="flex flex-col gap-3 rounded-2xl border border-white/10 bg-slate-950/40 p-4 text-slate-200 shadow-inner sm:flex-row sm:items-center sm:justify-between">
+              <button
+                className="rounded-xl border border-white/10 bg-white/5 px-4 py-1.5 text-sm font-semibold text-slate-200 transition hover:border-sky-400/40 hover:bg-sky-500/20 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:border-white/10 disabled:hover:bg-white/5"
+                disabled={page === 1}
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+              >
+                Prev
+              </button>
+              <span className="text-sm text-slate-300">
+                Halaman <b className="text-sky-200">{page}</b> dari {" "}
+                <b className="text-sky-200">{totalPages}</b>
+              </span>
+              <button
+                className="rounded-xl border border-white/10 bg-white/5 px-4 py-1.5 text-sm font-semibold text-slate-200 transition hover:border-sky-400/40 hover:bg-sky-500/20 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:border-white/10 disabled:hover:bg-white/5"
+                disabled={page === totalPages}
+                onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+              >
+                Next
+              </button>
+            </div>
+          )}
         </div>
-      )}
+      </div>
 
       {showRekapButton && (
-        <div className="sticky bottom-4 z-20 flex w-full justify-end px-4">
-          <div className="flex w-full max-w-xl flex-col gap-2 rounded-2xl border border-slate-200 bg-white/95 p-3 shadow-xl backdrop-blur-sm sm:flex-row sm:items-center">
+        <div className="pointer-events-none sticky bottom-4 z-20 flex w-full justify-end px-4">
+          <div className="pointer-events-auto flex w-full max-w-xl flex-col gap-3 rounded-2xl border border-slate-800/70 bg-slate-950/80 p-4 shadow-[0_20px_60px_rgba(15,118,110,0.2)] backdrop-blur md:flex-row md:items-center md:justify-end">
             <button
               onClick={handleDownloadRekap}
-              className="w-full px-4 py-2 bg-green-600 hover:bg-green-700 text-white rounded-lg shadow sm:w-auto"
+              className="w-full rounded-2xl border border-emerald-400/40 bg-emerald-500/20 px-4 py-2 text-sm font-semibold text-emerald-200 shadow-[0_0_25px_rgba(16,185,129,0.35)] transition hover:border-emerald-300/60 hover:bg-emerald-400/30 md:w-auto"
             >
               Download Rekap
             </button>
             <button
               onClick={handleCopyRekap}
-              className="w-full px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg shadow sm:w-auto"
+              className="w-full rounded-2xl border border-sky-400/40 bg-sky-500/20 px-4 py-2 text-sm font-semibold text-sky-200 shadow-[0_0_25px_rgba(56,189,248,0.35)] transition hover:border-sky-300/60 hover:bg-sky-400/30 md:w-auto"
             >
               Salin Rekap
             </button>
@@ -554,7 +583,7 @@ const RekapLikesIG = forwardRef(function RekapLikesIG(
 export default RekapLikesIG;
 
 // Semua card mengikuti style IG Post Hari Ini
-function SummaryCard({ title, value, color, icon, percentage }) {
+function SummaryCard({ title, value, icon, percentage, accent = "sky" }) {
   const formattedPercentage =
     typeof percentage === "number" && !Number.isNaN(percentage)
       ? `${percentage.toFixed(1).replace(".0", "")}%`
@@ -563,43 +592,80 @@ function SummaryCard({ title, value, color, icon, percentage }) {
     typeof percentage === "number"
       ? Math.min(100, Math.max(0, percentage))
       : 0;
-  const hasDarkText = /text-(gray|slate|zinc)-(8|9)00/.test(color);
-  const labelTextClass = hasDarkText ? "text-gray-900" : "text-white";
-  const percentageTextClass = hasDarkText ? "text-gray-900/80" : "text-white/80";
-  const progressBackground = hasDarkText ? "bg-gray-300/80" : "bg-white/30";
-  const progressFill = hasDarkText ? "bg-gray-700" : "bg-white";
+
+  const accentStyles = {
+    sky: {
+      border: "border-sky-400/40",
+      glow: "bg-sky-500/30",
+      text: "text-sky-200",
+      progress: "bg-sky-400",
+    },
+    slate: {
+      border: "border-slate-400/40",
+      glow: "bg-slate-500/25",
+      text: "text-slate-200",
+      progress: "bg-slate-400",
+    },
+    emerald: {
+      border: "border-emerald-400/40",
+      glow: "bg-emerald-500/25",
+      text: "text-emerald-200",
+      progress: "bg-emerald-400",
+    },
+    amber: {
+      border: "border-amber-400/50",
+      glow: "bg-amber-500/30",
+      text: "text-amber-100",
+      progress: "bg-amber-400",
+    },
+    rose: {
+      border: "border-rose-400/50",
+      glow: "bg-rose-500/30",
+      text: "text-rose-200",
+      progress: "bg-rose-400",
+    },
+    violet: {
+      border: "border-violet-400/50",
+      glow: "bg-violet-500/30",
+      text: "text-violet-200",
+      progress: "bg-violet-400",
+    },
+  };
+
+  const styles = accentStyles[accent] || accentStyles.sky;
 
   return (
-    <div
-      className={`rounded-2xl shadow-md p-6 flex flex-col items-center gap-2 text-center ${color}`}
-    >
-      <div className="flex items-center gap-2 text-3xl font-bold">
-        {icon}
-        <span>{value}</span>
-      </div>
-      <div
-        className={`text-xs mt-1 font-semibold uppercase tracking-wider ${labelTextClass}`}
-      >
-        {title}
-      </div>
-      {formattedPercentage && (
-        <div className="mt-1 flex flex-col items-center gap-1 w-full max-w-[180px]">
-          <span className={`text-[11px] font-medium ${percentageTextClass}`}>
-            {formattedPercentage}
+    <div className={`relative overflow-hidden rounded-2xl border ${styles.border} bg-slate-900/60 p-6 text-center shadow-[0_0_25px_rgba(56,189,248,0.08)] backdrop-blur`}>
+      <div className={`pointer-events-none absolute -right-10 top-0 h-24 w-24 rounded-full blur-3xl ${styles.glow}`} />
+      <div className="relative flex flex-col items-center gap-3">
+        <div className={`flex items-center gap-3 text-3xl font-semibold ${styles.text}`}>
+          <span className="rounded-full bg-white/5 p-2 shadow-inner">
+            {icon}
           </span>
-          <div className={`h-1.5 w-full rounded-full ${progressBackground}`}>
-            <div
-              className={`h-full rounded-full transition-all duration-300 ease-out ${progressFill}`}
-              style={{ width: `${clampedPercentage}%` }}
-              role="progressbar"
-              aria-valuenow={Math.round(Number(percentage) || 0)}
-              aria-valuemin={0}
-              aria-valuemax={100}
-              aria-label={`${title} ${formattedPercentage}`}
-            />
-          </div>
+          <span>{value}</span>
         </div>
-      )}
+        <div className="text-xs font-semibold uppercase tracking-[0.35em] text-slate-300">
+          {title}
+        </div>
+        {formattedPercentage && (
+          <div className="mt-1 flex w-full max-w-[200px] flex-col items-center gap-1">
+            <span className="text-[11px] font-medium text-slate-200">
+              {formattedPercentage}
+            </span>
+            <div className="h-1.5 w-full overflow-hidden rounded-full bg-slate-800/70">
+              <div
+                className={`h-full rounded-full transition-all duration-300 ease-out ${styles.progress}`}
+                style={{ width: `${clampedPercentage}%` }}
+                role="progressbar"
+                aria-valuenow={Math.round(Number(percentage) || 0)}
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-label={`${title} ${formattedPercentage}`}
+              />
+            </div>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/cicero-dashboard/components/likes/instagram/ChartBox.jsx
+++ b/cicero-dashboard/components/likes/instagram/ChartBox.jsx
@@ -12,8 +12,12 @@ export default function ChartBox({
   sortBy,
 }) {
   return (
-    <div className="bg-white rounded-xl shadow p-4">
-      <div className="font-bold text-blue-700 mb-2 text-center">{title}</div>
+    <div className="relative overflow-hidden rounded-3xl border border-slate-800/60 bg-slate-900/60 p-6 shadow-[0_0_32px_rgba(56,189,248,0.08)] backdrop-blur">
+      <div className="pointer-events-none absolute -right-12 top-6 h-32 w-32 rounded-full bg-cyan-500/10 blur-3xl" />
+      <div className="pointer-events-none absolute inset-x-10 top-0 h-16 bg-gradient-to-b from-white/10 to-transparent blur-2xl" />
+      <div className="relative mb-4 text-center text-sm font-semibold uppercase tracking-[0.4em] text-cyan-200/80">
+        {title}
+      </div>
       {users && users.length > 0 ? (
         <ChartDivisiAbsensi
           users={users}
@@ -31,7 +35,9 @@ export default function ChartBox({
           sortBy={sortBy}
         />
       ) : (
-        <div className="text-center text-gray-400 text-sm">Tidak ada data</div>
+        <div className="relative text-center text-sm text-slate-400">
+          Tidak ada data
+        </div>
       )}
       {narrative && <Narrative>{narrative}</Narrative>}
     </div>

--- a/cicero-dashboard/components/likes/instagram/Divider.jsx
+++ b/cicero-dashboard/components/likes/instagram/Divider.jsx
@@ -1,5 +1,7 @@
 "use client";
 
 export default function Divider() {
-  return <div className="hidden md:block w-px bg-gray-200 mx-2 my-2"></div>;
+  return (
+    <div className="hidden md:block h-16 w-px bg-gradient-to-b from-transparent via-slate-600/50 to-transparent" />
+  );
 }

--- a/cicero-dashboard/components/likes/instagram/SummaryItem.jsx
+++ b/cicero-dashboard/components/likes/instagram/SummaryItem.jsx
@@ -8,11 +8,31 @@ export default function SummaryItem({
   percentage,
 }) {
   const colorMap = {
-    blue: { text: "text-blue-700", bar: "bg-blue-500" },
-    green: { text: "text-green-600", bar: "bg-green-500" },
-    red: { text: "text-red-500", bar: "bg-red-500" },
-    gray: { text: "text-gray-700", bar: "bg-gray-500" },
-    orange: { text: "text-orange-500", bar: "bg-orange-500" },
+    blue: {
+      text: "text-sky-300",
+      bar: "bg-sky-400",
+      glow: "shadow-[0_0_20px_rgba(56,189,248,0.35)]",
+    },
+    green: {
+      text: "text-emerald-300",
+      bar: "bg-emerald-400",
+      glow: "shadow-[0_0_20px_rgba(16,185,129,0.35)]",
+    },
+    red: {
+      text: "text-rose-300",
+      bar: "bg-rose-400",
+      glow: "shadow-[0_0_20px_rgba(244,63,94,0.35)]",
+    },
+    gray: {
+      text: "text-slate-200",
+      bar: "bg-slate-400",
+      glow: "shadow-[0_0_20px_rgba(148,163,184,0.2)]",
+    },
+    orange: {
+      text: "text-amber-300",
+      bar: "bg-amber-400",
+      glow: "shadow-[0_0_20px_rgba(251,191,36,0.35)]",
+    },
   };
   const displayColor = colorMap[color] || colorMap.gray;
   const formattedPercentage =
@@ -24,20 +44,22 @@ export default function SummaryItem({
       ? `${Math.min(100, Math.max(0, percentage))}%`
       : "0%";
   return (
-    <div className="flex-1 flex flex-col items-center justify-center py-2">
-      <div className="mb-1">{icon}</div>
-      <div className={`text-3xl md:text-4xl font-bold ${displayColor.text}`}>
+    <div
+      className={`flex-1 flex min-w-[140px] flex-col items-center justify-center rounded-2xl border border-white/5 bg-white/5 py-4 text-center shadow-lg backdrop-blur-sm ${displayColor.glow}`}
+    >
+      <div className="mb-2 text-slate-200">{icon}</div>
+      <div className={`text-3xl md:text-4xl font-semibold ${displayColor.text}`}>
         {value}
       </div>
-      <div className="text-xs md:text-sm font-semibold text-gray-500 mt-1 uppercase tracking-wide text-center">
+      <div className="mt-2 text-xs md:text-sm font-semibold uppercase tracking-[0.2em] text-slate-300">
         {label}
       </div>
       {formattedPercentage && (
-        <div className="mt-1 flex flex-col items-center gap-1 w-full max-w-[160px]">
-          <span className="text-[11px] md:text-xs font-medium text-gray-600">
+        <div className="mt-3 flex w-full max-w-[180px] flex-col items-center gap-1">
+          <span className="text-[11px] md:text-xs font-medium text-slate-200">
             {formattedPercentage}
           </span>
-          <div className="h-1.5 w-full rounded-full bg-gray-200">
+          <div className="h-1.5 w-full overflow-hidden rounded-full bg-slate-800/80">
             <div
               className={`h-full rounded-full transition-all duration-300 ease-out ${displayColor.bar}`}
               style={{ width: progressWidth }}


### PR DESCRIPTION
## Summary
- restyle the Instagram likes dashboard with glassmorphism backgrounds, neon summary cards, and updated action buttons to match the main dashboard theme
- redesign the Instagram likes recap page header, filters, and sticky controls around the revitalized RekapLikesIG component
- refresh supporting components (summary cards, chart containers, tables, and narratives) with dark futuristic palettes and glow accents for consistent visuals across insights

## Testing
- ⚠️ `npm run lint` *(blocked by Next.js interactive ESLint setup that attempts to install additional dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d406f8e3b88327b9b9670f75e9d296