### PR TITLE
Sanitize NRP/NIP handling for user management

### DIFF
--- a/cicero-dashboard/__tests__/validateUserForm.test.ts
+++ b/cicero-dashboard/__tests__/validateUserForm.test.ts
@@ -1,15 +1,15 @@
 import { validateNewUser } from "@/utils/validateUserForm";
 
 describe("validateNewUser", () => {
-  it("returns trimmed values for valid input", () => {
+  it("returns sanitized values for valid input", () => {
     const res = validateNewUser({
       nama: "John",
       pangkat: "BRIPDA",
-      nrpNip: " 12345 ",
+      nrpNip: " 12 345-678 ",
       satfung: "SAT LANTAS",
       polsekName: "",
     });
-    expect(res).toEqual({ nrpNip: "12345", satfungValue: "SAT LANTAS" });
+    expect(res).toEqual({ nrpNip: "12345678", satfungValue: "SAT LANTAS" });
   });
 
   it("returns error for non numeric nrp", () => {
@@ -21,6 +21,17 @@ describe("validateNewUser", () => {
       polsekName: "",
     });
     expect(res.error).toBe("NRP hanya boleh angka");
+  });
+
+  it("returns error when sanitized nrp is empty", () => {
+    const res = validateNewUser({
+      nama: "Empty",
+      pangkat: "BRIPDA",
+      nrpNip: " -  ",
+      satfung: "SAT LANTAS",
+      polsekName: "",
+    });
+    expect(res.error).toBe("NRP/NIP wajib diisi");
   });
 
   it("returns error for invalid pangkat", () => {

--- a/cicero-dashboard/utils/validateUserForm.ts
+++ b/cicero-dashboard/utils/validateUserForm.ts
@@ -76,8 +76,11 @@ interface ValidationResult {
 }
 
 export function validateNewUser({ nama, pangkat, nrpNip, satfung, polsekName }: NewUserData): ValidationResult {
-  const trimmedNrpNip = nrpNip.trim();
-  if (!/^\d+$/.test(trimmedNrpNip)) {
+  const sanitizedNrpNip = nrpNip.replace(/\D/g, "");
+  if (!sanitizedNrpNip) {
+    return { error: "NRP/NIP wajib diisi" };
+  }
+  if (/[A-Za-z]/.test(nrpNip)) {
     return { error: "NRP hanya boleh angka" };
   }
   if (!PANGKAT_OPTIONS.includes(pangkat)) {
@@ -96,6 +99,6 @@ export function validateNewUser({ nama, pangkat, nrpNip, satfung, polsekName }: 
   if (satfung !== "POLSEK" && !SATFUNG_OPTIONS.includes(satfung)) {
     return { error: "Satfung tidak valid" };
   }
-  return { nrpNip: trimmedNrpNip, satfungValue };
+  return { nrpNip: sanitizedNrpNip, satfungValue };
 }
 


### PR DESCRIPTION
## Summary
- sanitize NRP/NIP inputs in the user directory form and inline editor before persisting
- update validation logic to use sanitized identifiers and guard against empty results
- extend unit coverage to include formatted inputs and empty sanitized identifiers

## Testing
- npm test -- validateUserForm

------
https://chatgpt.com/codex/tasks/task_e_68d7a5fae1948327a71c587ebbb2e4c5