### PR TITLE
Improve placeholder contrast on user directory inputs

### DIFF
--- a/cicero-dashboard/app/globals.css
+++ b/cicero-dashboard/app/globals.css
@@ -71,7 +71,17 @@ body {
 input::placeholder,
 textarea::placeholder,
 select::placeholder {
-  color: #121315; /* gray */
+  color: #94a3b8; /* Improved readability on dark backgrounds */
+  opacity: 0.9;
+}
+
+@media (prefers-color-scheme: dark) {
+  input::placeholder,
+  textarea::placeholder,
+  select::placeholder {
+    color: #cbd5f5; /* Brighter tone for dark surfaces */
+    opacity: 0.95;
+  }
 }
 
 input,

--- a/cicero-dashboard/app/users/page.jsx
+++ b/cicero-dashboard/app/users/page.jsx
@@ -545,7 +545,7 @@ export default function UserDirectoryPage() {
                     placeholder="Cari berdasarkan nama, NRP, divisi, atau username"
                     value={search}
                     onChange={(e) => setSearch(e.target.value)}
-                    className="w-full bg-transparent text-sm text-slate-100 placeholder:text-slate-500 focus:outline-none"
+                    className="w-full bg-transparent text-sm text-slate-100 placeholder:text-slate-300 focus:outline-none"
                     aria-label="Pencarian pengguna"
                   />
                 </label>


### PR DESCRIPTION
## Summary
- brighten global placeholder colors for inputs to improve readability on dark surfaces
- update the user directory search field to use the higher-contrast placeholder styling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d66fefd32483278a46bc5b610fb8c9