### PR TITLE
Prioritize polres grouping on executive summary bar chart

### DIFF
--- a/cicero-dashboard/app/executive-summary/page.jsx
+++ b/cicero-dashboard/app/executive-summary/page.jsx
@@ -62,15 +62,12 @@ const shortenDivisionName = (name) => {
 
 const extractUserGroupInfo = (user) => {
   const candidateFields = [
-    user?.nama_client,
-    user?.client_name,
-    user?.client,
-    user?.polres,
     user?.polres_name,
-    user?.satker,
+    user?.polres,
     user?.satker_name,
-    user?.kesatuan,
+    user?.satker,
     user?.kesatuan_name,
+    user?.kesatuan,
     user?.unit,
     user?.divisi,
   ];


### PR DESCRIPTION
## Summary
- prioritize polres fields when grouping user directory data for the executive summary bar chart so the ratios reflect each polres

## Testing
- not run (prompted for eslint configuration)

------
https://chatgpt.com/codex/tasks/task_e_68d53ab01fd08327b6ec1fae8bddd8d4