### PR TITLE
Add executive summary page with PPT export

### DIFF
--- a/cicero-dashboard/app/executive-summary/page.jsx
+++ b/cicero-dashboard/app/executive-summary/page.jsx
@@ -1,0 +1,642 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+  LabelList,
+  PieChart,
+  Pie,
+  Cell,
+} from "recharts";
+import { Download } from "lucide-react";
+import pptxgen from "pptxgenjs";
+import useRequireAuth from "@/hooks/useRequireAuth";
+import { Button } from "@/components/ui/button";
+
+const formatNumber = (value, options = {}) => {
+  const formatter = new Intl.NumberFormat("id-ID", {
+    maximumFractionDigits: options.maximumFractionDigits ?? 1,
+    minimumFractionDigits: options.minimumFractionDigits ?? 0,
+  });
+  return formatter.format(value ?? 0);
+};
+
+const monthlyData = {
+  "2024-11": {
+    monthLabel: "November 2024",
+    summaryMetrics: [
+      { label: "Total Reach", value: 184320, change: "+8,4%" },
+      { label: "Engagement Rate", value: 6.2, suffix: "%", change: "+0,9 pts" },
+      { label: "Konten Dipublikasikan", value: 76, change: "-4 konten" },
+      { label: "Sentimen Positif", value: 62, suffix: "%", change: "+5 pts" },
+    ],
+    overviewNarrative:
+      "Momentum kampanye pengamanan Nataru menghasilkan peningkatan reach dan engagement lintas kanal, sementara sentimen publik tetap dikelola secara positif.",
+    dashboardNarrative:
+      "Traffic dashboard menunjukkan lonjakan impresi sebesar 8% dibanding bulan sebelumnya, dipicu oleh konten sinergi pengamanan libur panjang dan quick response terhadap isu lalu lintas.",
+    userInsightNarrative:
+      "83% admin aktif melakukan monitoring harian dan 61% di antaranya memanfaatkan fitur alert. Divisi Humas tetap menjadi kontributor utama percakapan dengan pertumbuhan partisipasi 6%.",
+    instagramNarrative:
+      "Instagram fokus pada storytelling humanis. Konten carousel edukasi keselamatan meraih reach tertinggi dengan 7,4% engagement rate dan menyumbang 31% dari total interaksi.",
+    tiktokNarrative:
+      "Tiktok menonjolkan konten video cepat seputar himbauan lalu lintas. Format duet dengan influencer lokal menaikkan completion rate hingga 68% dan memperluas jangkauan Gen-Z.",
+    engagementByChannel: [
+      { channel: "Instagram", reach: 112300, engagementRate: 7.4 },
+      { channel: "TikTok", reach: 54020, engagementRate: 6.1 },
+      { channel: "Facebook", reach: 17900, engagementRate: 3.8 },
+    ],
+    audienceComposition: [
+      { name: "Masyarakat Umum", value: 52 },
+      { name: "Komunitas Lokal", value: 23 },
+      { name: "Media", value: 15 },
+      { name: "Internal", value: 10 },
+    ],
+    highlights: [
+      "Kampanye #OperasiLilin2024 mendominasi percakapan positif selama 10 hari berturut-turut.",
+      "Respons cepat terhadap isu kemacetan arus balik menjaga sentimen negatif di bawah 12%.",
+      "Pemanfaatan fitur Q&A Instagram Live meningkatkan partisipasi komunitas hingga 18%.",
+    ],
+    userInsightMetrics: [
+      { label: "Admin Aktif Harian", value: 1230, change: "+6%" },
+      { label: "Alert Ditindaklanjuti", value: 214, change: "+12%" },
+      { label: "Respons Rata-rata", value: 37, suffix: "mnt", change: "-9 mnt" },
+    ],
+    contentTable: [
+      {
+        platform: "Instagram",
+        title: "Carousel Edukasi Keselamatan Nataru",
+        format: "Carousel",
+        reach: 48760,
+        engagement: 7.4,
+        takeaway: "Sorotan humanis keluarga petugas meningkatkan share",
+      },
+      {
+        platform: "Instagram",
+        title: "Reel Patroli Gabungan",
+        format: "Reel",
+        reach: 39210,
+        engagement: 6.8,
+        takeaway: "Cut-to-action cepat menjaga retention di atas 65%",
+      },
+      {
+        platform: "TikTok",
+        title: "Duet Influencer Himbauan Mudik",
+        format: "Video",
+        reach: 28940,
+        engagement: 6.1,
+        takeaway: "Kolaborasi lokal memperluas jangkauan Gen-Z",
+      },
+      {
+        platform: "TikTok",
+        title: "Tips Cek Kendaraan Sebelum Perjalanan",
+        format: "Video",
+        reach: 25110,
+        engagement: 5.6,
+        takeaway: "Format checklist visual memudahkan pemahaman",
+      },
+    ],
+  },
+  "2024-10": {
+    monthLabel: "Oktober 2024",
+    summaryMetrics: [
+      { label: "Total Reach", value: 169520, change: "+3,1%" },
+      { label: "Engagement Rate", value: 5.3, suffix: "%", change: "-0,4 pts" },
+      { label: "Konten Dipublikasikan", value: 82, change: "+7 konten" },
+      { label: "Sentimen Positif", value: 57, suffix: "%", change: "+2 pts" },
+    ],
+    overviewNarrative:
+      "Penetrasi program Bulan Tertib Berlalu Lintas memperluas awareness, namun engagement sedikit menurun karena penurunan interaksi video panjang.",
+    dashboardNarrative:
+      "Panel dashboard memperlihatkan pertumbuhan reach 3% dan dominasi trafik mobile sebesar 92%, menandakan konsumsi konten mayoritas terjadi di perjalanan.",
+    userInsightNarrative:
+      "Adopsi fitur scheduling meningkat 14% seiring koordinasi antar divisi. Sebanyak 76% admin konsisten menutup laporan harian tepat waktu.",
+    instagramNarrative:
+      "Instagram fokus pada edukasi visual. Postingan infografik rawan kecelakaan menjadi konten dengan save tertinggi dan menjaga engagement stabil.",
+    tiktokNarrative:
+      "TikTok mengeksplorasi format behind-the-scene operasi lapangan. Walau watch time stabil, call-to-action belum maksimal sehingga engagement turun tipis.",
+    engagementByChannel: [
+      { channel: "Instagram", reach: 102400, engagementRate: 6.1 },
+      { channel: "TikTok", reach: 46300, engagementRate: 5.2 },
+      { channel: "Facebook", reach: 20820, engagementRate: 3.5 },
+    ],
+    audienceComposition: [
+      { name: "Masyarakat Umum", value: 49 },
+      { name: "Komunitas Lokal", value: 25 },
+      { name: "Media", value: 14 },
+      { name: "Internal", value: 12 },
+    ],
+    highlights: [
+      "Program live report pengaturan lalu lintas mendapat 3,4 ribu komentar positif.",
+      "Penguatan cross-posting IG Stories ke TikTok meningkatkan traffic silang 11%.",
+      "Kolaborasi dengan Dishub memperbanyak mention organik.",
+    ],
+    userInsightMetrics: [
+      { label: "Admin Aktif Harian", value: 1160, change: "+4%" },
+      { label: "Alert Ditindaklanjuti", value: 191, change: "+5%" },
+      { label: "Respons Rata-rata", value: 42, suffix: "mnt", change: "-4 mnt" },
+    ],
+    contentTable: [
+      {
+        platform: "Instagram",
+        title: "Infografik Rawan Kecelakaan",
+        format: "Infografik",
+        reach: 42110,
+        engagement: 6.3,
+        takeaway: "CTA simpan peta meningkatkan saves 23%",
+      },
+      {
+        platform: "Instagram",
+        title: "Reel Testimoni Pemudik",
+        format: "Reel",
+        reach: 34780,
+        engagement: 5.9,
+        takeaway: "Kutipan nyata menjaga komentar positif",
+      },
+      {
+        platform: "TikTok",
+        title: "Behind the Scene Operasi Zebra",
+        format: "Video",
+        reach: 26140,
+        engagement: 5.1,
+        takeaway: "Butuh CTA jelas untuk arahkan traffic lanjutan",
+      },
+      {
+        platform: "TikTok",
+        title: "Tips Aman Berkendara Malam",
+        format: "Video",
+        reach: 23810,
+        engagement: 4.8,
+        takeaway: "Durasi 45 detik sedikit menurunkan completion",
+      },
+    ],
+  },
+  "2024-09": {
+    monthLabel: "September 2024",
+    summaryMetrics: [
+      { label: "Total Reach", value: 164420, change: "-5,2%" },
+      { label: "Engagement Rate", value: 5.7, suffix: "%", change: "+0,3 pts" },
+      { label: "Konten Dipublikasikan", value: 68, change: "-6 konten" },
+      { label: "Sentimen Positif", value: 54, suffix: "%", change: "-1 pt" },
+    ],
+    overviewNarrative:
+      "Transisi menuju fokus akhir tahun membuat volume konten lebih selektif, namun kualitas engagement tetap terjaga oleh kampanye keselamatan komunitas.",
+    dashboardNarrative:
+      "Dashboard menunjukkan trafik menurun 5%, didominasi jam sibuk pagi. Pengguna mengkonsumsi konten ringkas sehingga bounce rate turun ke 28%.",
+    userInsightNarrative:
+      "Pemanfaatan fitur knowledge base meningkat 21% dengan 312 pencarian internal. Hal ini membantu standar jawaban konsisten antar admin.",
+    instagramNarrative:
+      "Instagram mengedepankan konten komunitas. Live IG bersama relawan lalu lintas memicu lonjakan komentar dan pertanyaan relevan.",
+    tiktokNarrative:
+      "TikTok menerapkan format challenge #AmanBerkendara yang diikuti 480 user-generated content, menambah 4,6 ribu pengikut baru.",
+    engagementByChannel: [
+      { channel: "Instagram", reach: 96410, engagementRate: 5.9 },
+      { channel: "TikTok", reach: 41120, engagementRate: 5.4 },
+      { channel: "Facebook", reach: 26900, engagementRate: 3.1 },
+    ],
+    audienceComposition: [
+      { name: "Masyarakat Umum", value: 47 },
+      { name: "Komunitas Lokal", value: 27 },
+      { name: "Media", value: 13 },
+      { name: "Internal", value: 13 },
+    ],
+    highlights: [
+      "UGC challenge #AmanBerkendara menghasilkan 8,7 ribu mention organik.",
+      "Program literasi lalu lintas sekolah menumbuhkan follower baru 6%.",
+      "Sentimen negatif muncul dari isu kemacetan lokal dan telah tertangani.",
+    ],
+    userInsightMetrics: [
+      { label: "Admin Aktif Harian", value: 1085, change: "+3%" },
+      { label: "Alert Ditindaklanjuti", value: 176, change: "+8%" },
+      { label: "Respons Rata-rata", value: 48, suffix: "mnt", change: "-2 mnt" },
+    ],
+    contentTable: [
+      {
+        platform: "Instagram",
+        title: "Live Relawan Lalu Lintas",
+        format: "Live",
+        reach: 38240,
+        engagement: 6.1,
+        takeaway: "Kolaborasi komunitas meningkatkan pertanyaan edukatif",
+      },
+      {
+        platform: "Instagram",
+        title: "Carousel Tips Aman Konvoi",
+        format: "Carousel",
+        reach: 33110,
+        engagement: 5.7,
+        takeaway: "Checklist visual memicu simpan konten",
+      },
+      {
+        platform: "TikTok",
+        title: "Challenge #AmanBerkendara",
+        format: "Video",
+        reach: 28490,
+        engagement: 5.4,
+        takeaway: "UGC memperluas jangkauan komunitas",
+      },
+      {
+        platform: "TikTok",
+        title: "Quick Tips Lampu Hazard",
+        format: "Video",
+        reach: 23980,
+        engagement: 4.9,
+        takeaway: "Format 30 detik ideal untuk edukasi singkat",
+      },
+    ],
+  },
+};
+
+const PIE_COLORS = ["#22d3ee", "#6366f1", "#fbbf24", "#f43f5e"];
+
+export default function ExecutiveSummaryPage() {
+  useRequireAuth();
+  const monthKeys = Object.keys(monthlyData);
+  const [selectedMonth, setSelectedMonth] = useState(monthKeys[0]);
+
+  const data = monthlyData[selectedMonth];
+
+  const pptSummary = useMemo(() => {
+    return [
+      data.dashboardNarrative,
+      data.userInsightNarrative,
+      data.instagramNarrative,
+      data.tiktokNarrative,
+    ];
+  }, [data]);
+
+  const handleDownload = () => {
+    const pptx = new pptxgen();
+    pptx.layout = "LAYOUT_16x9";
+
+    const titleSlide = pptx.addSlide();
+    titleSlide.addText(`Executive Summary ${data.monthLabel}`, {
+      x: 0.5,
+      y: 1,
+      w: 9,
+      fontSize: 34,
+      bold: true,
+      color: "1F2937",
+    });
+    titleSlide.addText(data.overviewNarrative, {
+      x: 0.5,
+      y: 2.1,
+      w: 9,
+      fontSize: 18,
+      color: "334155",
+    });
+
+    const metricSlide = pptx.addSlide();
+    metricSlide.addText("Sorotan Kinerja", {
+      x: 0.5,
+      y: 0.4,
+      fontSize: 26,
+      bold: true,
+      color: "0f172a",
+    });
+    data.summaryMetrics.forEach((metric, index) => {
+      metricSlide.addText(metric.label, {
+        x: 0.5,
+        y: 1.2 + index * 1.1,
+        fontSize: 18,
+        color: "0369a1",
+      });
+      metricSlide.addText(
+        `${formatNumber(metric.value, { maximumFractionDigits: 1 })}${
+          metric.suffix ? metric.suffix : ""
+        }`,
+        {
+          x: 4.4,
+          y: 1.2 + index * 1.1,
+          fontSize: 20,
+          bold: true,
+          color: "0f172a",
+        },
+      );
+      metricSlide.addText(metric.change, {
+        x: 6.6,
+        y: 1.2 + index * 1.1,
+        fontSize: 16,
+        color: "059669",
+      });
+    });
+
+    const narrativeSlide = pptx.addSlide();
+    narrativeSlide.addText("Insight Naratif", {
+      x: 0.5,
+      y: 0.4,
+      fontSize: 26,
+      bold: true,
+      color: "0f172a",
+    });
+    pptSummary.forEach((item, idx) => {
+      narrativeSlide.addText(`• ${item}`, {
+        x: 0.5,
+        y: 1.1 + idx * 0.8,
+        w: 9,
+        fontSize: 18,
+        color: "1e293b",
+      });
+    });
+
+    const tableSlide = pptx.addSlide();
+    tableSlide.addText("Konten Terbaik", {
+      x: 0.5,
+      y: 0.4,
+      fontSize: 26,
+      bold: true,
+      color: "0f172a",
+    });
+    const tableData = [
+      ["Platform", "Judul", "Format", "Reach", "Engagement", "Takeaway"],
+      ...data.contentTable.map((row) => [
+        row.platform,
+        row.title,
+        row.format,
+        formatNumber(row.reach, { maximumFractionDigits: 0 }),
+        `${row.engagement}%`,
+        row.takeaway,
+      ]),
+    ];
+    tableSlide.addTable(tableData, {
+      x: 0.3,
+      y: 1.0,
+      w: 9.4,
+      fontSize: 14,
+      colW: [1.1, 2.6, 1.0, 1.1, 1.3, 2.3],
+      border: { pt: 1, color: "cbd5f5" },
+      fill: "f8fafc",
+      color: "0f172a",
+      valign: "middle",
+    });
+
+    pptx.writeFile({
+      fileName: `Executive-Summary-${data.monthLabel.replace(/\s+/g, "-")}.pptx`,
+    });
+  };
+
+  return (
+    <div className="space-y-8">
+      <header className="rounded-3xl border border-slate-800/60 bg-gradient-to-r from-slate-950 via-slate-900 to-slate-950 p-8 shadow-[0_0_35px_rgba(15,23,42,0.4)]">
+        <div className="flex flex-col gap-6 md:flex-row md:items-end md:justify-between">
+          <div className="space-y-2">
+            <h1 className="text-3xl font-bold text-slate-100">Executive Summary</h1>
+            <p className="max-w-2xl text-sm text-slate-300">
+              Rangkuman performa dashboard, insight pengguna, serta kinerja Instagram dan TikTok
+              selama satu bulan penuh. Pilih periode untuk melihat insight dan unduh presentasi PPT.
+            </p>
+          </div>
+          <div className="flex flex-col gap-3 md:flex-row md:items-center">
+            <label className="flex flex-col text-sm font-medium text-slate-200">
+              Pilih Bulan
+              <select
+                value={selectedMonth}
+                onChange={(event) => setSelectedMonth(event.target.value)}
+                className="mt-1 w-56 rounded-xl border border-cyan-500/40 bg-slate-900/80 px-4 py-2 text-slate-100 shadow-[0_0_20px_rgba(56,189,248,0.2)] focus:border-cyan-400 focus:outline-none"
+              >
+                {monthKeys.map((key) => (
+                  <option key={key} value={key}>
+                    {monthlyData[key].monthLabel}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <Button
+              onClick={handleDownload}
+              className="flex items-center gap-2 rounded-xl bg-cyan-500 px-5 py-2 text-white shadow-[0_10px_30px_rgba(6,182,212,0.25)] transition hover:bg-cyan-400"
+            >
+              <Download className="h-4 w-4" /> Unduh PPT
+            </Button>
+          </div>
+        </div>
+      </header>
+
+      <section
+        aria-label="Ikhtisar Kinerja"
+        className="grid gap-4 md:grid-cols-4"
+      >
+        {data.summaryMetrics.map((metric) => (
+          <div
+            key={metric.label}
+            className="rounded-3xl border border-cyan-500/20 bg-slate-950/70 p-6 shadow-[0_20px_45px_rgba(15,118,110,0.15)]"
+          >
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-cyan-200/80">
+              {metric.label}
+            </p>
+            <p className="mt-3 text-3xl font-bold text-slate-100">
+              {formatNumber(metric.value, { maximumFractionDigits: metric.suffix ? 1 : 0 })}
+              {metric.suffix ? metric.suffix : ""}
+            </p>
+            <p className="mt-2 text-sm text-emerald-400">{metric.change}</p>
+          </div>
+        ))}
+      </section>
+
+      <section className="grid gap-6 lg:grid-cols-5">
+        <div className="rounded-3xl border border-slate-800/60 bg-slate-950/70 p-6 shadow-[0_20px_45px_rgba(15,23,42,0.4)] lg:col-span-3">
+          <h2 className="text-sm font-semibold uppercase tracking-[0.35em] text-cyan-200/80">
+            Narasi Utama Bulanan
+          </h2>
+          <p className="mt-4 text-base leading-relaxed text-slate-200">
+            {data.overviewNarrative}
+          </p>
+          <ul className="mt-4 space-y-3 text-sm text-slate-300">
+            {data.highlights.map((item) => (
+              <li key={item} className="flex gap-2">
+                <span className="mt-1 h-2 w-2 rounded-full bg-cyan-400" aria-hidden="true" />
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div className="rounded-3xl border border-cyan-500/20 bg-slate-950/70 p-6 shadow-[0_20px_45px_rgba(56,189,248,0.18)] lg:col-span-2">
+          <h2 className="text-sm font-semibold uppercase tracking-[0.35em] text-cyan-200/80">
+            Aktivitas Admin
+          </h2>
+          <div className="mt-5 space-y-5">
+            {data.userInsightMetrics.map((metric) => (
+              <div key={metric.label} className="flex items-center justify-between rounded-2xl bg-slate-900/60 px-4 py-3">
+                <div>
+                  <p className="text-sm font-medium text-slate-200">{metric.label}</p>
+                  <p className="text-xs text-slate-400">Perbandingan bulan sebelumnya</p>
+                </div>
+                <div className="text-right">
+                  <p className="text-xl font-semibold text-white">
+                    {formatNumber(metric.value, { maximumFractionDigits: metric.suffix ? 1 : 0 })}
+                    {metric.suffix ? metric.suffix : ""}
+                  </p>
+                  <p className="text-xs text-emerald-400">{metric.change}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-6 lg:grid-cols-7" aria-label="Visualisasi Kinerja">
+        <div className="rounded-3xl border border-slate-800/60 bg-slate-950/70 p-6 shadow-[0_20px_45px_rgba(15,23,42,0.4)] lg:col-span-4">
+          <h2 className="text-sm font-semibold uppercase tracking-[0.35em] text-cyan-200/80">
+            Sebaran Reach & Engagement per Kanal
+          </h2>
+          <div className="mt-6 h-72">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={data.engagementByChannel}>
+                <CartesianGrid strokeDasharray="3 3" stroke="rgba(148,163,184,0.25)" />
+                <XAxis dataKey="channel" stroke="#94a3b8" tick={{ fill: "#cbd5f5", fontSize: 12 }} />
+                <YAxis stroke="#94a3b8" tick={{ fill: "#cbd5f5", fontSize: 12 }} />
+                <Tooltip
+                  cursor={{ fill: "rgba(15,23,42,0.3)" }}
+                  contentStyle={{
+                    backgroundColor: "rgba(15,23,42,0.92)",
+                    borderRadius: 16,
+                    borderColor: "rgba(148,163,184,0.4)",
+                    boxShadow: "0 20px 45px rgba(14,116,144,0.3)",
+                    color: "#e2e8f0",
+                  }}
+                  formatter={(value, name) => {
+                    if (name === "reach") {
+                      return [formatNumber(value, { maximumFractionDigits: 0 }), "Reach"];
+                    }
+                    return [`${formatNumber(value, { maximumFractionDigits: 1 })}%`, "Engagement Rate"];
+                  }}
+                />
+                <Legend wrapperStyle={{ color: "#e2e8f0" }} />
+                <Bar dataKey="reach" name="Reach" fill="#38bdf8" radius={[8, 8, 0, 0]}>
+                  <LabelList
+                    dataKey="reach"
+                    position="top"
+                    formatter={(value) => formatNumber(value, { maximumFractionDigits: 0 })}
+                    fill="#e2e8f0"
+                    fontSize={11}
+                  />
+                </Bar>
+                <Bar dataKey="engagementRate" name="Engagement Rate" fill="#a855f7" radius={[8, 8, 0, 0]}>
+                  <LabelList
+                    dataKey="engagementRate"
+                    position="top"
+                    formatter={(value) => `${formatNumber(value, { maximumFractionDigits: 1 })}%`}
+                    fill="#f5f3ff"
+                    fontSize={11}
+                  />
+                </Bar>
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        </div>
+        <div className="rounded-3xl border border-cyan-500/20 bg-slate-950/70 p-6 shadow-[0_20px_45px_rgba(56,189,248,0.18)] lg:col-span-3">
+          <h2 className="text-sm font-semibold uppercase tracking-[0.35em] text-cyan-200/80">
+            Komposisi Audiens
+          </h2>
+          <div className="mt-6 h-72">
+            <ResponsiveContainer width="100%" height="100%">
+              <PieChart>
+                <Pie
+                  data={data.audienceComposition}
+                  dataKey="value"
+                  nameKey="name"
+                  innerRadius={60}
+                  outerRadius={100}
+                  paddingAngle={4}
+                >
+                  {data.audienceComposition.map((entry, index) => (
+                    <Cell key={entry.name} fill={PIE_COLORS[index % PIE_COLORS.length]} />
+                  ))}
+                </Pie>
+                <Tooltip
+                  contentStyle={{
+                    backgroundColor: "rgba(15,23,42,0.92)",
+                    borderRadius: 16,
+                    borderColor: "rgba(148,163,184,0.4)",
+                    color: "#e2e8f0",
+                  }}
+                  formatter={(value) => [`${value}%`, "Kontribusi"]}
+                />
+                <Legend verticalAlign="bottom" wrapperStyle={{ color: "#e2e8f0" }} />
+              </PieChart>
+            </ResponsiveContainer>
+          </div>
+        </div>
+      </section>
+
+      <section className="space-y-6" aria-label="Analisis Mendalam">
+        <div className="grid gap-6 lg:grid-cols-2">
+          <article className="rounded-3xl border border-slate-800/60 bg-slate-950/70 p-6 shadow-[0_20px_45px_rgba(15,23,42,0.4)]">
+            <h2 className="text-sm font-semibold uppercase tracking-[0.35em] text-cyan-200/80">
+              Dashboard & Monitoring
+            </h2>
+            <p className="mt-4 text-sm leading-relaxed text-slate-200">
+              {data.dashboardNarrative}
+            </p>
+          </article>
+          <article className="rounded-3xl border border-slate-800/60 bg-slate-950/70 p-6 shadow-[0_20px_45px_rgba(15,23,42,0.4)]">
+            <h2 className="text-sm font-semibold uppercase tracking-[0.35em] text-cyan-200/80">
+              Insight Pengguna Internal
+            </h2>
+            <p className="mt-4 text-sm leading-relaxed text-slate-200">
+              {data.userInsightNarrative}
+            </p>
+          </article>
+        </div>
+        <div className="grid gap-6 lg:grid-cols-2">
+          <article className="rounded-3xl border border-cyan-500/20 bg-slate-950/70 p-6 shadow-[0_20px_45px_rgba(56,189,248,0.18)]">
+            <h2 className="text-sm font-semibold uppercase tracking-[0.35em] text-cyan-200/80">
+              Rekap Instagram
+            </h2>
+            <p className="mt-4 text-sm leading-relaxed text-slate-200">
+              {data.instagramNarrative}
+            </p>
+          </article>
+          <article className="rounded-3xl border border-cyan-500/20 bg-slate-950/70 p-6 shadow-[0_20px_45px_rgba(56,189,248,0.18)]">
+            <h2 className="text-sm font-semibold uppercase tracking-[0.35em] text-cyan-200/80">
+              Rekap TikTok
+            </h2>
+            <p className="mt-4 text-sm leading-relaxed text-slate-200">
+              {data.tiktokNarrative}
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <section
+        aria-label="Daftar Konten Berperforma"
+        className="rounded-3xl border border-slate-800/60 bg-slate-950/70 p-6 shadow-[0_20px_45px_rgba(15,23,42,0.4)]"
+      >
+        <h2 className="text-sm font-semibold uppercase tracking-[0.35em] text-cyan-200/80">
+          Konten dengan Performa Tertinggi
+        </h2>
+        <div className="mt-6 overflow-x-auto">
+          <table className="min-w-full divide-y divide-slate-800 text-left">
+            <thead className="bg-slate-900/70 text-xs uppercase tracking-wider text-slate-300">
+              <tr>
+                <th scope="col" className="px-4 py-3">Platform</th>
+                <th scope="col" className="px-4 py-3">Judul Konten</th>
+                <th scope="col" className="px-4 py-3">Format</th>
+                <th scope="col" className="px-4 py-3 text-right">Reach</th>
+                <th scope="col" className="px-4 py-3 text-right">Engagement</th>
+                <th scope="col" className="px-4 py-3">Insight</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-800 text-sm text-slate-200">
+              {data.contentTable.map((row) => (
+                <tr key={`${row.platform}-${row.title}`} className="hover:bg-slate-900/40">
+                  <td className="px-4 py-3 font-medium text-cyan-200">{row.platform}</td>
+                  <td className="px-4 py-3">{row.title}</td>
+                  <td className="px-4 py-3">{row.format}</td>
+                  <td className="px-4 py-3 text-right">{formatNumber(row.reach, { maximumFractionDigits: 0 })}</td>
+                  <td className="px-4 py-3 text-right">{row.engagement}%</td>
+                  <td className="px-4 py-3 text-slate-300">{row.takeaway}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/cicero-dashboard/components/Sidebar.jsx
+++ b/cicero-dashboard/components/Sidebar.jsx
@@ -16,6 +16,7 @@ import {
   ChevronLeft,
   ChevronRight,
   Link as LinkIcon,
+  FilePieChart,
   Book,
 } from "lucide-react";
 import {
@@ -52,6 +53,7 @@ export default function Sidebar() {
 
   const menu = [
     { label: "Dashboard", path: "/dashboard", icon: Home },
+    { label: "Executive Summary", path: "/executive-summary", icon: FilePieChart },
     { label: "User Directory", path: "/users", icon: Users },
     { label: "User Insight", path: "/user-insight", icon: BarChart3 },
     ...(instagramEnabled

--- a/cicero-dashboard/package-lock.json
+++ b/cicero-dashboard/package-lock.json
@@ -15,6 +15,7 @@
         "framer-motion": "^12.18.1",
         "lucide-react": "^0.364.0",
         "next": "15.3.3",
+        "pptxgenjs": "^4.0.1",
         "react": "18.3.1",
         "react-chartjs-2": "^5.3.0",
         "react-d3-cloud": "^1.0.6",
@@ -4257,6 +4258,12 @@
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "license": "MIT"
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
@@ -5211,6 +5218,12 @@
         "node": ">= 14"
       }
     },
+    "node_modules/https": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/https/-/https-1.0.0.tgz",
+      "integrity": "sha512-4EC57ddXrkaF0x83Oj8sM6SLQHAWXw90Skqu2M4AEWENZ3F02dFJE/GARA8igO79tcgYqGrD7ae4f5L3um2lgg==",
+      "license": "ISC"
+    },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
@@ -5247,6 +5260,27 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/image-size": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
+      "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
+      "license": "MIT",
+      "dependencies": {
+        "queue": "6.0.2"
+      },
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=16.x"
+      }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
@@ -5320,7 +5354,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/internmap": {
@@ -5439,6 +5472,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -6611,6 +6650,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -6619,6 +6670,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lightningcss": {
@@ -7410,6 +7470,12 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -7730,6 +7796,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pptxgenjs": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pptxgenjs/-/pptxgenjs-4.0.1.tgz",
+      "integrity": "sha512-TeJISr8wouAuXw4C1F/mC33xbZs/FuEG6nH9FG1Zj+nuPcGMP5YRHl6X+j3HSUnS1f3at6k75ZZXPMZlA5Lj9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^22.8.1",
+        "https": "^1.0.0",
+        "image-size": "^1.2.1",
+        "jszip": "^3.10.1"
+      }
+    },
+    "node_modules/pptxgenjs/node_modules/@types/node": {
+      "version": "22.18.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.6.tgz",
+      "integrity": "sha512-r8uszLPpeIWbNKtvWRt/DbVi5zbqZyj1PTmhRMqBMvDnaz1QpmSKujUtJLrqGZeoM8v72MfYggDceY4K1itzWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
@@ -7779,6 +7866,12 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -7824,6 +7917,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.3"
       }
     },
     "node_modules/queue-microtask": {
@@ -8154,6 +8256,21 @@
         "pify": "^2.3.0"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -8323,6 +8440,12 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -8364,6 +8487,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/sharp": {
       "version": "0.34.2",
@@ -8550,6 +8679,15 @@
       "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/string-length": {
@@ -9220,7 +9358,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {
@@ -9345,7 +9482,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {

--- a/cicero-dashboard/package.json
+++ b/cicero-dashboard/package.json
@@ -17,6 +17,7 @@
     "framer-motion": "^12.18.1",
     "lucide-react": "^0.364.0",
     "next": "15.3.3",
+    "pptxgenjs": "^4.0.1",
     "react": "18.3.1",
     "react-chartjs-2": "^5.3.0",
     "react-d3-cloud": "^1.0.6",


### PR DESCRIPTION
## Summary
- add a protected Executive Summary page with month selection, narrative insight, charts, and tabular highlights
- integrate PPTX export capability so the selected month report can be downloaded as a presentation
- surface the new report from the main sidebar navigation and include supporting static datasets

## Testing
- npm run lint *(fails: prompts for interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68d489d5af448327996f4d2377814087