### PR TITLE
Fix activity ratio classification when no content exists

### DIFF
--- a/cicero-dashboard/__tests__/computeActivityBuckets.test.ts
+++ b/cicero-dashboard/__tests__/computeActivityBuckets.test.ts
@@ -1,0 +1,33 @@
+import { computeActivityBuckets } from "@/app/executive-summary/page";
+
+describe("computeActivityBuckets", () => {
+  it("does not classify participants without content as most active", () => {
+    const users = [
+      {
+        id: "user-1",
+        username: "user.one",
+      },
+    ];
+
+    const likes = [
+      {
+        user_id: "user-1",
+        jumlah_like: 5,
+      },
+    ];
+
+    const result = computeActivityBuckets({
+      users,
+      likes,
+      comments: [],
+      totalIGPosts: 0,
+      totalTikTokPosts: 0,
+    });
+
+    const mostActive = result.categories.find((category) => category.key === "most-active");
+    const lowActivity = result.categories.find((category) => category.key === "low");
+
+    expect(mostActive?.count).toBe(0);
+    expect(lowActivity?.count).toBe(1);
+  });
+});

--- a/cicero-dashboard/app/executive-summary/page.jsx
+++ b/cicero-dashboard/app/executive-summary/page.jsx
@@ -1233,7 +1233,12 @@ const computeActivityBuckets = ({
       numerator += Math.min(commentCount, safeTikTokPosts);
     }
 
-    const ratio = denominator > 0 ? numerator / denominator : 1;
+    if (denominator === 0) {
+      low += 1;
+      return;
+    }
+
+    const ratio = numerator / denominator;
     const clampedRatio = Math.max(0, Math.min(ratio, 1));
 
     if (clampedRatio >= 0.9) {
@@ -2918,3 +2923,5 @@ export default function ExecutiveSummaryPage() {
     </div>
   );
 }
+
+export { computeActivityBuckets };


### PR DESCRIPTION
## Summary
- adjust activity bucket computation to treat zero-content participants as low activity instead of most active
- export the activity computation helper and cover the zero-content case with a regression test

## Testing
- npm test -- --runTestsByPath __tests__/computeActivityBuckets.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68db8e78dd748327bc75a614a27d2c1a