### PR TITLE
Adjust Ditbinmas account handling for Instagram likes

### DIFF
--- a/cicero-dashboard/hooks/useInstagramLikesData.ts
+++ b/cicero-dashboard/hooks/useInstagramLikesData.ts
@@ -69,8 +69,11 @@ export default function useInstagramLikesData({
       return () => controller.abort();
     }
 
-    const isDitbinmas = String(role).toLowerCase() === "ditbinmas";
-    const taskClientId = isDitbinmas ? "DITBINMAS" : userClientId;
+    const roleLower = String(role).toLowerCase();
+    const clientIdLower = String(userClientId).toLowerCase();
+    const isDitbinmasRole = roleLower === "ditbinmas";
+    const isDitbinmasAccount = isDitbinmasRole && clientIdLower === "ditbinmas";
+    const taskClientId = isDitbinmasAccount ? "DITBINMAS" : userClientId;
 
     async function fetchData() {
       try {
@@ -82,7 +85,7 @@ export default function useInstagramLikesData({
           viewBy,
           selectedDate,
         );
-        if (isDitbinmas) {
+        if (isDitbinmasAccount) {
           const { users, summary, posts, clientName } =
             await fetchDitbinmasAbsensiLikes(
               token,


### PR DESCRIPTION
## Summary
- only call the Ditbinmas aggregate API when both role and client_id correspond to Ditbinmas
- allow Ditbinmas-role users with other client_ids to fetch data using their selected client context

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d623702c4c8327904c5971c317a18e