### PR TITLE
Revamp TikTok comments experience with futuristic theme

### DIFF
--- a/cicero-dashboard/app/comments/tiktok/page.jsx
+++ b/cicero-dashboard/app/comments/tiktok/page.jsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useState } from "react";
+import { cloneElement, useEffect, useState } from "react";
 import {
   getDashboardStats,
   getRekapKomentarTiktok,
@@ -19,6 +19,7 @@ import ViewDataSelector, {
   getPeriodeDateForView,
   VIEW_OPTIONS,
 } from "@/components/ViewDataSelector";
+import { cn } from "@/lib/utils";
 import {
   Music,
   User,
@@ -292,9 +293,18 @@ export default function TiktokEngagementInsightPage() {
   if (isInitialLoad) return <Loader />;
   if (error)
     return (
-      <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100 p-4">
-        <div className="bg-white rounded-lg shadow-md p-6 text-center text-red-500 font-bold">
-          {error}
+      <div className="flex min-h-screen items-center justify-center bg-slate-950 p-6 text-slate-100">
+        <div className="relative w-full max-w-lg overflow-hidden rounded-3xl border border-rose-500/40 bg-slate-900/80 p-8 text-center shadow-[0_0_40px_rgba(244,63,94,0.25)]">
+          <div className="absolute inset-x-12 -top-8 h-24 rounded-full bg-gradient-to-b from-rose-500/30 to-transparent blur-2xl" />
+          <div className="relative space-y-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.4em] text-rose-200/80">
+              System Alert
+            </p>
+            <p className="text-lg font-semibold text-rose-100">{error}</p>
+            <p className="text-sm text-slate-300">
+              Coba muat ulang halaman atau periksa kembali koneksi data Anda.
+            </p>
+          </div>
         </div>
       </div>
     );
@@ -420,177 +430,189 @@ export default function TiktokEngagementInsightPage() {
 
   return (
     <div
-      className="min-h-screen bg-gray-100 flex flex-col"
+      className="relative min-h-screen overflow-hidden bg-slate-950 text-slate-100"
       aria-busy={isRefreshing}
     >
-      <div className="flex-1 flex items-start justify-center">
-        <div className="relative w-full max-w-5xl px-2 md:px-8 py-8">
-          {isRefreshing && (
-            <div className="pointer-events-none absolute inset-x-0 top-3 z-10 flex justify-center sm:justify-end px-2">
-              <div className="flex items-center gap-2 rounded-full bg-white/90 px-3 py-2 shadow-md text-pink-700">
-                <span
-                  className="h-4 w-4 rounded-full border-2 border-pink-500 border-t-transparent animate-spin"
-                  aria-hidden="true"
-                ></span>
-                <span className="text-xs font-semibold tracking-wide uppercase">
-                  Memuat data...
-                </span>
-              </div>
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute -left-40 top-[-120px] h-[420px] w-[420px] rounded-full bg-fuchsia-500/20 blur-[160px]" />
+        <div className="absolute right-[-120px] top-1/3 h-[380px] w-[380px] rounded-full bg-cyan-400/20 blur-[160px]" />
+        <div className="absolute inset-x-0 bottom-[-180px] h-[320px] bg-gradient-to-t from-slate-900 via-slate-950/60 to-transparent" />
+      </div>
+      <div className="relative z-10 mx-auto flex w-full max-w-6xl flex-1 flex-col px-4 pb-16 pt-10 sm:px-6 lg:px-10">
+        {isRefreshing && (
+          <div className="pointer-events-none absolute inset-x-0 top-6 z-20 flex justify-center sm:justify-end">
+            <div className="flex items-center gap-2 rounded-full border border-cyan-500/40 bg-slate-900/80 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-cyan-200 shadow-[0_0_24px_rgba(34,211,238,0.25)]">
+              <span
+                className="h-4 w-4 rounded-full border-2 border-cyan-400/80 border-t-transparent animate-spin"
+                aria-hidden="true"
+              ></span>
+              Memuat data
             </div>
-          )}
-          <div className="flex flex-col gap-8">
-            <h1 className="text-2xl md:text-3xl font-bold text-pink-700 mb-2">
-              TikTok Engagement Insight
+          </div>
+        )}
+
+        <div className="flex flex-1 flex-col gap-10">
+          <div className="space-y-3">
+            <span className="inline-flex w-fit items-center gap-2 rounded-full border border-cyan-400/40 bg-cyan-500/10 px-4 py-1 text-[11px] font-semibold uppercase tracking-[0.4em] text-cyan-200">
+              TikTok Command
+            </span>
+            <h1 className="text-3xl font-semibold leading-tight text-slate-50 md:text-4xl">
+              TikTok Engagement Command Center
             </h1>
+            <p className="max-w-3xl text-sm text-slate-300 md:text-base">
+              Pantau performa komentar personel TikTok untuk{" "}
+              <span className="font-semibold text-cyan-200">
+                {clientName || "satuan Anda"}
+              </span>
+              . Gunakan panel ini untuk melihat kepatuhan komentar, memantau
+              divisi yang aktif, dan mengambil tindakan cepat ketika komentar
+              belum terpenuhi.
+            </p>
+          </div>
 
-            <div className="flex flex-col gap-3">
-              <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
-                <ViewDataSelector
-                  value={viewBy}
-                  onChange={setViewBy}
-                  options={viewOptions}
-                  date={
-                    viewBy === "custom_range"
-                      ? { startDate: fromDate, endDate: toDate }
-                      : customDate
-                  }
-                  onDateChange={(val) => {
-                    if (viewBy === "custom_range") {
-                      setFromDate(val.startDate || "");
-                      setToDate(val.endDate || "");
-                    } else {
-                      setCustomDate(val);
-                    }
-                  }}
-                  disabled={isRefreshing}
-                />
-              </div>
+          <div className="flex flex-col gap-6">
+            <ViewDataSelector
+              value={viewBy}
+              onChange={setViewBy}
+              options={viewOptions}
+              date={
+                viewBy === "custom_range"
+                  ? { startDate: fromDate, endDate: toDate }
+                  : customDate
+              }
+              onDateChange={(val) => {
+                if (viewBy === "custom_range") {
+                  setFromDate(val.startDate || "");
+                  setToDate(val.endDate || "");
+                } else {
+                  setCustomDate(val);
+                }
+              }}
+              disabled={isRefreshing}
+              className="justify-start gap-3 rounded-3xl border border-slate-800/70 bg-slate-900/70 px-4 py-4 backdrop-blur"
+              labelClassName="text-xs font-semibold uppercase tracking-[0.35em] text-slate-400/90"
+              controlClassName="border-slate-700/60 bg-slate-900/70 text-slate-100 focus:border-cyan-400 focus:outline-none focus:ring-2 focus:ring-cyan-500/40"
+            />
 
-              <div className="bg-gradient-to-tr from-fuchsia-50 to-white rounded-2xl shadow flex flex-col md:flex-row items-stretch justify-between p-3 md:p-5 gap-2 md:gap-4 border">
-                <SummaryItem
-                  label="Jumlah TikTok Post"
-                  value={rekapSummary.totalTiktokPost}
-                  color="fuchsia"
-                  icon={<Music className="text-fuchsia-400" />}
-                />
-                <Divider />
-                <SummaryItem
-                  label="Total User"
-                  value={rekapSummary.totalUser}
-                  color="gray"
-                  icon={<User className="text-gray-400" />}
-                />
-                <Divider />
-                <SummaryItem
-                  label="Sudah Komentar"
-                  value={rekapSummary.totalSudahKomentar}
-                  color="green"
-                  icon={<MessageCircle className="text-green-500" />}
-                  percentage={getPercentage(rekapSummary.totalSudahKomentar)}
-                />
-                <Divider />
-                <SummaryItem
-                  label="Kurang Komentar"
-                  value={rekapSummary.totalKurangKomentar}
-                  color="orange"
-                  icon={<MessageCircle className="text-orange-500" />}
-                  percentage={getPercentage(rekapSummary.totalKurangKomentar)}
-                />
-                <Divider />
-                <SummaryItem
-                  label="Belum Komentar"
-                  value={rekapSummary.totalBelumKomentar}
-                  color="red"
-                  icon={<X className="text-red-500" />}
-                  percentage={getPercentage(rekapSummary.totalBelumKomentar)}
-                />
-                <Divider />
-                <SummaryItem
-                  label="Tanpa Username"
-                  value={rekapSummary.totalTanpaUsername}
-                  color="gray"
-                  icon={<UserX className="text-gray-400" />}
-                  percentage={getPercentage(
-                    rekapSummary.totalTanpaUsername,
-                    totalUser,
-                  )}
-                />
-              </div>
+            <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+              <SummaryItem
+                label="Jumlah TikTok Post"
+                value={rekapSummary.totalTiktokPost}
+                color="fuchsia"
+                icon={<Music className="h-5 w-5" />}
+              />
+              <SummaryItem
+                label="Total User"
+                value={rekapSummary.totalUser}
+                color="slate"
+                icon={<User className="h-5 w-5" />}
+              />
+              <SummaryItem
+                label="Sudah Komentar"
+                value={rekapSummary.totalSudahKomentar}
+                color="green"
+                icon={<MessageCircle className="h-5 w-5" />}
+                percentage={getPercentage(rekapSummary.totalSudahKomentar)}
+              />
+              <SummaryItem
+                label="Kurang Komentar"
+                value={rekapSummary.totalKurangKomentar}
+                color="amber"
+                icon={<MessageCircle className="h-5 w-5" />}
+                percentage={getPercentage(rekapSummary.totalKurangKomentar)}
+              />
+              <SummaryItem
+                label="Belum Komentar"
+                value={rekapSummary.totalBelumKomentar}
+                color="red"
+                icon={<X className="h-5 w-5" />}
+                percentage={getPercentage(rekapSummary.totalBelumKomentar)}
+              />
+              <SummaryItem
+                label="Tanpa Username"
+                value={rekapSummary.totalTanpaUsername}
+                color="violet"
+                icon={<UserX className="h-5 w-5" />}
+                percentage={getPercentage(
+                  rekapSummary.totalTanpaUsername,
+                  totalUser,
+                )}
+              />
             </div>
+          </div>
 
-            {isDirectorate ? (
+          {isDirectorate ? (
+            <ChartBox
+              title="POLRES JAJARAN"
+              users={chartData}
+              totalPost={rekapSummary.totalTiktokPost}
+              groupBy="client_id"
+              orientation="horizontal"
+              sortBy="percentage"
+            />
+          ) : (
+            <div className="flex flex-col gap-6">
               <ChartBox
-                title="POLRES JAJARAN"
-                users={chartData}
+                title="BAG"
+                users={kelompok.BAG}
                 totalPost={rekapSummary.totalTiktokPost}
-                groupBy="client_id"
-                orientation="horizontal"
+                narrative="Grafik ini menampilkan perbandingan jumlah komentar TikTok dari user di divisi BAG."
                 sortBy="percentage"
               />
-            ) : (
-              <div className="flex flex-col gap-6">
-                <ChartBox
-                  title="BAG"
-                  users={kelompok.BAG}
-                  totalPost={rekapSummary.totalTiktokPost}
-                  narrative="Grafik ini menampilkan perbandingan jumlah komentar TikTok dari user di divisi BAG."
-                  sortBy="percentage"
-                />
-                <ChartBox
-                  title="SAT"
-                  users={kelompok.SAT}
-                  totalPost={rekapSummary.totalTiktokPost}
-                  narrative="Grafik ini menampilkan perbandingan jumlah komentar TikTok dari user di divisi SAT."
-                  sortBy="percentage"
-                />
-                <ChartBox
-                  title="SI & SPKT"
-                  users={kelompok["SI & SPKT"]}
-                  totalPost={rekapSummary.totalTiktokPost}
-                  narrative="Grafik ini menampilkan perbandingan jumlah komentar TikTok dari user di divisi SI & SPKT."
-                  sortBy="percentage"
-                />
-                <ChartBox
-                  title="LAINNYA"
-                  users={kelompok.LAINNYA}
-                  totalPost={rekapSummary.totalTiktokPost}
-                  narrative="Grafik ini menampilkan perbandingan jumlah komentar TikTok dari user di divisi lainnya."
-                  sortBy="percentage"
-                />
-                <ChartHorizontal
-                  title="POLSEK"
-                  users={kelompok.POLSEK}
-                  totalPost={rekapSummary.totalTiktokPost}
-                  fieldJumlah="jumlah_komentar"
-                  labelSudah="User Sudah Komentar"
-                  labelBelum="User Belum Komentar"
-                  labelTotal="Total Komentar"
-                  showTotalUser
-                  sortBy="percentage"
-                />
-                <Narrative>
-                  Grafik POLSEK menggambarkan distribusi komentar antar user dari
-                  setiap polsek serta total komentar yang berhasil dikumpulkan.
-                </Narrative>
-              </div>
-            )}
-
-            <div className="flex justify-end gap-2 my-2">
-              <button
-                onClick={handleCopyRekap}
-                className="bg-green-600 hover:bg-green-700 text-white font-bold px-6 py-3 rounded-xl shadow transition-all duration-150 text-lg flex items-center gap-2"
-              >
-                <Copy className="w-5 h-5" />
-                Rekap Komentar
-              </button>
-              <Link
-                href="/comments/tiktok/rekap"
-                className="bg-pink-700 hover:bg-pink-800 text-white font-bold px-6 py-3 rounded-xl shadow transition-all duration-150 text-lg flex items-center gap-2"
-              >
-                <ArrowRight className="w-5 h-5 inline" />
-                Lihat Rekap Detail
-              </Link>
+              <ChartBox
+                title="SAT"
+                users={kelompok.SAT}
+                totalPost={rekapSummary.totalTiktokPost}
+                narrative="Grafik ini menampilkan perbandingan jumlah komentar TikTok dari user di divisi SAT."
+                sortBy="percentage"
+              />
+              <ChartBox
+                title="SI & SPKT"
+                users={kelompok["SI & SPKT"]}
+                totalPost={rekapSummary.totalTiktokPost}
+                narrative="Grafik ini menampilkan perbandingan jumlah komentar TikTok dari user di divisi SI & SPKT."
+                sortBy="percentage"
+              />
+              <ChartBox
+                title="LAINNYA"
+                users={kelompok.LAINNYA}
+                totalPost={rekapSummary.totalTiktokPost}
+                narrative="Grafik ini menampilkan perbandingan jumlah komentar TikTok dari user di divisi lainnya."
+                sortBy="percentage"
+              />
+              <ChartHorizontal
+                title="POLSEK"
+                users={kelompok.POLSEK}
+                totalPost={rekapSummary.totalTiktokPost}
+                fieldJumlah="jumlah_komentar"
+                labelSudah="User Sudah Komentar"
+                labelBelum="User Belum Komentar"
+                labelTotal="Total Komentar"
+                showTotalUser
+                sortBy="percentage"
+              />
+              <Narrative>
+                Grafik POLSEK menggambarkan distribusi komentar antar user dari
+                setiap polsek serta total komentar yang berhasil dikumpulkan.
+              </Narrative>
             </div>
+          )}
+
+          <div className="flex flex-wrap justify-end gap-3">
+            <button
+              onClick={handleCopyRekap}
+              className="group flex items-center gap-2 rounded-2xl border border-emerald-400/40 bg-emerald-500/10 px-6 py-3 text-sm font-semibold uppercase tracking-widest text-emerald-200 shadow-[0_0_25px_rgba(16,185,129,0.25)] transition hover:border-emerald-300/70 hover:bg-emerald-400/20"
+            >
+              <Copy className="h-4 w-4" />
+              Rekap Komentar
+            </button>
+            <Link
+              href="/comments/tiktok/rekap"
+              className="group flex items-center gap-2 rounded-2xl border border-fuchsia-400/40 bg-fuchsia-500/10 px-6 py-3 text-sm font-semibold uppercase tracking-widest text-fuchsia-200 shadow-[0_0_25px_rgba(217,70,239,0.25)] transition hover:border-fuchsia-300/70 hover:bg-fuchsia-500/20"
+            >
+              <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-1" />
+              Lihat Rekap Detail
+            </Link>
           </div>
         </div>
       </div>
@@ -608,8 +630,13 @@ function ChartBox({
   sortBy,
 }) {
   return (
-    <div className="bg-white rounded-xl shadow p-4">
-      <div className="font-bold text-pink-700 mb-2 text-center">{title}</div>
+    <div className="relative overflow-hidden rounded-3xl border border-slate-800/80 bg-slate-900/70 p-5 shadow-[0_0_32px_rgba(30,64,175,0.25)]">
+      <div className="absolute inset-x-6 top-0 h-20 rounded-full bg-gradient-to-b from-white/10 to-transparent blur-2xl" />
+      <div className="relative text-center">
+        <div className="mb-4 text-xs font-semibold uppercase tracking-[0.4em] text-slate-400">
+          {title}
+        </div>
+      </div>
       {users && users.length > 0 ? (
         <ChartDivisiAbsensi
           users={users}
@@ -627,7 +654,9 @@ function ChartBox({
           sortBy={sortBy}
         />
       ) : (
-        <div className="text-center text-gray-400 text-sm">Tidak ada data</div>
+        <div className="rounded-2xl border border-slate-800/60 bg-slate-950/60 px-4 py-6 text-center text-sm text-slate-400">
+          Tidak ada data
+        </div>
       )}
       {narrative && <Narrative>{narrative}</Narrative>}
     </div>
@@ -635,14 +664,45 @@ function ChartBox({
 }
 
 function SummaryItem({ label, value, color = "gray", icon, percentage }) {
-  const colorMap = {
-    fuchsia: { text: "text-fuchsia-700", bar: "bg-fuchsia-500" },
-    green: { text: "text-green-600", bar: "bg-green-500" },
-    red: { text: "text-red-500", bar: "bg-red-500" },
-    gray: { text: "text-gray-700", bar: "bg-gray-500" },
-    orange: { text: "text-orange-500", bar: "bg-orange-500" },
+  const palettes = {
+    fuchsia: {
+      icon: "text-fuchsia-300",
+      border: "border-fuchsia-500/40",
+      glow: "from-fuchsia-500/20 via-fuchsia-500/10 to-transparent",
+      bar: "from-fuchsia-400 to-pink-500",
+    },
+    green: {
+      icon: "text-emerald-300",
+      border: "border-emerald-500/40",
+      glow: "from-emerald-500/20 via-emerald-500/10 to-transparent",
+      bar: "from-emerald-400 to-lime-400",
+    },
+    red: {
+      icon: "text-rose-300",
+      border: "border-rose-500/40",
+      glow: "from-rose-500/25 via-rose-500/10 to-transparent",
+      bar: "from-rose-400 to-orange-400",
+    },
+    amber: {
+      icon: "text-amber-200",
+      border: "border-amber-400/40",
+      glow: "from-amber-400/20 via-amber-500/10 to-transparent",
+      bar: "from-amber-300 to-orange-400",
+    },
+    violet: {
+      icon: "text-violet-300",
+      border: "border-violet-500/40",
+      glow: "from-violet-500/20 via-violet-500/10 to-transparent",
+      bar: "from-violet-400 to-purple-500",
+    },
+    slate: {
+      icon: "text-slate-300",
+      border: "border-slate-500/40",
+      glow: "from-slate-500/20 via-slate-500/10 to-transparent",
+      bar: "from-slate-300 to-slate-400",
+    },
   };
-  const displayColor = colorMap[color] || colorMap.gray;
+  const palette = palettes[color] || palettes.slate;
   const formattedPercentage =
     typeof percentage === "number" && !Number.isNaN(percentage)
       ? `${percentage.toFixed(1).replace(".0", "")} %`
@@ -651,38 +711,67 @@ function SummaryItem({ label, value, color = "gray", icon, percentage }) {
     typeof percentage === "number"
       ? `${Math.min(100, Math.max(0, percentage))}%`
       : "0%";
+  const iconElement = icon
+    ? cloneElement(icon, {
+        className: cn(
+          "h-6 w-6",
+          palette.icon,
+          icon.props?.className,
+        ),
+      })
+    : null;
+
   return (
-    <div className="flex-1 flex flex-col items-center justify-center py-2">
-      <div className="mb-1">{icon}</div>
-      <div className={`text-3xl md:text-4xl font-bold ${displayColor.text}`}>
-        {value}
-      </div>
-      <div className="text-xs md:text-sm font-semibold text-gray-500 mt-1 uppercase tracking-wide text-center">
-        {label}
-      </div>
-      {formattedPercentage && (
-        <div className="mt-1 flex flex-col items-center gap-1 w-full max-w-[160px]">
-          <span className="text-[11px] md:text-xs font-medium text-gray-600">
-            {formattedPercentage}
-          </span>
-          <div className="h-1.5 w-full rounded-full bg-gray-200">
-            <div
-              className={`h-full rounded-full transition-all duration-300 ease-out ${displayColor.bar}`}
-              style={{ width: progressWidth }}
-              role="progressbar"
-              aria-valuenow={Math.round(Number(percentage) || 0)}
-              aria-valuemin={0}
-              aria-valuemax={100}
-              aria-label={`${label} ${formattedPercentage}`}
-            />
+    <div className="relative overflow-hidden rounded-3xl border border-slate-800/70 bg-slate-900/70 p-5 shadow-[0_0_24px_rgba(30,64,175,0.25)] transition duration-300 hover:-translate-y-1 hover:shadow-[0_0_36px_rgba(34,211,238,0.25)]">
+      <div
+        className={cn(
+          "pointer-events-none absolute inset-px rounded-[1.35rem] bg-gradient-to-br opacity-70 blur-2xl",
+          palette.glow,
+        )}
+      />
+      <div className="relative flex flex-col gap-3">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <span className="flex h-11 w-11 items-center justify-center rounded-2xl bg-slate-950/80">
+              {iconElement}
+            </span>
+            <div className="text-[11px] font-semibold uppercase tracking-[0.35em] text-slate-400">
+              {label}
+            </div>
           </div>
+          <span
+            className={cn(
+              "h-10 w-10 rounded-full border bg-slate-950/70",
+              palette.border,
+            )}
+          />
         </div>
-      )}
+        <div className="text-3xl font-semibold text-slate-50 md:text-4xl">
+          {value}
+        </div>
+        {formattedPercentage && (
+          <div className="mt-1 flex flex-col gap-2">
+            <span className="text-[11px] font-medium text-slate-300">
+              {formattedPercentage}
+            </span>
+            <div className="h-1.5 w-full rounded-full bg-slate-800/80">
+              <div
+                className={cn(
+                  "h-full rounded-full bg-gradient-to-r",
+                  palette.bar,
+                )}
+                style={{ width: progressWidth }}
+                role="progressbar"
+                aria-valuenow={Math.round(Number(percentage) || 0)}
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-label={`${label} ${formattedPercentage}`}
+              />
+            </div>
+          </div>
+        )}
+      </div>
     </div>
   );
-}
-
-function Divider() {
-  return <div className="hidden md:block w-px bg-gray-200 mx-2 my-2"></div>;
 }
 

--- a/cicero-dashboard/app/comments/tiktok/rekap/page.jsx
+++ b/cicero-dashboard/app/comments/tiktok/rekap/page.jsx
@@ -241,45 +241,72 @@ export default function RekapKomentarTiktokPage() {
   if (loading) return <Loader />;
   if (error)
     return (
-      <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100 p-4">
-        <div className="bg-white rounded-lg shadow-md p-6 text-center text-red-500 font-bold">
-          {error}
+      <div className="flex min-h-screen items-center justify-center bg-slate-950 p-6 text-slate-100">
+        <div className="relative w-full max-w-lg overflow-hidden rounded-3xl border border-rose-500/40 bg-slate-900/80 p-8 text-center shadow-[0_0_40px_rgba(244,63,94,0.25)]">
+          <div className="absolute inset-x-12 -top-8 h-24 rounded-full bg-gradient-to-b from-rose-500/30 to-transparent blur-2xl" />
+          <div className="relative space-y-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.4em] text-rose-200/80">
+              System Alert
+            </p>
+            <p className="text-lg font-semibold text-rose-100">{error}</p>
+            <p className="text-sm text-slate-300">
+              Coba muat ulang halaman atau periksa kembali koneksi data Anda.
+            </p>
+          </div>
         </div>
       </div>
     );
 
   return (
-    <div className="min-h-screen bg-gray-100">
-      <div className="p-4 md:p-8 max-w-6xl mx-auto w-full">
-        <div className="flex flex-col gap-6">
-          <div className="flex items-center justify-between mb-2">
-            <h1 className="text-2xl md:text-3xl font-bold text-pink-700">
-              Rekapitulasi Komentar TikTok
-            </h1>
-            <Link
-              href="/comments/tiktok"
-              className="inline-block bg-gray-100 hover:bg-pink-50 text-pink-700 border border-pink-300 font-semibold px-4 py-2 rounded-lg transition-all duration-150 shadow flex items-center gap-2"
-            >
-              <ArrowLeft className="w-4 h-4" />
-              Kembali
-            </Link>
-          </div>
-          <div className="flex flex-wrap items-center justify-start md:justify-end gap-3 mb-2">
-            <ViewDataSelector
-              value={viewBy}
-              onChange={handleViewChange}
-              options={viewOptions}
-              date={selectorDateValue}
-              onDateChange={handleDateChange}
-            />
+    <div className="relative min-h-screen overflow-hidden bg-slate-950 text-slate-100">
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute -left-32 top-[-100px] h-[360px] w-[360px] rounded-full bg-fuchsia-500/20 blur-[150px]" />
+        <div className="absolute right-[-120px] top-1/4 h-[400px] w-[400px] rounded-full bg-cyan-500/20 blur-[160px]" />
+        <div className="absolute inset-x-0 bottom-[-200px] h-[320px] bg-gradient-to-t from-slate-900 via-slate-950/60 to-transparent" />
+      </div>
+      <div className="relative z-10 mx-auto flex w-full max-w-6xl flex-col gap-8 px-4 pb-16 pt-10 sm:px-6 lg:px-10">
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-3">
+            <span className="inline-flex w-fit items-center gap-2 rounded-full border border-fuchsia-400/40 bg-fuchsia-500/10 px-4 py-1 text-[11px] font-semibold uppercase tracking-[0.4em] text-fuchsia-200">
+              Rekap Komentar
+            </span>
+            <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+              <div className="space-y-2">
+                <h1 className="text-3xl font-semibold leading-tight text-slate-50 md:text-4xl">
+                  Rekapitulasi Komentar TikTok
+                </h1>
+                <p className="max-w-3xl text-sm text-slate-300 md:text-base">
+                  Selaraskan laporan komentar harian hingga rentang tanggal tertentu.
+                  Panel rekap memberikan ringkasan kepatuhan serta detail pengguna
+                  sehingga Anda bisa menindaklanjuti satuan yang belum aktif.
+                </p>
+              </div>
+              <Link
+                href="/comments/tiktok"
+                className="group inline-flex items-center gap-2 rounded-2xl border border-slate-700/70 bg-slate-900/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-slate-200 transition hover:border-fuchsia-400/60 hover:bg-fuchsia-500/10"
+              >
+                <ArrowLeft className="h-4 w-4 transition-transform group-hover:-translate-x-1" />
+                Kembali
+              </Link>
+            </div>
           </div>
 
-          {/* Kirim data ke komponen detail rekap TikTok */}
-          <RekapKomentarTiktok
-            users={chartData}
-            totalTiktokPost={rekapSummary.totalTiktokPost}
+          <ViewDataSelector
+            value={viewBy}
+            onChange={handleViewChange}
+            options={viewOptions}
+            date={selectorDateValue}
+            onDateChange={handleDateChange}
+            className="justify-start gap-3 rounded-3xl border border-slate-800/70 bg-slate-900/70 px-4 py-4 backdrop-blur"
+            labelClassName="text-xs font-semibold uppercase tracking-[0.35em] text-slate-400/90"
+            controlClassName="border-slate-700/60 bg-slate-900/70 text-slate-100 focus:border-fuchsia-400 focus:outline-none focus:ring-2 focus:ring-fuchsia-500/30"
           />
         </div>
+
+        <RekapKomentarTiktok
+          users={chartData}
+          totalTiktokPost={rekapSummary.totalTiktokPost}
+        />
       </div>
     </div>
   );

--- a/cicero-dashboard/components/RekapKomentarTiktok.jsx
+++ b/cicero-dashboard/components/RekapKomentarTiktok.jsx
@@ -1,8 +1,9 @@
 "use client";
-import { useMemo, useEffect, useState } from "react";
+import { cloneElement, useMemo, useEffect, useState } from "react";
 import usePersistentState from "@/hooks/usePersistentState";
 import { AlertTriangle, Music, User, Check, X, Minus, UserX } from "lucide-react";
 import { showToast } from "@/utils/showToast";
+import { cn } from "@/lib/utils";
 
 function bersihkanSatfung(divisi = "") {
   return divisi
@@ -123,8 +124,10 @@ export default function RekapKomentarTiktok({ users = [], totalTiktokPost = 0 })
         message: "Tidak ada data komentar TikTok yang tersedia untuk periode ini.",
         description:
           "Silakan cek kembali periode laporan atau pastikan sumber data sudah terhubung.",
-        containerClass: "bg-amber-50 border border-amber-200 text-amber-700",
-        badgeClass: "bg-amber-500/20 border border-amber-400/60 text-amber-700",
+        containerClass:
+          "border border-fuchsia-500/30 bg-slate-950/60 text-slate-200 backdrop-blur",
+        badgeClass:
+          "bg-fuchsia-500/10 border border-fuchsia-400/40 text-fuchsia-200",
       }
     : showSearchEmptyState
     ? {
@@ -134,8 +137,10 @@ export default function RekapKomentarTiktok({ users = [], totalTiktokPost = 0 })
             ? `Hasil pencarian untuk “${trimmedSearch}” tidak ditemukan.`
             : "Tidak ada data yang cocok dengan filter saat ini.",
         description: "Coba ubah kata kunci atau atur ulang filter pencarian.",
-        containerClass: "bg-indigo-50 border border-indigo-200 text-indigo-700",
-        badgeClass: "bg-indigo-500/10 border border-indigo-400/50 text-indigo-700",
+        containerClass:
+          "border border-cyan-500/30 bg-slate-950/60 text-slate-200 backdrop-blur",
+        badgeClass:
+          "bg-cyan-500/10 border border-cyan-400/40 text-cyan-200",
       }
     : null;
   useEffect(() => setPage(1), [search, setPage]);
@@ -365,56 +370,56 @@ export default function RekapKomentarTiktok({ users = [], totalTiktokPost = 0 })
   }
 
   return (
-    <div className="flex flex-col gap-6 mt-8 min-h-screen pb-24">
-      <div className="grid grid-cols-1 md:grid-cols-6 gap-4">
+    <div className="relative mt-10 flex flex-col gap-10 pb-24">
+      <div className="grid gap-4 md:grid-cols-3 xl:grid-cols-6">
         <SummaryCard
-          title="TikTok Post Hari Ini"
+          title="TikTok Post Aktif"
           value={totalTiktokPostCount}
-          color="bg-gradient-to-r from-pink-400 via-fuchsia-400 to-blue-400 text-white"
-          icon={<Music className="h-7 w-7" />}
+          tone="fuchsia"
+          icon={<Music className="h-6 w-6" />}
         />
         <SummaryCard
-          title="Total User"
+          title="Total Personel"
           value={totalUser}
-          color="bg-gradient-to-r from-blue-400 via-blue-500 to-sky-400 text-white"
-          icon={<User className="h-7 w-7" />}
+          tone="slate"
+          icon={<User className="h-6 w-6" />}
         />
         <SummaryCard
           title="Sudah Komentar"
           value={totalSudahKomentar}
-          color="bg-gradient-to-r from-green-400 via-green-500 to-lime-400 text-white"
-          icon={<Check className="h-7 w-7" />}
+          tone="emerald"
+          icon={<Check className="h-6 w-6" />}
           percentage={getPercentage(totalSudahKomentar)}
         />
         <SummaryCard
           title="Kurang Komentar"
           value={totalKurangKomentar}
-          color="bg-gradient-to-r from-yellow-400 via-orange-500 to-orange-600 text-white"
-          icon={<AlertTriangle className="h-7 w-7" />}
+          tone="amber"
+          icon={<AlertTriangle className="h-6 w-6" />}
           percentage={getPercentage(totalKurangKomentar)}
         />
         <SummaryCard
           title="Belum Komentar"
           value={totalBelumKomentar}
-          color="bg-gradient-to-r from-red-400 via-pink-500 to-yellow-400 text-white"
-          icon={<X className="h-7 w-7" />}
+          tone="rose"
+          icon={<X className="h-6 w-6" />}
           percentage={getPercentage(totalBelumKomentar)}
         />
         <SummaryCard
           title="Tanpa Username"
           value={totalTanpaUsername}
-          color="bg-gradient-to-r from-gray-300 via-gray-400 to-gray-500 text-gray-800"
-          icon={<UserX className="h-7 w-7" />}
+          tone="violet"
+          icon={<UserX className="h-6 w-6" />}
           percentage={getPercentage(totalTanpaUsername, totalUser)}
         />
       </div>
       {tidakAdaPost && (
-        <p className="text-xs text-gray-500 italic text-center md:text-right">
+        <p className="text-xs text-slate-400 text-center md:text-right">
           Tidak ada posting aktif. Tidak diperlukan aksi komentar.
         </p>
       )}
 
-      <div className="flex justify-end mb-2">
+      <div className="flex justify-end">
         <div className="flex flex-col items-end">
           <label htmlFor={searchInputId} className="sr-only">
             Cari komentar TikTok
@@ -431,7 +436,7 @@ export default function RekapKomentarTiktok({ users = [], totalTiktokPost = 0 })
                 : "Cari nama, username, atau divisi"
             }
             aria-describedby={searchHelpId}
-            className="px-3 py-2 border rounded-lg text-sm w-64 shadow focus:outline-none focus:ring-2 focus:ring-pink-300"
+            className="w-full rounded-2xl border border-slate-800/70 bg-slate-900/70 px-3 py-2 text-sm text-slate-100 placeholder-slate-500 shadow focus:border-fuchsia-400 focus:outline-none focus:ring-2 focus:ring-fuchsia-500/30 sm:w-72"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
           />
@@ -439,23 +444,27 @@ export default function RekapKomentarTiktok({ users = [], totalTiktokPost = 0 })
       </div>
 
       {tidakAdaPost && (
-        <div className="rounded-xl border border-gray-200 bg-gray-50 px-4 py-3 text-sm text-gray-700">
+        <div className="rounded-3xl border border-slate-800/70 bg-slate-900/70 px-4 py-3 text-sm text-slate-300">
           Tidak ada posting TikTok yang perlu dikomentari hari ini. Tim kamu bisa
           beristirahat sejenak.
         </div>
       )}
 
-      <div className="relative overflow-x-auto rounded-xl shadow">
-        <table className="w-full text-sm text-left">
-          <thead className="sticky top-0 bg-gray-50 z-10">
+      <div className="relative overflow-x-auto rounded-3xl border border-slate-800/70 bg-slate-900/60 shadow-[0_0_32px_rgba(15,118,110,0.2)]">
+        <table className="w-full text-left text-sm text-slate-200">
+          <thead className="sticky top-0 z-10 bg-slate-950/80 backdrop-blur">
             <tr>
-              <th className="py-2 px-2">No</th>
-              <th className="py-2 px-2">Satker</th>
-              <th className="py-2 px-2">Nama</th>
-              <th className="py-2 px-2">Username tiktok</th>
-              <th className="py-2 px-2">Divisi/Satfung</th>
-              <th className="py-2 px-2 text-center">Status</th>
-              <th className="py-2 px-2 text-center">Jumlah Komentar</th>
+              <th className="py-3 px-3 text-xs font-semibold uppercase tracking-widest text-slate-400">No</th>
+              <th className="py-3 px-3 text-xs font-semibold uppercase tracking-widest text-slate-400">Satker</th>
+              <th className="py-3 px-3 text-xs font-semibold uppercase tracking-widest text-slate-400">Nama</th>
+              <th className="py-3 px-3 text-xs font-semibold uppercase tracking-widest text-slate-400">Username TikTok</th>
+              <th className="py-3 px-3 text-xs font-semibold uppercase tracking-widest text-slate-400">Divisi/Satfung</th>
+              <th className="py-3 px-3 text-center text-xs font-semibold uppercase tracking-widest text-slate-400">
+                Status
+              </th>
+              <th className="py-3 px-3 text-center text-xs font-semibold uppercase tracking-widest text-slate-400">
+                Jumlah Komentar
+              </th>
             </tr>
           </thead>
           <tbody>
@@ -463,10 +472,10 @@ export default function RekapKomentarTiktok({ users = [], totalTiktokPost = 0 })
               <tr>
                 <td colSpan={7} className="py-10 px-4">
                   <div
-                    className={`mx-auto flex max-w-xl flex-col items-center gap-3 rounded-2xl px-6 py-6 text-center text-sm shadow-inner ${emptyState.containerClass}`}
+                    className={`mx-auto flex max-w-xl flex-col items-center gap-3 rounded-3xl px-6 py-6 text-center text-sm shadow-inner ${emptyState.containerClass}`}
                   >
                     <span
-                      className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide ${emptyState.badgeClass}`}
+                      className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.35em] ${emptyState.badgeClass}`}
                     >
                       {emptyState.badge}
                     </span>
@@ -480,35 +489,39 @@ export default function RekapKomentarTiktok({ users = [], totalTiktokPost = 0 })
             ) : currentRows.map((u, i) => {
                 const sudahKomentar =
                   tidakAdaPost ? false : Number(u.jumlah_komentar) > 0;
+                const baseRowClass =
+                  "border-b border-slate-800/60 transition duration-150 hover:bg-slate-800/60";
                 const rowClass = tidakAdaPost
-                  ? "bg-gray-50"
+                  ? `bg-slate-900/60 ${baseRowClass}`
                   : sudahKomentar
-                  ? "bg-green-50"
-                  : "bg-red-50";
+                  ? `bg-emerald-500/10 ${baseRowClass}`
+                  : `bg-rose-500/10 ${baseRowClass}`;
                 const statusClass = tidakAdaPost
-                  ? "inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs bg-gray-400 text-white font-semibold"
+                  ? "inline-flex items-center gap-1 rounded-full border border-slate-600/70 bg-slate-800/80 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-300"
                   : sudahKomentar
-                  ? "inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs bg-green-500 text-white font-semibold"
-                  : "inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs bg-red-500 text-white font-semibold";
+                  ? "inline-flex items-center gap-1 rounded-full border border-emerald-500/50 bg-emerald-500/15 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-emerald-200"
+                  : "inline-flex items-center gap-1 rounded-full border border-rose-500/50 bg-rose-500/15 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-rose-200";
                 return (
                   <tr
                     key={u.user_id}
                     className={rowClass}
                   >
-                    <td className="py-1 px-2">{(page - 1) * PAGE_SIZE + i + 1}</td>
-                    <td className="py-1 px-2">
+                    <td className="py-3 px-3 text-slate-400">{(page - 1) * PAGE_SIZE + i + 1}</td>
+                    <td className="py-3 px-3">
                       {u.nama_client || u.client_name || u.client || u.client_id || "-"}
                     </td>
-                    <td className="py-1 px-2">
+                    <td className="py-3 px-3">
                       {u.title ? `${u.title} ${u.nama}` : u.nama}
                     </td>
-                    <td className="py-1 px-2 font-mono text-pink-700">{u.username}</td>
-                    <td className="py-1 px-2">
-                      <span className="inline-block px-2 py-0.5 rounded bg-sky-100 text-sky-800 font-medium">
+                    <td className="py-3 px-3 font-mono text-fuchsia-300">
+                      {u.username}
+                    </td>
+                    <td className="py-3 px-3">
+                      <span className="inline-flex items-center gap-2 rounded-full border border-sky-500/40 bg-sky-500/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-sky-200">
                         {bersihkanSatfung(u.divisi || "-")}
                       </span>
                     </td>
-                    <td className="py-1 px-2 text-center">
+                    <td className="py-3 px-3 text-center">
                       <span className={statusClass}>
                         {tidakAdaPost ? (
                           <>
@@ -528,7 +541,7 @@ export default function RekapKomentarTiktok({ users = [], totalTiktokPost = 0 })
                         )}
                       </span>
                     </td>
-                    <td className="py-1 px-2 text-center font-bold">
+                    <td className="py-3 px-3 text-center text-lg font-semibold text-slate-50">
                       {tidakAdaPost ? "-" : u.jumlah_komentar}
                     </td>
                   </tr>
@@ -537,25 +550,25 @@ export default function RekapKomentarTiktok({ users = [], totalTiktokPost = 0 })
           </tbody>
         </table>
       </div>
-      <p className="mt-2 text-sm text-gray-500 italic">
+      <p className="mt-2 text-sm text-slate-400">
         Tabel ini merangkum status komentar TikTok setiap user dan total jumlah
         komentar yang diberikan.
       </p>
 
       {totalPages > 1 && (
-        <div className="flex items-center justify-between mt-4">
+        <div className="mt-6 flex items-center justify-between">
           <button
-            className="px-3 py-1 rounded bg-gray-200 hover:bg-gray-300 text-gray-700 font-semibold disabled:opacity-50"
+            className="rounded-full border border-slate-700/60 bg-slate-900/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-200 transition hover:border-cyan-400/60 hover:bg-cyan-500/10 disabled:opacity-40 disabled:hover:bg-slate-900/70"
             disabled={page === 1}
             onClick={() => setPage(p => Math.max(1, p - 1))}
           >
             Prev
           </button>
-          <span className="text-sm text-gray-600">
+          <span className="text-sm text-slate-300">
             Halaman <b>{page}</b> dari <b>{totalPages}</b>
           </span>
           <button
-            className="px-3 py-1 rounded bg-gray-200 hover:bg-gray-300 text-gray-700 font-semibold disabled:opacity-50"
+            className="rounded-full border border-slate-700/60 bg-slate-900/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-200 transition hover:border-cyan-400/60 hover:bg-cyan-500/10 disabled:opacity-40 disabled:hover:bg-slate-900/70"
             disabled={page === totalPages}
             onClick={() => setPage(p => Math.min(totalPages, p + 1))}
           >
@@ -564,17 +577,17 @@ export default function RekapKomentarTiktok({ users = [], totalTiktokPost = 0 })
         </div>
       )}
 
-      <div className="sticky bottom-4 z-20 flex w-full justify-end px-4">
-        <div className="flex w-full max-w-xl flex-col gap-2 rounded-2xl border border-pink-200 bg-white/95 p-3 shadow-xl backdrop-blur-sm sm:flex-row sm:items-center">
+      <div className="sticky bottom-6 z-20 flex w-full justify-end px-4">
+        <div className="flex w-full max-w-xl flex-col gap-2 rounded-3xl border border-slate-700/60 bg-slate-900/80 p-4 shadow-[0_0_32px_rgba(217,70,239,0.25)] backdrop-blur-sm sm:flex-row sm:items-center">
           <button
             onClick={handleDownloadRekap}
-            className="w-full px-4 py-2 bg-green-600 hover:bg-green-700 text-white rounded-lg shadow sm:w-auto"
+            className="w-full rounded-2xl border border-emerald-400/40 bg-emerald-500/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-emerald-200 transition hover:border-emerald-300/60 hover:bg-emerald-400/20 sm:w-auto"
           >
             Download Rekap
           </button>
           <button
             onClick={handleCopyRekap}
-            className="w-full px-4 py-2 bg-pink-600 hover:bg-pink-700 text-white rounded-lg shadow sm:w-auto"
+            className="w-full rounded-2xl border border-fuchsia-400/40 bg-fuchsia-500/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-fuchsia-200 transition hover:border-fuchsia-300/60 hover:bg-fuchsia-500/20 sm:w-auto"
           >
             Salin Rekap
           </button>
@@ -584,7 +597,46 @@ export default function RekapKomentarTiktok({ users = [], totalTiktokPost = 0 })
   );
 }
 
-function SummaryCard({ title, value, color, icon, percentage }) {
+function SummaryCard({ title, value, icon, percentage, tone = "slate" }) {
+  const palettes = {
+    fuchsia: {
+      icon: "text-fuchsia-300",
+      border: "border-fuchsia-500/40",
+      glow: "from-fuchsia-500/25 via-fuchsia-500/10 to-transparent",
+      bar: "from-fuchsia-400 to-pink-500",
+    },
+    emerald: {
+      icon: "text-emerald-300",
+      border: "border-emerald-500/40",
+      glow: "from-emerald-500/25 via-emerald-500/10 to-transparent",
+      bar: "from-emerald-400 to-lime-400",
+    },
+    amber: {
+      icon: "text-amber-200",
+      border: "border-amber-400/40",
+      glow: "from-amber-400/20 via-amber-500/10 to-transparent",
+      bar: "from-amber-300 to-orange-400",
+    },
+    rose: {
+      icon: "text-rose-300",
+      border: "border-rose-500/40",
+      glow: "from-rose-500/20 via-rose-500/10 to-transparent",
+      bar: "from-rose-400 to-amber-400",
+    },
+    violet: {
+      icon: "text-violet-300",
+      border: "border-violet-500/40",
+      glow: "from-violet-500/20 via-violet-500/10 to-transparent",
+      bar: "from-violet-400 to-purple-500",
+    },
+    slate: {
+      icon: "text-slate-300",
+      border: "border-slate-500/40",
+      glow: "from-slate-500/20 via-slate-500/10 to-transparent",
+      bar: "from-slate-300 to-slate-400",
+    },
+  };
+  const palette = palettes[tone] || palettes.slate;
   const formattedPercentage =
     typeof percentage === "number" && !Number.isNaN(percentage)
       ? `${percentage.toFixed(1).replace(".0", "")}%`
@@ -593,43 +645,52 @@ function SummaryCard({ title, value, color, icon, percentage }) {
     typeof percentage === "number"
       ? Math.min(100, Math.max(0, percentage))
       : 0;
-  const hasDarkText = /text-(gray|slate|zinc)-(8|9)00/.test(color);
-  const labelTextClass = hasDarkText ? "text-gray-900" : "text-white";
-  const percentageTextClass = hasDarkText ? "text-gray-900/80" : "text-white/80";
-  const progressBackground = hasDarkText ? "bg-gray-300/80" : "bg-white/30";
-  const progressFill = hasDarkText ? "bg-gray-700" : "bg-white";
+  const iconElement = icon
+    ? cloneElement(icon, {
+        className: cn("h-7 w-7", palette.icon, icon.props?.className),
+      })
+    : null;
 
   return (
-    <div
-      className={`rounded-2xl shadow-md p-6 flex flex-col items-center gap-2 text-center ${color}`}
-    >
-      <div className="flex items-center gap-2 text-3xl font-bold">
-        {icon}
-        <span>{value}</span>
-      </div>
+    <div className="relative overflow-hidden rounded-3xl border border-slate-800/70 bg-slate-900/70 p-5 text-center shadow-[0_0_32px_rgba(30,64,175,0.25)]">
       <div
-        className={`text-xs mt-1 font-semibold uppercase tracking-wider ${labelTextClass}`}
-      >
-        {title}
-      </div>
-      {formattedPercentage && (
-        <div className="mt-1 flex flex-col items-center gap-1 w-full max-w-[180px]">
-          <span className={`text-[11px] font-medium ${percentageTextClass}`}>
-            {formattedPercentage}
-          </span>
-          <div className={`h-1.5 w-full rounded-full ${progressBackground}`}>
-            <div
-              className={`h-full rounded-full transition-all duration-300 ease-out ${progressFill}`}
-              style={{ width: `${clampedPercentage}%` }}
-              role="progressbar"
-              aria-valuenow={Math.round(Number(percentage) || 0)}
-              aria-valuemin={0}
-              aria-valuemax={100}
-              aria-label={`${title} ${formattedPercentage}`}
-            />
-          </div>
+        className={cn(
+          "pointer-events-none absolute inset-px rounded-[1.35rem] bg-gradient-to-br opacity-70 blur-2xl",
+          palette.glow,
+        )}
+      />
+      <div className="relative flex flex-col items-center gap-2">
+        <div
+          className={cn(
+            "flex h-12 w-12 items-center justify-center rounded-2xl border bg-slate-950/70",
+            palette.border,
+          )}
+        >
+          {iconElement}
         </div>
-      )}
+        <div className="text-3xl font-semibold text-slate-50">{value}</div>
+        <div className="text-[11px] font-semibold uppercase tracking-[0.35em] text-slate-400">
+          {title}
+        </div>
+        {formattedPercentage && (
+          <div className="mt-2 flex w-full max-w-[180px] flex-col items-center gap-2">
+            <span className="text-[11px] font-medium text-slate-300">
+              {formattedPercentage}
+            </span>
+            <div className="h-1.5 w-full rounded-full bg-slate-800/80">
+              <div
+                className={cn("h-full rounded-full bg-gradient-to-r", palette.bar)}
+                style={{ width: `${clampedPercentage}%` }}
+                role="progressbar"
+                aria-valuenow={Math.round(Number(percentage) || 0)}
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-label={`${title} ${formattedPercentage}`}
+              />
+            </div>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/cicero-dashboard/components/ViewDataSelector.jsx
+++ b/cicero-dashboard/components/ViewDataSelector.jsx
@@ -1,5 +1,6 @@
 "use client";
 import { useId } from "react";
+import { cn } from "@/lib/utils";
 
 export const VIEW_OPTIONS = [
   { value: "today", label: "Hari ini", periode: "harian" },
@@ -57,6 +58,9 @@ export default function ViewDataSelector({
   onDateChange,
   options = VIEW_OPTIONS,
   disabled = false,
+  className,
+  controlClassName,
+  labelClassName,
 }) {
   const id = useId();
   const showDateInput = value === "date";
@@ -66,22 +70,28 @@ export default function ViewDataSelector({
   const monthInputId = `${id}-month`;
   const rangeStartId = `${id}-start`;
   const rangeEndId = `${id}-end`;
+  const baseContainerClass = cn(
+    "flex w-full flex-wrap items-center gap-2 justify-between sm:justify-start",
+    disabled && "opacity-60",
+    className,
+  );
+  const baseLabelClass = cn(
+    "text-sm font-semibold w-full sm:w-auto",
+    labelClassName,
+  );
+  const baseControlClass = cn(
+    "w-full rounded border px-2 py-1 text-sm transition sm:w-auto",
+    controlClassName,
+  );
+
   return (
-    <div
-      className={`flex flex-wrap items-center gap-2 justify-between sm:justify-start w-full ${
-        disabled ? "opacity-60" : ""
-      }`}
-      aria-disabled={disabled}
-    >
-      <label
-        htmlFor={id}
-        className="text-sm font-semibold w-full sm:w-auto"
-      >
+    <div className={baseContainerClass} aria-disabled={disabled}>
+      <label htmlFor={id} className={baseLabelClass}>
         View Data By:
       </label>
       <select
         id={id}
-        className="border rounded px-2 py-1 text-sm w-full sm:w-auto"
+        className={baseControlClass}
         value={value}
         onChange={(e) => onChange(e.target.value)}
         disabled={disabled}
@@ -100,7 +110,7 @@ export default function ViewDataSelector({
           <input
             id={dateInputId}
             type="date"
-            className="border rounded px-2 py-1 text-sm w-full sm:w-auto mt-2 sm:mt-0"
+            className={cn(baseControlClass, "mt-2 sm:mt-0")}
             value={date}
             onChange={(e) => onDateChange?.(e.target.value)}
             disabled={disabled}
@@ -115,7 +125,7 @@ export default function ViewDataSelector({
           <input
             id={monthInputId}
             type="month"
-            className="border rounded px-2 py-1 text-sm w-full sm:w-auto mt-2 sm:mt-0"
+            className={cn(baseControlClass, "mt-2 sm:mt-0")}
             value={date}
             onChange={(e) => onDateChange?.(e.target.value)}
             disabled={disabled}
@@ -130,7 +140,7 @@ export default function ViewDataSelector({
           <input
             id={rangeStartId}
             type="date"
-            className="border rounded px-2 py-1 text-sm w-full sm:w-auto mt-2 sm:mt-0"
+            className={cn(baseControlClass, "mt-2 sm:mt-0")}
             value={date?.startDate || ""}
             onChange={(e) =>
               onDateChange?.({ ...date, startDate: e.target.value })
@@ -143,7 +153,7 @@ export default function ViewDataSelector({
           <input
             id={rangeEndId}
             type="date"
-            className="border rounded px-2 py-1 text-sm w-full sm:w-auto mt-2 sm:mt-0"
+            className={cn(baseControlClass, "mt-2 sm:mt-0")}
             value={date?.endDate || ""}
             onChange={(e) =>
               onDateChange?.({ ...date, endDate: e.target.value })


### PR DESCRIPTION
## Summary
- redesign the TikTok comments dashboard with a neon-futuristic shell, refreshed hero, and glowing KPI cards
- restyle the TikTok comments recap page to align with the dashboard aesthetic and expose configurable view selector controls
- overhaul the recap detail table and summary widgets with dark glassmorphism styling, richer badges, and reusable ViewDataSelector options

## Testing
- npm run lint *(fails: prompts for ESLint configuration in this repo)*

------
https://chatgpt.com/codex/tasks/task_e_68d40c2df2ec8327b2af0d1ea0eb9776