### PR TITLE
Fix aggregator query param naming for executive summary

### DIFF
--- a/cicero-dashboard/app/executive-summary/page.jsx
+++ b/cicero-dashboard/app/executive-summary/page.jsx
@@ -1929,7 +1929,7 @@ export default function ExecutiveSummaryPage() {
         }
 
         if (clientId) {
-          params.set("clientId", String(clientId));
+          params.set("client_id", String(clientId));
         }
 
         const baseUrl = (API_BASE_URL || "").replace(/\/+$/, "");


### PR DESCRIPTION
## Summary
- update the executive summary aggregator request to send the `client_id` query parameter expected by the backend

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db76cfb7808327a2175b74f06d1cb4