### PR TITLE
Fix NRP input handler to preserve numeric input

### DIFF
--- a/cicero-dashboard/app/users/page.jsx
+++ b/cicero-dashboard/app/users/page.jsx
@@ -581,7 +581,12 @@ export default function UserDirectoryPage() {
                   type="text"
                   placeholder="NRP/NIP"
                   value={nrpNip}
-                  onChange={(e) => setNrpNip(e.target.value.replace(/[^0-9]/g, ""))}
+                  onChange={(e) => {
+                    const { value } = e.target;
+                    if (/^\d*$/.test(value)) {
+                      setNrpNip(value);
+                    }
+                  }}
                   inputMode="numeric"
                   pattern="\\d*"
                   required


### PR DESCRIPTION
## Summary
- update the NRP/NIP field change handler to only accept updates that pass a numeric regex
- keep validation logic so non-digit characters are still rejected when submitting the form

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7a1ed6f2c83278d6f4ab1d40088d1