### PR TITLE
Adjust Instagram like completion thresholds

### DIFF
--- a/cicero-dashboard/components/ChartDivisiAbsensi.jsx
+++ b/cicero-dashboard/components/ChartDivisiAbsensi.jsx
@@ -122,7 +122,7 @@ export default function ChartDivisiAbsensi({
         : key;
     const jumlah = Number(u[fieldJumlah] || 0);
     const hasUsername = Boolean(String(u.username || "").trim());
-    const sudah = !isZeroPost && jumlah >= effectiveTotal * 0.5;
+    const sudah = !isZeroPost && jumlah >= effectiveTotal;
     const kurang = !sudah && !isZeroPost && jumlah > 0;
     const nilai = jumlah;
     if (!divisiMap[key])

--- a/cicero-dashboard/components/ChartHorizontal.jsx
+++ b/cicero-dashboard/components/ChartHorizontal.jsx
@@ -44,7 +44,7 @@ export default function ChartHorizontal({
     const key = bersihkanSatfung(u.divisi || "LAINNYA");
     // Logic: sudahLike hanya berlaku kalau ada post
     const jumlah = Number(u[fieldJumlah] || 0);
-    const sudah = !isZeroPost && jumlah >= effectiveTotal * 0.5;
+    const sudah = !isZeroPost && jumlah >= effectiveTotal;
     const kurang = !sudah && !isZeroPost && jumlah > 0;
     const nilai = jumlah;
     if (!divisiMap[key])

--- a/cicero-dashboard/components/RekapLikesIG.jsx
+++ b/cicero-dashboard/components/RekapLikesIG.jsx
@@ -59,14 +59,13 @@ const RekapLikesIG = forwardRef(function RekapLikesIG(
   const totalSudahLike =
     totalIGPost === 0
       ? 0
-      : validUsers.filter((u) => Number(u.jumlah_like) >= totalIGPost * 0.5)
-          .length;
+      : validUsers.filter((u) => Number(u.jumlah_like) >= totalIGPost).length;
   const totalKurangLike =
     totalIGPost === 0
       ? 0
       : validUsers.filter((u) => {
           const likes = Number(u.jumlah_like) || 0;
-          return likes > 0 && likes < totalIGPost * 0.5;
+          return likes > 0 && likes < totalIGPost;
         }).length;
   const totalBelumLike =
     totalIGPost === 0
@@ -163,7 +162,7 @@ const RekapLikesIG = forwardRef(function RekapLikesIG(
       const likes = Number(u.jumlah_like) || 0;
       if (totalIGPost === 0) {
         satkerMap[client].belum += 1;
-      } else if (likes >= totalIGPost * 0.5) {
+      } else if (likes >= totalIGPost) {
         satkerMap[client].sudah += 1;
       } else if (likes > 0) {
         satkerMap[client].kurang += 1;
@@ -231,7 +230,7 @@ const RekapLikesIG = forwardRef(function RekapLikesIG(
       const likes = Number(u.jumlah_like) || 0;
       let status = "Belum";
       if (totalIGPost !== 0) {
-        if (likes >= totalIGPost * 0.5) status = "Sudah";
+        if (likes >= totalIGPost) status = "Sudah";
         else if (likes > 0) status = "Kurang";
       }
       clients[client][status].push(u);
@@ -479,7 +478,7 @@ const RekapLikesIG = forwardRef(function RekapLikesIG(
                       jumlahDisplay = 0;
                     } else if (totalIGPost !== 0) {
                       const likes = Number(u.jumlah_like) || 0;
-                      if (likes >= totalIGPost * 0.5) {
+                      if (likes >= totalIGPost) {
                         rowClass = "bg-emerald-500/10";
                         statusEl = (
                           <span className="inline-flex items-center gap-1 rounded-full border border-emerald-400/40 bg-emerald-500/20 px-2 py-0.5 text-xs font-semibold text-emerald-200 shadow-[0_0_14px_rgba(16,185,129,0.35)]">

--- a/cicero-dashboard/hooks/useInstagramLikesData.ts
+++ b/cicero-dashboard/hooks/useInstagramLikesData.ts
@@ -253,7 +253,7 @@ export default function useInstagramLikesData({
             totalBelumLike += 1;
             return;
           }
-          if (jumlah >= totalIGPost * 0.5) {
+          if (jumlah >= totalIGPost) {
             totalSudahLike += 1;
           } else if (jumlah > 0) {
             totalKurangLike += 1;

--- a/cicero-dashboard/utils/absensiLikes.ts
+++ b/cicero-dashboard/utils/absensiLikes.ts
@@ -115,7 +115,7 @@ export async function fetchDitbinmasAbsensiLikes(
       totalBelumLike += 1;
       return;
     }
-    if (jumlah >= totalIGPost * 0.5) {
+    if (jumlah >= totalIGPost) {
       totalSudahLike += 1;
     } else if (jumlah > 0) {
       totalKurangLike += 1;

--- a/cicero-dashboard/utils/buildInstagramRekap.ts
+++ b/cicero-dashboard/utils/buildInstagramRekap.ts
@@ -1,5 +1,3 @@
-const LIKE_THRESHOLD = Number(process.env.NEXT_PUBLIC_LIKE_THRESHOLD ?? 1);
-
 interface RekapSummary {
   totalIGPost: number;
   totalUser: number;
@@ -56,7 +54,7 @@ export function buildInstagramRekap(
             acc.tanpaUsername++;
           } else if (totalIGPost === 0) {
             acc.belum++;
-          } else if (jumlah >= totalIGPost * LIKE_THRESHOLD) {
+          } else if (jumlah >= totalIGPost) {
             acc.sudah++;
           } else if (jumlah > 0) {
             acc.kurang++;


### PR DESCRIPTION
## Summary
- require full completion of Instagram likes before marking users as "sudah" in summary calculations
- align Ditbinmas aggregation, charts, exports, and rekap builder with the new completion rule

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d61fd641d08327a1e001d38fde471c