### PR TITLE
Fix TikTok recap client scoping for Ditbinmas role

### DIFF
--- a/cicero-dashboard/app/comments/tiktok/rekap/page.jsx
+++ b/cicero-dashboard/app/comments/tiktok/rekap/page.jsx
@@ -123,8 +123,26 @@ export default function RekapKomentarTiktokPage() {
       typeof window !== "undefined"
         ? localStorage.getItem("cicero_token")
         : null;
+    const userClientId =
+      typeof window !== "undefined"
+        ? localStorage.getItem("client_id")
+        : null;
+    const role =
+      typeof window !== "undefined"
+        ? localStorage.getItem("user_role")
+        : null;
+    const isDitbinmas = String(role || "").toLowerCase() === "ditbinmas";
+    const taskClientId = isDitbinmas ? "DITBINMAS" : userClientId;
+    const rekapClientId = userClientId;
+
     if (!token) {
       setError("Token tidak ditemukan. Silakan login ulang.");
+      setLoading(false);
+      return;
+    }
+
+    if (!rekapClientId) {
+      setError("Client ID pengguna tidak ditemukan. Silakan login ulang.");
       setLoading(false);
       return;
     }
@@ -141,24 +159,14 @@ export default function RekapKomentarTiktokPage() {
           date,
           startDate,
           endDate,
-          undefined,
+          taskClientId,
           controller.signal,
         );
         const statsData = statsRes.data || statsRes;
 
-        const client_id =
-          statsData?.client_id ||
-          statsData.client_id ||
-          localStorage.getItem("client_id");
-        if (!client_id) {
-          setError("Client ID tidak ditemukan.");
-          setLoading(false);
-          return;
-        }
-
         const rekapRes = await getRekapKomentarTiktok(
           token,
-          client_id,
+          rekapClientId,
           periode,
           date,
           startDate,


### PR DESCRIPTION
## Summary
- load client ID and user role from storage to determine Ditbinmas scope for dashboard stats
- ensure Rekap TikTok stats requests use Ditbinmas client only for tasks and user client for recap data
- add clear error handling when a logged-in client ID is missing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6b89b0ab4832797dc213c4a9f4d11