### PR TITLE
Adjust Ditbinmas Instagram view to group by division

### DIFF
--- a/cicero-dashboard/app/likes/instagram/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/page.jsx
@@ -37,6 +37,7 @@ export default function InstagramEngagementInsightPage() {
     rekapSummary,
     isDirectorate,
     clientName,
+    isDitbinmasScopedClient,
   } = useInstagramLikesData({ viewBy, customDate, fromDate, toDate });
 
   const viewOptions = VIEW_OPTIONS;
@@ -52,6 +53,12 @@ export default function InstagramEngagementInsightPage() {
 
   // Group chartData by kelompok jika bukan direktorat
   const kelompok = isDirectorate ? null : groupUsersByKelompok(chartData);
+  const shouldGroupByClient = isDirectorate && !isDitbinmasScopedClient;
+  const directorateGroupBy = shouldGroupByClient ? "client_id" : "divisi";
+  const directorateOrientation = shouldGroupByClient ? "horizontal" : "vertical";
+  const directorateTitle = shouldGroupByClient
+    ? "POLRES JAJARAN"
+    : `DIVISI / SATFUNG${clientName ? ` - ${clientName}` : ""}`;
 
   const totalUser = Number(rekapSummary.totalUser) || 0;
   const totalTanpaUsername = Number(rekapSummary.totalTanpaUsername) || 0;
@@ -178,12 +185,17 @@ export default function InstagramEngagementInsightPage() {
             {/* Chart per kelompok / polres */}
             {isDirectorate ? (
               <ChartBox
-                title="POLRES JAJARAN"
+                title={directorateTitle}
                 users={chartData}
                 totalPost={rekapSummary.totalIGPost}
-                groupBy="client_id"
-                orientation="horizontal"
+                groupBy={directorateGroupBy}
+                orientation={directorateOrientation}
                 sortBy="percentage"
+                narrative={
+                  shouldGroupByClient
+                    ? undefined
+                    : "Grafik dan tabel ini menampilkan perbandingan capaian likes berdasarkan divisi/satfung."
+                }
               />
             ) : (
               <div className="flex flex-col gap-6">

--- a/cicero-dashboard/hooks/useInstagramLikesData.ts
+++ b/cicero-dashboard/hooks/useInstagramLikesData.ts
@@ -46,6 +46,7 @@ export default function useInstagramLikesData({
   });
   const [isDirectorate, setIsDirectorate] = useState(false);
   const [clientName, setClientName] = useState("");
+  const [isDitbinmasScopedClient, setIsDitbinmasScopedClient] = useState(false);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -71,6 +72,10 @@ export default function useInstagramLikesData({
 
     const roleLower = String(role).toLowerCase();
     const isDitbinmasRole = roleLower === "ditbinmas";
+    const normalizedClientId = String(userClientId || "").trim();
+    const normalizedClientIdUpper = normalizedClientId.toUpperCase();
+    const isDitbinmasClient = normalizedClientIdUpper === "DITBINMAS";
+    setIsDitbinmasScopedClient(isDitbinmasRole && !isDitbinmasClient);
     const dashboardClientId = isDitbinmasRole ? "DITBINMAS" : userClientId;
 
     async function fetchData() {
@@ -324,6 +329,7 @@ export default function useInstagramLikesData({
     igPosts,
     rekapSummary,
     isDirectorate,
+    isDitbinmasScopedClient,
     clientName,
     loading,
     error,


### PR DESCRIPTION
## Summary
- add a Ditbinmas scoped-client flag in the Instagram likes data hook to detect non-DITBINMAS logins
- switch the /likes/instagram directorate view to group by division when the Ditbinmas role is scoped to a single client and provide contextual narrative copy

## Testing
- npm run lint *(fails: Next.js lint prompts for configuration in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b4419d58832790e732dc7692f659