### PR TITLE
Update user insight narrative to highlight satker context

### DIFF
--- a/cicero-dashboard/app/executive-summary/page.jsx
+++ b/cicero-dashboard/app/executive-summary/page.jsx
@@ -136,7 +136,7 @@ const buildUserNarrative = ({
 
   const sentences = [];
   sentences.push(
-    `Direktori saat ini memuat ${formatNumber(totalUsers, { maximumFractionDigits: 0 })} personil aktif.`,
+    `Direktori saat ini memuat ${formatNumber(totalUsers, { maximumFractionDigits: 0 })} personil aktif lintas satker.`,
   );
 
   if (bothCount > 0) {
@@ -179,7 +179,7 @@ const buildUserNarrative = ({
   if (bestPolres) {
     const bestName = bestPolres.displayName || formatPolresName(bestPolres.polres);
     sentences.push(
-      `${bestName} menjadi Polres paling siap dengan kelengkapan rata-rata ${formatPercent(
+      `${bestName} menjadi satker paling siap dengan kelengkapan rata-rata ${formatPercent(
         bestPolres.completionPercent,
       )} dan basis ${formatNumber(bestPolres.total, { maximumFractionDigits: 0 })} personil aktif.`,
     );
@@ -189,7 +189,7 @@ const buildUserNarrative = ({
     const lowestName =
       lowestPolres.displayName || formatPolresName(lowestPolres.polres);
     sentences.push(
-      `Pendampingan perlu difokuskan pada Polres ${lowestName} yang baru mencapai ${formatPercent(
+      `Pendampingan perlu difokuskan pada satker ${lowestName} yang baru mencapai ${formatPercent(
         lowestPolres.completionPercent,
       )} rata-rata kelengkapan data username.`,
     );


### PR DESCRIPTION
## Summary
- adjust the automated insight narrative on the executive summary page so the messaging highlights readiness per satker rather than per divisi/polres

## Testing
- `npm run lint` *(fails: command prompts for interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68d4ea238c488327a9a147f3ecb7eecd