### PR TITLE
Remove copy rekap buttons on rekap pages

### DIFF
--- a/cicero-dashboard/app/comments/tiktok/rekap/page.jsx
+++ b/cicero-dashboard/app/comments/tiktok/rekap/page.jsx
@@ -437,6 +437,7 @@ export default function RekapKomentarTiktokPage() {
         <RekapKomentarTiktok
           users={chartData}
           totalTiktokPost={rekapSummary.totalTiktokPost}
+          showCopyButton={false}
         />
       </div>
     </div>

--- a/cicero-dashboard/app/likes/instagram/rekap/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/rekap/page.jsx
@@ -184,6 +184,7 @@ export default function RekapLikesIGPage() {
             totalIGPost={rekapSummary.totalIGPost}
             posts={igPosts}
             showRekapButton
+            showCopyButton={false}
             clientName={clientName}
           />
         </div>

--- a/cicero-dashboard/components/RekapKomentarTiktok.jsx
+++ b/cicero-dashboard/components/RekapKomentarTiktok.jsx
@@ -14,7 +14,11 @@ function bersihkanSatfung(divisi = "") {
 
 const PAGE_SIZE = 25;
 
-export default function RekapKomentarTiktok({ users = [], totalTiktokPost = 0 }) {
+export default function RekapKomentarTiktok({
+  users = [],
+  totalTiktokPost = 0,
+  showCopyButton = true,
+}) {
   const totalTiktokPostCount = Number(totalTiktokPost) || 0;
   const summary = useMemo(() => {
     const totalUser = users.length;
@@ -585,12 +589,14 @@ export default function RekapKomentarTiktok({ users = [], totalTiktokPost = 0 })
           >
             Download Rekap
           </button>
-          <button
-            onClick={handleCopyRekap}
-            className="w-full rounded-2xl border border-fuchsia-400/40 bg-fuchsia-500/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-fuchsia-200 transition hover:border-fuchsia-300/60 hover:bg-fuchsia-500/20 sm:w-auto"
-          >
-            Salin Rekap
-          </button>
+          {showCopyButton && (
+            <button
+              onClick={handleCopyRekap}
+              className="w-full rounded-2xl border border-fuchsia-400/40 bg-fuchsia-500/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-fuchsia-200 transition hover:border-fuchsia-300/60 hover:bg-fuchsia-500/20 sm:w-auto"
+            >
+              Salin Rekap
+            </button>
+          )}
         </div>
       </div>
     </div>

--- a/cicero-dashboard/components/RekapLikesIG.jsx
+++ b/cicero-dashboard/components/RekapLikesIG.jsx
@@ -18,7 +18,8 @@ const PAGE_SIZE = 25;
  * @param {Array} users - array user rekap likes IG (sudah HARUS hasil filter/fetch periode yg benar dari parent)
  * @param {number} totalIGPost - jumlah IG Post hari ini (atau sesuai periode, dari parent)
  * @param {Array} posts - daftar posting IG untuk rekap ORG
- * @param {boolean} showRekapButton - tampilkan tombol salin rekap jika true
+ * @param {boolean} showRekapButton - tampilkan panel aksi rekap jika true
+ * @param {boolean} showCopyButton - tampilkan tombol salin rekap jika true
  * @param {string} clientName - nama client ORG
  */
 const RekapLikesIG = forwardRef(function RekapLikesIG(
@@ -28,6 +29,7 @@ const RekapLikesIG = forwardRef(function RekapLikesIG(
     posts = [],
     // tampilkan tombol rekap secara default
     showRekapButton = true,
+    showCopyButton = true,
     clientName = "",
   },
   ref,
@@ -613,12 +615,14 @@ const RekapLikesIG = forwardRef(function RekapLikesIG(
             >
               Download Rekap
             </button>
-            <button
-              onClick={handleCopyRekap}
-              className="w-full rounded-2xl border border-sky-400/40 bg-sky-500/20 px-4 py-2 text-sm font-semibold text-sky-200 shadow-[0_0_25px_rgba(56,189,248,0.35)] transition hover:border-sky-300/60 hover:bg-sky-400/30 md:w-auto"
-            >
-              Salin Rekap
-            </button>
+            {showCopyButton && (
+              <button
+                onClick={handleCopyRekap}
+                className="w-full rounded-2xl border border-sky-400/40 bg-sky-500/20 px-4 py-2 text-sm font-semibold text-sky-200 shadow-[0_0_25px_rgba(56,189,248,0.35)] transition hover:border-sky-300/60 hover:bg-sky-400/30 md:w-auto"
+              >
+                Salin Rekap
+              </button>
+            )}
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- hide the "Salin Rekap" action on the Instagram likes rekap page
- add a prop to disable the copy button in the rekap components and apply it to the TikTok comments rekap page

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7985e5db8832784ef0c425e94e8c4