### PR TITLE
Ensure executive summary API calls use selected month range

### DIFF
--- a/cicero-dashboard/app/executive-summary/page.jsx
+++ b/cicero-dashboard/app/executive-summary/page.jsx
@@ -1778,6 +1778,8 @@ export default function ExecutiveSummaryPage() {
       const periodRange = getMonthDateRange(selectedMonth);
       const periodeParam = periodRange ? "bulanan" : undefined;
       const tanggalParam = periodRange?.startDate;
+      const startDateParam = periodRange?.startDate;
+      const endDateParam = periodRange?.endDate;
 
       try {
         const [directoryResponse, statsResult, likesResult, commentsResult] =
@@ -1787,8 +1789,8 @@ export default function ExecutiveSummaryPage() {
               token,
               periodeParam,
               tanggalParam,
-              undefined,
-              undefined,
+              startDateParam,
+              endDateParam,
               clientId,
               controller.signal,
             ),
@@ -1797,8 +1799,8 @@ export default function ExecutiveSummaryPage() {
               clientId,
               periodeParam ?? "bulanan",
               tanggalParam,
-              undefined,
-              undefined,
+              startDateParam,
+              endDateParam,
               controller.signal,
             ).catch((error) => {
               console.warn("Gagal memuat rekap likes IG", error);
@@ -1809,8 +1811,8 @@ export default function ExecutiveSummaryPage() {
               clientId,
               periodeParam ?? "bulanan",
               tanggalParam,
-              undefined,
-              undefined,
+              startDateParam,
+              endDateParam,
               controller.signal,
             ).catch((error) => {
               console.warn("Gagal memuat rekap komentar TikTok", error);


### PR DESCRIPTION
## Summary
- include the selected month date range when requesting dashboard stats and engagement recaps
- ensure Instagram and TikTok recap endpoints receive the same start and end dates as the selected month

## Testing
- not run (npm run lint prompts for interactive setup in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68db822b1ad48327af6af4119e499aac