### PR TITLE
Fix platform metric filter by month on executive summary

### DIFF
--- a/cicero-dashboard/app/executive-summary/page.jsx
+++ b/cicero-dashboard/app/executive-summary/page.jsx
@@ -1928,10 +1928,17 @@ export default function ExecutiveSummaryPage() {
         const range = getMonthDateRange(selectedMonth);
         if (range?.startDate) {
           params.set("tanggal_mulai", range.startDate);
+          params.set("start_date", range.startDate);
+          params.set("tanggal", range.startDate);
         }
 
         if (range?.endDate) {
           params.set("tanggal_selesai", range.endDate);
+          params.set("end_date", range.endDate);
+        }
+
+        if (selectedMonth) {
+          params.set("month", selectedMonth);
         }
 
         if (clientId) {


### PR DESCRIPTION
## Summary
- ensure the executive summary's platform metrics request forwards explicit month and date parameters so the API can filter results correctly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db895cd28083279964c9206df21dcc