### PR TITLE
Ensure Ditbinmas Instagram likes dashboard groups by division

### DIFF
--- a/cicero-dashboard/app/likes/instagram/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/page.jsx
@@ -38,6 +38,7 @@ export default function InstagramEngagementInsightPage() {
     isDirectorate,
     clientName,
     isDitbinmasScopedClient,
+    isDitbinmasRole,
   } = useInstagramLikesData({ viewBy, customDate, fromDate, toDate });
 
   const viewOptions = VIEW_OPTIONS;
@@ -53,7 +54,8 @@ export default function InstagramEngagementInsightPage() {
 
   // Group chartData by kelompok jika bukan direktorat
   const kelompok = isDirectorate ? null : groupUsersByKelompok(chartData);
-  const shouldGroupByClient = isDirectorate && !isDitbinmasScopedClient;
+  const shouldGroupByClient =
+    isDirectorate && !isDitbinmasScopedClient && !isDitbinmasRole;
   const directorateGroupBy = shouldGroupByClient ? "client_id" : "divisi";
   const directorateOrientation = shouldGroupByClient ? "horizontal" : "vertical";
   const directorateTitle = shouldGroupByClient

--- a/cicero-dashboard/hooks/useInstagramLikesData.ts
+++ b/cicero-dashboard/hooks/useInstagramLikesData.ts
@@ -47,6 +47,7 @@ export default function useInstagramLikesData({
   const [isDirectorate, setIsDirectorate] = useState(false);
   const [clientName, setClientName] = useState("");
   const [isDitbinmasScopedClient, setIsDitbinmasScopedClient] = useState(false);
+  const [isDitbinmasRole, setIsDitbinmasRole] = useState(false);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -71,12 +72,15 @@ export default function useInstagramLikesData({
     }
 
     const roleLower = String(role).toLowerCase();
-    const isDitbinmasRole = roleLower === "ditbinmas";
+    const isDitbinmasRoleValue = roleLower === "ditbinmas";
+    setIsDitbinmasRole(isDitbinmasRoleValue);
     const normalizedClientId = String(userClientId || "").trim();
     const normalizedClientIdUpper = normalizedClientId.toUpperCase();
     const isDitbinmasClient = normalizedClientIdUpper === "DITBINMAS";
-    setIsDitbinmasScopedClient(isDitbinmasRole && !isDitbinmasClient);
-    const dashboardClientId = isDitbinmasRole ? "DITBINMAS" : userClientId;
+    setIsDitbinmasScopedClient(isDitbinmasRoleValue && !isDitbinmasClient);
+    const dashboardClientId = isDitbinmasRoleValue
+      ? "DITBINMAS"
+      : userClientId;
 
     async function fetchData() {
       try {
@@ -88,7 +92,7 @@ export default function useInstagramLikesData({
           viewBy,
           selectedDate,
         );
-        if (isDitbinmasRole) {
+        if (isDitbinmasRoleValue) {
           const { users, summary, posts, clientName } =
             await fetchDitbinmasAbsensiLikes(
               token,
@@ -138,7 +142,7 @@ export default function useInstagramLikesData({
         );
         const profile = profileRes.client || profileRes.profile || profileRes || {};
         const dir =
-          isDitbinmasRole ||
+          isDitbinmasRoleValue ||
           (String(profile.client_type || "").toUpperCase() === "DIREKTORAT");
         if (controller.signal.aborted) return;
         setIsDirectorate(dir);
@@ -330,6 +334,7 @@ export default function useInstagramLikesData({
     rekapSummary,
     isDirectorate,
     isDitbinmasScopedClient,
+    isDitbinmasRole,
     clientName,
     loading,
     error,


### PR DESCRIPTION
## Summary
- track and expose the Ditbinmas role state within the Instagram likes hook
- keep Ditbinmas users grouped by division on the Instagram likes dashboard recap

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d77654286c832787f381472eef53b6