### PR TITLE
Expand executive summary month options

### DIFF
--- a/cicero-dashboard/__tests__/executiveSummaryMonthOptions.test.ts
+++ b/cicero-dashboard/__tests__/executiveSummaryMonthOptions.test.ts
@@ -1,0 +1,20 @@
+import { mergeAvailableMonthOptions } from "../app/executive-summary/page";
+
+describe("mergeAvailableMonthOptions", () => {
+  it("keeps earlier months of the current year selectable when the actual year exceeds the resolved year", () => {
+    const availableYears = [2023, 2024];
+    const options = mergeAvailableMonthOptions({
+      availableYears,
+      locale: "id-ID",
+      now: new Date("2025-03-18T00:00:00Z"),
+    });
+
+    const optionKeys = options.map((option) => option.key);
+
+    expect(optionKeys[0]).toBe("2025-03");
+    expect(optionKeys).toContain("2025-02");
+    expect(optionKeys).toContain("2025-01");
+    expect(new Set(optionKeys).size).toBe(optionKeys.length);
+    expect(optionKeys[optionKeys.length - 1]).toBe("2023-01");
+  });
+});


### PR DESCRIPTION
## Summary
- merge available month options across available years with current year months and keep them sorted newest-first
- reuse the merged month helper in the executive summary page to ensure curated data always finds the latest entry
- add a unit test covering the scenario where the actual year surpasses the resolved year

## Testing
- npm test -- executiveSummaryMonthOptions.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dbf052772083279f62ebabfcb63622