### PR TITLE
Filter Ditbinmas likes data by login client

### DIFF
--- a/cicero-dashboard/hooks/useInstagramLikesData.ts
+++ b/cicero-dashboard/hooks/useInstagramLikesData.ts
@@ -94,6 +94,7 @@ export default function useInstagramLikesData({
                 endDate,
               },
               controller.signal,
+              userClientId,
             );
           if (controller.signal.aborted) return;
           setChartData(users);

--- a/cicero-dashboard/utils/absensiLikes.ts
+++ b/cicero-dashboard/utils/absensiLikes.ts
@@ -11,6 +11,7 @@ export async function fetchDitbinmasAbsensiLikes(
   token: string,
   { periode, date, startDate, endDate }: FetchParams,
   signal?: AbortSignal,
+  loginClientId?: string,
 ) {
   const clientId = "DITBINMAS";
 
@@ -77,6 +78,22 @@ export async function fetchDitbinmasAbsensiLikes(
       ? res
       : [],
   );
+
+  const normalizedLoginClientId = String(loginClientId || "")
+    .trim()
+    .toLowerCase();
+  if (normalizedLoginClientId) {
+    const normalizeValue = (value: unknown) =>
+      String(value || "")
+        .trim()
+        .toLowerCase();
+    users = users.filter((u) => {
+      const userClientId = normalizeValue(
+        u.client_id || u.clientId || u.clientID || u.client || "",
+      );
+      return userClientId === normalizedLoginClientId;
+    });
+  }
 
   const nameMap = await getClientNames(
     token,


### PR DESCRIPTION
## Summary
- propagate the login client_id when loading Ditbinmas Instagram likes data
- filter Ditbinmas rekap users and summary to only include the login client_id

## Testing
- npm run lint *(fails: requires interactive Next.js ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b2464a348327b18a0e87ccde4a6f