### PR TITLE
Ensure Ditbinmas TikTok comments align with recap filtering

### DIFF
--- a/cicero-dashboard/__tests__/useTiktokCommentsData.test.ts
+++ b/cicero-dashboard/__tests__/useTiktokCommentsData.test.ts
@@ -94,7 +94,7 @@ describe("useTiktokCommentsData", () => {
     expect(result.current.rekapSummary.totalUser).toBe(1);
   });
 
-  it("keeps aggregated directorate data for the root Ditbinmas account", async () => {
+  it("filters directorate data for the root Ditbinmas account to match recap", async () => {
     localStorage.setItem("cicero_token", "token");
     localStorage.setItem("client_id", "DITBINMAS");
     localStorage.setItem("user_role", "ditbinmas");
@@ -145,10 +145,9 @@ describe("useTiktokCommentsData", () => {
 
     expect(result.current.isDirectorate).toBe(true);
     expect(result.current.isDitbinmasScopedClient).toBe(false);
-    expect(result.current.chartData).toHaveLength(3);
+    expect(result.current.chartData).toHaveLength(1);
     const clientIds = result.current.chartData.map((item: any) => item.client_id);
-    expect(clientIds).toEqual(
-      expect.arrayContaining(["CLIENT_A", "CLIENT_B", "DITBINMAS"]),
-    );
+    expect(clientIds).toEqual(["DITBINMAS"]);
+    expect(result.current.rekapSummary.totalUser).toBe(1);
   });
 });

--- a/cicero-dashboard/hooks/useTiktokCommentsData.ts
+++ b/cicero-dashboard/hooks/useTiktokCommentsData.ts
@@ -235,7 +235,9 @@ export default function useTiktokCommentsData({
         }
 
         let filteredUsers = users;
-        const shouldFilterByClient = Boolean(normalizedClientIdLower) && (!directorate || isScopedDirectorateClient);
+        const shouldFilterByClient =
+          Boolean(normalizedClientIdLower) &&
+          (isDitbinmasRoleValue || !directorate || isScopedDirectorateClient);
         if (shouldFilterByClient) {
           const normalizeValue = (value: unknown) =>
             String(value || "").trim().toLowerCase();


### PR DESCRIPTION
## Summary
- ensure TikTok comments hook filters Ditbinmas data by the logged-in client id, including the root account
- update the Ditbinmas root scenario test to expect filtered data that matches the recap view

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d78eea500883279fefb12ca1a31a7f