### PR TITLE
Filter TikTok rekap data by active client

### DIFF
--- a/cicero-dashboard/app/comments/tiktok/rekap/page.jsx
+++ b/cicero-dashboard/app/comments/tiktok/rekap/page.jsx
@@ -178,17 +178,36 @@ export default function RekapKomentarTiktokPage() {
         );
         const users = Array.isArray(rekapRes.data) ? rekapRes.data : [];
 
+        const normalizedRekapClientId = String(rekapClientId || "")
+          .trim()
+          .toUpperCase();
+        const filteredUsers = normalizedRekapClientId
+          ? users.filter((u) => {
+              const possibleIds = [
+                u.client_id,
+                u.clientId,
+                u.client,
+                u.clientID,
+                u.clientid,
+              ];
+              return possibleIds.some((cid) =>
+                String(cid || "").trim().toUpperCase() ===
+                normalizedRekapClientId,
+              );
+            })
+          : users;
+
         // map client_id to client name for satker column
         const nameMap = await getClientNames(
           token,
-          users.map((u) =>
+          filteredUsers.map((u) =>
             String(
               u.client_id || u.clientId || u.client || u.clientID || "",
             ),
           ),
           controller.signal,
         );
-        const enrichedUsers = users.map((u) => {
+        const enrichedUsers = filteredUsers.map((u) => {
           const cid = String(
             u.client_id || u.clientId || u.client || u.clientID || "",
           );
@@ -209,10 +228,10 @@ export default function RekapKomentarTiktokPage() {
           statsData.tiktokPosts ||
           0;
         const isZeroPost = (totalTiktokPost || 0) === 0;
-        const totalUser = users.length;
+        const totalUser = filteredUsers.length;
         const totalSudahKomentar = isZeroPost
           ? 0
-          : users.filter(
+          : filteredUsers.filter(
               (u) => Number(u.jumlah_komentar) > 0 || u.exception
             ).length;
         const totalBelumKomentar = totalUser - totalSudahKomentar;


### PR DESCRIPTION
## Summary
- normalize the active client identifier and filter TikTok rekap users against matching client ids
- derive satker name mapping, aggregate totals, and chart data from the filtered user list

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d78ca2bfcc8327a7dd281dc4f9dc62