### PR TITLE
Configure webpack aliases for node protocol

### DIFF
--- a/cicero-dashboard/next.config.ts
+++ b/cicero-dashboard/next.config.ts
@@ -1,7 +1,18 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  webpack: (config) => {
+    config.resolve ??= {};
+    config.resolve.alias = {
+      ...(config.resolve.alias ?? {}),
+      "node:https": "https",
+      "node:http": "http",
+      "node:stream": "stream",
+      "node:buffer": "buffer",
+    };
+
+    return config;
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- map Node.js protocol-prefixed imports to their standard module names in the Next.js webpack configuration
- ensure client and server bundles can resolve built-in modules such as https, http, stream, and buffer without triggering UnhandledSchemeError

## Testing
- npm run build *(fails: unable to download Google Fonts and resolve pptxgenjs in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d48e0d19548327875e63b6f9b2d4e5