### PR TITLE
Fix Next.js page export by extracting numeric normalizer

### DIFF
--- a/cicero-dashboard/__tests__/normalizeNumericInput.test.ts
+++ b/cicero-dashboard/__tests__/normalizeNumericInput.test.ts
@@ -1,4 +1,4 @@
-import { normalizeNumericInput } from "@/app/executive-summary/page";
+import { normalizeNumericInput } from "@/lib/normalizeNumericInput";
 
 describe("normalizeNumericInput", () => {
   it("parses dot thousand separators", () => {

--- a/cicero-dashboard/app/executive-summary/page.jsx
+++ b/cicero-dashboard/app/executive-summary/page.jsx
@@ -26,85 +26,12 @@ import {
   getRekapKomentarTiktok,
 } from "@/utils/api";
 import { cn } from "@/lib/utils";
+import {
+  normalizeFormattedNumber,
+  normalizeNumericInput,
+} from "@/lib/normalizeNumericInput";
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "";
-
-const normalizeFormattedNumber = (raw) => {
-  if (typeof raw !== "string") {
-    return raw;
-  }
-
-  const trimmed = raw.trim();
-  if (!trimmed) {
-    return trimmed;
-  }
-
-  const sign = trimmed.startsWith("-") ? "-" : "";
-  const numericPortion = trimmed.replace(/[^0-9.,-]/g, "");
-  const digitsOnly = numericPortion.replace(/[^0-9.,]/g, "");
-
-  if (!digitsOnly) {
-    const direct = Number(trimmed);
-    if (Number.isFinite(direct)) {
-      return direct;
-    }
-    return trimmed;
-  }
-
-  const thousandStyleDot = /^-?\d{1,3}(\.\d{3})+$/;
-  const thousandStyleComma = /^-?\d{1,3}(,\d{3})+$/;
-
-  const lastComma = digitsOnly.lastIndexOf(",");
-  const lastDot = digitsOnly.lastIndexOf(".");
-  let decimalSeparator = null;
-
-  if (lastComma !== -1 && lastDot !== -1) {
-    decimalSeparator = lastComma > lastDot ? "," : ".";
-  } else if (lastComma !== -1) {
-    if (!thousandStyleComma.test(digitsOnly)) {
-      decimalSeparator = ",";
-    }
-  } else if (lastDot !== -1) {
-    if (!thousandStyleDot.test(digitsOnly)) {
-      decimalSeparator = ".";
-    }
-  }
-
-  let integerPart = digitsOnly;
-  let fractionalPart = "";
-
-  if (decimalSeparator) {
-    const segments = digitsOnly.split(decimalSeparator);
-    integerPart = segments.shift() ?? "";
-    fractionalPart = segments.join("");
-  }
-
-  integerPart = integerPart.replace(/[.,]/g, "");
-  fractionalPart = fractionalPart.replace(/[.,]/g, "");
-
-  if (!integerPart) {
-    integerPart = "0";
-  }
-
-  const normalized = sign + integerPart + (fractionalPart ? `.${fractionalPart}` : "");
-  return normalized;
-};
-
-export const normalizeNumericInput = (value) => {
-  if (typeof value === "number") {
-    return Number.isFinite(value) ? value : 0;
-  }
-
-  if (typeof value === "string") {
-    const normalized = normalizeFormattedNumber(value);
-    const parsed = Number(normalized);
-    return Number.isFinite(parsed) ? parsed : 0;
-  }
-
-  const normalized = normalizeFormattedNumber(value);
-  const coerced = Number(normalized);
-  return Number.isFinite(coerced) ? coerced : 0;
-};
 
 const clamp = (value, min, max) => {
   if (!Number.isFinite(value)) {

--- a/cicero-dashboard/lib/normalizeNumericInput.js
+++ b/cicero-dashboard/lib/normalizeNumericInput.js
@@ -1,0 +1,78 @@
+export const normalizeFormattedNumber = (raw) => {
+  if (typeof raw !== "string") {
+    return raw;
+  }
+
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return trimmed;
+  }
+
+  const sign = trimmed.startsWith("-") ? "-" : "";
+  const numericPortion = trimmed.replace(/[^0-9.,-]/g, "");
+  const digitsOnly = numericPortion.replace(/[^0-9.,]/g, "");
+
+  if (!digitsOnly) {
+    const direct = Number(trimmed);
+    if (Number.isFinite(direct)) {
+      return direct;
+    }
+    return trimmed;
+  }
+
+  const thousandStyleDot = /^-?\d{1,3}(\.\d{3})+$/;
+  const thousandStyleComma = /^-?\d{1,3}(,\d{3})+$/;
+
+  const lastComma = digitsOnly.lastIndexOf(",");
+  const lastDot = digitsOnly.lastIndexOf(".");
+  let decimalSeparator = null;
+
+  if (lastComma !== -1 && lastDot !== -1) {
+    decimalSeparator = lastComma > lastDot ? "," : ".";
+  } else if (lastComma !== -1) {
+    if (!thousandStyleComma.test(digitsOnly)) {
+      decimalSeparator = ",";
+    }
+  } else if (lastDot !== -1) {
+    if (!thousandStyleDot.test(digitsOnly)) {
+      decimalSeparator = ".";
+    }
+  }
+
+  let integerPart = digitsOnly;
+  let fractionalPart = "";
+
+  if (decimalSeparator) {
+    const segments = digitsOnly.split(decimalSeparator);
+    integerPart = segments.shift() ?? "";
+    fractionalPart = segments.join("");
+  }
+
+  integerPart = integerPart.replace(/[.,]/g, "");
+  fractionalPart = fractionalPart.replace(/[.,]/g, "");
+
+  if (!integerPart) {
+    integerPart = "0";
+  }
+
+  const normalized = sign + integerPart + (fractionalPart ? `.${fractionalPart}` : "");
+  return normalized;
+};
+
+export const normalizeNumericInput = (value) => {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : 0;
+  }
+
+  if (typeof value === "string") {
+    const normalized = normalizeFormattedNumber(value);
+    const parsed = Number(normalized);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+
+  const normalized = normalizeFormattedNumber(value);
+  const coerced = Number(normalized);
+  return Number.isFinite(coerced) ? coerced : 0;
+};
+
+export default normalizeNumericInput;


### PR DESCRIPTION
## Summary
- move numeric normalization helpers from the executive summary page into a dedicated library module
- update the page to import the shared helpers instead of exporting them directly
- adjust the numeric normalization unit test to use the new module path

## Testing
- npm test -- normalizeNumericInput

------
https://chatgpt.com/codex/tasks/task_e_68db6dfd033c83278443e32228b9af14