### PR TITLE
Improve numeric normalization handling for localized inputs

### DIFF
--- a/cicero-dashboard/__tests__/normalizeNumericInput.test.ts
+++ b/cicero-dashboard/__tests__/normalizeNumericInput.test.ts
@@ -1,0 +1,15 @@
+import { normalizeNumericInput } from "@/app/executive-summary/page";
+
+describe("normalizeNumericInput", () => {
+  it("parses dot thousand separators", () => {
+    expect(normalizeNumericInput("1.234")).toBe(1234);
+  });
+
+  it("parses European formatted decimals", () => {
+    expect(normalizeNumericInput("1.234,56")).toBeCloseTo(1234.56);
+  });
+
+  it("parses US formatted decimals", () => {
+    expect(normalizeNumericInput("1,234.56")).toBeCloseTo(1234.56);
+  });
+});

--- a/cicero-dashboard/app/executive-summary/page.jsx
+++ b/cicero-dashboard/app/executive-summary/page.jsx
@@ -29,18 +29,80 @@ import { cn } from "@/lib/utils";
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "";
 
-const normalizeNumericInput = (value) => {
+const normalizeFormattedNumber = (raw) => {
+  if (typeof raw !== "string") {
+    return raw;
+  }
+
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return trimmed;
+  }
+
+  const sign = trimmed.startsWith("-") ? "-" : "";
+  const numericPortion = trimmed.replace(/[^0-9.,-]/g, "");
+  const digitsOnly = numericPortion.replace(/[^0-9.,]/g, "");
+
+  if (!digitsOnly) {
+    const direct = Number(trimmed);
+    if (Number.isFinite(direct)) {
+      return direct;
+    }
+    return trimmed;
+  }
+
+  const thousandStyleDot = /^-?\d{1,3}(\.\d{3})+$/;
+  const thousandStyleComma = /^-?\d{1,3}(,\d{3})+$/;
+
+  const lastComma = digitsOnly.lastIndexOf(",");
+  const lastDot = digitsOnly.lastIndexOf(".");
+  let decimalSeparator = null;
+
+  if (lastComma !== -1 && lastDot !== -1) {
+    decimalSeparator = lastComma > lastDot ? "," : ".";
+  } else if (lastComma !== -1) {
+    if (!thousandStyleComma.test(digitsOnly)) {
+      decimalSeparator = ",";
+    }
+  } else if (lastDot !== -1) {
+    if (!thousandStyleDot.test(digitsOnly)) {
+      decimalSeparator = ".";
+    }
+  }
+
+  let integerPart = digitsOnly;
+  let fractionalPart = "";
+
+  if (decimalSeparator) {
+    const segments = digitsOnly.split(decimalSeparator);
+    integerPart = segments.shift() ?? "";
+    fractionalPart = segments.join("");
+  }
+
+  integerPart = integerPart.replace(/[.,]/g, "");
+  fractionalPart = fractionalPart.replace(/[.,]/g, "");
+
+  if (!integerPart) {
+    integerPart = "0";
+  }
+
+  const normalized = sign + integerPart + (fractionalPart ? `.${fractionalPart}` : "");
+  return normalized;
+};
+
+export const normalizeNumericInput = (value) => {
   if (typeof value === "number") {
     return Number.isFinite(value) ? value : 0;
   }
 
   if (typeof value === "string") {
-    const sanitized = value.replace(/[^0-9,.-]+/g, "").replace(/,/g, ".");
-    const parsed = parseFloat(sanitized);
+    const normalized = normalizeFormattedNumber(value);
+    const parsed = Number(normalized);
     return Number.isFinite(parsed) ? parsed : 0;
   }
 
-  const coerced = Number(value);
+  const normalized = normalizeFormattedNumber(value);
+  const coerced = Number(normalized);
   return Number.isFinite(coerced) ? coerced : 0;
 };
 
@@ -475,41 +537,6 @@ const getMonthDateRange = (monthKey) => {
 };
 
 const extractNumericValue = (...candidates) => {
-  const normalizeFormattedNumber = (raw) => {
-    if (typeof raw !== "string") {
-      return raw;
-    }
-
-    const trimmed = raw.trim();
-    if (!trimmed) {
-      return trimmed;
-    }
-
-    const direct = Number(trimmed);
-    if (Number.isFinite(direct)) {
-      return direct;
-    }
-
-    const match = trimmed.match(/-?\d+(?:[.,]\d+)?/);
-    if (!match) {
-      return trimmed;
-    }
-
-    const primary = match[0];
-    const thousandStyleDot = /^-?\d{1,3}(\.\d{3})+(,\d+)?$/;
-    const thousandStyleComma = /^-?\d{1,3}(,\d{3})+(\.\d+)?$/;
-
-    if (thousandStyleDot.test(primary)) {
-      return primary.replace(/\./g, "").replace(/,/g, ".");
-    }
-
-    if (thousandStyleComma.test(primary)) {
-      return primary.replace(/,/g, "").replace(/\./g, ".");
-    }
-
-    return primary.replace(/,/g, ".");
-  };
-
   for (const candidate of candidates) {
     if (candidate === undefined || candidate === null) {
       continue;


### PR DESCRIPTION
## Summary
- refactor the executive summary numeric normalizer to share the locale-aware formatting cleaner
- enhance parsing so localized thousand and decimal separators retain the correct magnitudes
- add unit tests covering European and US formatted numeric inputs

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68db6c827dc483278fbf895ba1dab1da