### PR TITLE
Fix Ditbinmas filtering in TikTok recap

### DIFF
--- a/cicero-dashboard/app/comments/tiktok/rekap/page.jsx
+++ b/cicero-dashboard/app/comments/tiktok/rekap/page.jsx
@@ -265,7 +265,8 @@ export default function RekapKomentarTiktokPage() {
 
         let filteredUsers = users;
         const shouldFilterByClient =
-          Boolean(clientIdLower) && (!isDirectorate || isScopedDirectorateClient);
+          Boolean(clientIdLower) &&
+          (isDitbinmasRole || !isDirectorate || isScopedDirectorateClient);
         if (shouldFilterByClient) {
           const normalizeValue = (value) =>
             String(value || "").trim().toLowerCase();


### PR DESCRIPTION
## Summary
- ensure the TikTok recap page filters client data when the Ditbinmas role is used, matching the hook behavior

## Testing
- node -e 'const isDitbinmasRole=true; const isDirectorate=true; const isScopedDirectorateClient=false; const clientIdLower="ditbinmas"; console.log(Boolean(clientIdLower) && (isDitbinmasRole || !isDirectorate || isScopedDirectorateClient));'

------
https://chatgpt.com/codex/tasks/task_e_68d7970655bc8327a78524c4380ed554