### PR TITLE
Send date range when fetching aggregator metrics

### DIFF
--- a/cicero-dashboard/app/executive-summary/page.jsx
+++ b/cicero-dashboard/app/executive-summary/page.jsx
@@ -1925,7 +1925,11 @@ export default function ExecutiveSummaryPage() {
 
         const range = getMonthDateRange(selectedMonth);
         if (range?.startDate) {
-          params.set("tanggal", range.startDate);
+          params.set("tanggal_mulai", range.startDate);
+        }
+
+        if (range?.endDate) {
+          params.set("tanggal_selesai", range.endDate);
         }
 
         if (clientId) {


### PR DESCRIPTION
## Summary
- include both start and end dates in the aggregator request parameters to avoid duplicate date filters

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db77c922208327815e1947f26f3929