### PR TITLE
Add TikTok weekly trend analysis to executive summary

### DIFF
--- a/cicero-dashboard/components/executive-summary/WeeklyTrendCard.tsx
+++ b/cicero-dashboard/components/executive-summary/WeeklyTrendCard.tsx
@@ -27,6 +27,8 @@ type WeeklyTrendSeriesPoint = {
   label?: string;
   posts?: number;
   likes?: number;
+  primary?: number;
+  secondary?: number;
 };
 
 type WeeklyTrendCardProps = {
@@ -40,6 +42,8 @@ type WeeklyTrendCardProps = {
   series?: WeeklyTrendSeriesPoint[];
   formatNumber?: FormatNumberFn;
   formatPercent?: FormatPercentFn;
+  primaryMetricLabel?: string;
+  secondaryMetricLabel?: string;
 };
 
 const defaultNumberFormatter: FormatNumberFn = (value, options) => {
@@ -71,6 +75,8 @@ const WeeklyTrendCard: React.FC<WeeklyTrendCardProps> = ({
   series = [],
   formatNumber = defaultNumberFormatter,
   formatPercent = defaultPercentFormatter,
+  primaryMetricLabel = "Post",
+  secondaryMetricLabel = "Likes",
 }) => {
   if (loading) {
     return (
@@ -221,8 +227,13 @@ const WeeklyTrendCard: React.FC<WeeklyTrendCardProps> = ({
                   {item.label ?? item.key}
                 </p>
                 <p className="mt-1 text-slate-400">
-                  Post: {formatNumber(item.posts ?? 0, { maximumFractionDigits: 0 })} • Likes: {" "}
-                  {formatNumber(item.likes ?? 0, { maximumFractionDigits: 0 })}
+                  {primaryMetricLabel}: {" "}
+                  {formatNumber(item.primary ?? item.posts ?? 0, {
+                    maximumFractionDigits: 0,
+                  })} {" "}• {secondaryMetricLabel}: {" "}
+                  {formatNumber(item.secondary ?? item.likes ?? 0, {
+                    maximumFractionDigits: 0,
+                  })}
                 </p>
               </div>
             ))}


### PR DESCRIPTION
## Summary
- extend the weekly grouping helper to accept explicit date path hints for activity rollups
- add TikTok weekly post/comment aggregation, expose comparison metrics, and render the Instagram/TikTok cards side by side with appropriate guards
- enhance WeeklyTrendCard so the weekly series supports customizable metric labels used by both platforms

## Testing
- npm run lint *(fails: prompts for ESLint configuration in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc9760ba8c8327b851c4bb2ebd84cf