### PR TITLE
Fix platform detail grid layout

### DIFF
--- a/cicero-dashboard/app/executive-summary/page.jsx
+++ b/cicero-dashboard/app/executive-summary/page.jsx
@@ -3243,7 +3243,7 @@ export default function ExecutiveSummaryPage() {
               return (
                 <div
                   key={platform.key}
-                  className="grid gap-6 lg:grid-cols-[minmax(0,1.4fr)_minmax(0,1.6fr)]"
+                  className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,1.4fr)_minmax(0,1.6fr)] lg:items-start"
                 >
                   <div className="space-y-6">
                     <PlatformOverviewCard


### PR DESCRIPTION
## Summary
- ensure the platform detail section falls back to a single-column grid on smaller viewports to prevent cards from overlapping
- align grid items to the top of their tracks so each platform card keeps consistent spacing

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68dbd1a6b1e88327a9451863cd71e224