### PR TITLE
Fix pptxgenjs build failure

### DIFF
--- a/cicero-dashboard/next.config.ts
+++ b/cicero-dashboard/next.config.ts
@@ -5,10 +5,19 @@ const nextConfig: NextConfig = {
     config.resolve ??= {};
     config.resolve.alias = {
       ...(config.resolve.alias ?? {}),
-      "node:https": "https",
+      "node:https": false,
+      "node:fs": false,
+      https: false,
+      fs: false,
       "node:http": "http",
       "node:stream": "stream",
       "node:buffer": "buffer",
+    };
+
+    config.resolve.fallback = {
+      ...(config.resolve.fallback ?? {}),
+      https: false,
+      fs: false,
     };
 
     return config;


### PR DESCRIPTION
## Summary
- stub pptxgenjs node-specific imports by aliasing node:https and node:fs to false in the webpack config
- add resolve fallbacks for https and fs to prevent bundling errors during client builds

## Testing
- npm run build *(fails: blocked by remote font downloads)*

------
https://chatgpt.com/codex/tasks/task_e_68d498ba80ac832790f690e69b3ca9a5