### PR TITLE
Normalize client social usernames

### DIFF
--- a/cicero-dashboard/app/dashboard/page.tsx
+++ b/cicero-dashboard/app/dashboard/page.tsx
@@ -111,11 +111,47 @@ const pickNumericValue = (source: any, paths: string[]): number => {
 };
 
 export default function DashboardPage() {
-  const { token } = useAuth();
+  const { token, profile } = useAuth();
   const [igProfile, setIgProfile] = useState<any>(null);
   const [igPosts, setIgPosts] = useState<any[]>([]);
   const [tiktokProfile, setTiktokProfile] = useState<any>(null);
   const [tiktokPosts, setTiktokPosts] = useState<any[]>([]);
+
+  const clientUsernames = useMemo(() => {
+    const sanitizeUsername = (value: unknown) =>
+      typeof value === "string" ? value.replace(/^@+/, "").trim() : "";
+
+    const pickUsername = (candidates: unknown[]) => {
+      for (const candidate of candidates) {
+        const sanitized = sanitizeUsername(candidate);
+        if (sanitized) return sanitized;
+      }
+      return "";
+    };
+
+    const instagram = pickUsername([
+      profile?.client?.client_insta,
+      profile?.client_insta,
+      profile?.client?.instagram,
+      profile?.instagram,
+      profile?.client?.instagram_username,
+      profile?.instagram_username,
+    ]);
+
+    const tiktok = pickUsername([
+      profile?.client?.client_tiktok,
+      profile?.client_tiktok,
+      profile?.client?.tiktok,
+      profile?.tiktok,
+      profile?.client?.tiktok_username,
+      profile?.tiktok_username,
+    ]);
+
+    return {
+      instagram: instagram || undefined,
+      tiktok: tiktok || undefined,
+    } as const;
+  }, [profile]);
 
   useEffect(() => {
     if (!token) return;
@@ -725,6 +761,7 @@ export default function DashboardPage() {
               },
               {} as Record<string, (typeof analytics.platforms)[number]>
             )}
+            clientUsernames={clientUsernames}
           />
         </section>
 

--- a/cicero-dashboard/components/SocialCardsClient.tsx
+++ b/cicero-dashboard/components/SocialCardsClient.tsx
@@ -28,6 +28,7 @@ interface Props {
   tiktokProfile: any;
   tiktokPosts: any[];
   platformMetrics?: Record<string, PlatformMetric>;
+  clientUsernames?: Partial<Record<PlatformKey, string>>;
 }
 
 const formatNumber = (value?: number) => {
@@ -45,6 +46,7 @@ export default function SocialCardsClient({
   tiktokProfile,
   tiktokPosts,
   platformMetrics,
+  clientUsernames,
 }: Props) {
   const [platform, setPlatform] = useState<"all" | PlatformKey>("all");
   const instagramProfileRef = useRef<HTMLDivElement>(null);
@@ -111,6 +113,7 @@ export default function SocialCardsClient({
             platform={key}
             profile={key === "instagram" ? igProfile : tiktokProfile}
             postCount={key === "instagram" ? igPosts.length : tiktokPosts.length}
+            username={clientUsernames?.[key]}
           />
         </div>
         <SocialPostsCard


### PR DESCRIPTION
## Summary
- normalize client Instagram and TikTok usernames from the auth profile for the dashboard
- allow overriding SocialProfileCard handles/links via optional usernames propagated through SocialCardsClient

## Testing
- npm run lint *(fails: command prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68dca17d351c8327aaf0ba8ff371d7a0