### PR TITLE
Update Ditbinmas task fetch to use central client

### DIFF
--- a/cicero-dashboard/app/comments/tiktok/rekap/page.jsx
+++ b/cicero-dashboard/app/comments/tiktok/rekap/page.jsx
@@ -134,8 +134,7 @@ export default function RekapKomentarTiktokPage() {
     const roleLower = String(role || "").toLowerCase();
     const clientIdUpper = String(userClientId || "").toUpperCase();
     const isDitbinmasRole = roleLower === "ditbinmas";
-    const isRootDitbinmas = isDitbinmasRole && clientIdUpper === "DITBINMAS";
-    const taskClientId = isRootDitbinmas ? "DITBINMAS" : userClientId;
+    const taskClientId = isDitbinmasRole ? "DITBINMAS" : userClientId;
     const rekapClientId = userClientId;
 
     if (!token) {


### PR DESCRIPTION
## Summary
- ensure Ditbinmas roles fetch task statistics from the central Ditbinmas client ID while retaining per-user rekap queries

## Testing
- not run (requires Ditbinmas non-root account workflow which is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d6bcb0eab483278f1a5164b6586a4f