### PR TITLE
Update TikTok rekap header copy format

### DIFF
--- a/cicero-dashboard/components/RekapKomentarTiktok.jsx
+++ b/cicero-dashboard/components/RekapKomentarTiktok.jsx
@@ -330,24 +330,22 @@ export default function RekapKomentarTiktok({
         : uniqueClients.join(", ");
 
     const headerLines = [
-      "*Mohon ijin Komandan,*",
-      "",
-      "📋 *Laporan Rekap Komentar TikTok Ditbinmas*",
+      "Mohon ijin Komandan,",
+      "📋 Laporan Rekap Komentar TikTok Ditbinmas",
       "Sumber: Konten akun official Direktorat Binmas",
       `Dilaporkan oleh personel: ${headerClientName}`,
-      periodeLabel ? `Periode data: ${periodeLabel}` : null,
+      periodeLabel
+        ? `Periode data: ${periodeLabel}`
+        : `Periode data: ${hari}, ${tanggal}`,
       viewLabel ? `Mode tampilan: ${viewLabel}` : null,
       `Waktu kompilasi: ${jam} WIB`,
-      "",
       "Ringkasan Data:",
-      "",
       `- Jumlah Konten TikTok : ${totalTiktokPostCount}`,
       `- Jumlah Total Personel : ${totalUser} pers`,
       `- Sudah Melaksanakan : ${totalSudahKomentar} pers`,
       `- Melaksanakan Kurang Lengkap : ${totalKurangKomentar} pers`,
       `- Belum Melaksanakan : ${totalBelumKomentar} pers`,
       `- Belum Update Username TikTok : ${totalTanpaUsername} pers`,
-      "",
       "Rincian terperinci sebagai berikut:",
       "",
     ].filter(Boolean);
@@ -367,7 +365,7 @@ export default function RekapKomentarTiktok({
         return;
       }
 
-      lines.push(`*${client.toUpperCase()}*`);
+      lines.push(client.toUpperCase());
 
       const pushSection = (title, entries, formatter) => {
         if (!entries.length) return;


### PR DESCRIPTION
## Summary
- adjust the generated header text for the TikTok comments rekap copy so it follows the new wording
- ensure the period line always shows a value and remove markdown emphasis from client headings

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d7a25837cc8327afa0391011785780