### PR TITLE
Ensure executive summary weekly trends use dated records

### DIFF
--- a/cicero-dashboard/__tests__/executiveSummaryWeeklyTrend.test.ts
+++ b/cicero-dashboard/__tests__/executiveSummaryWeeklyTrend.test.ts
@@ -1,0 +1,49 @@
+import { groupRecordsByWeek, shouldShowWeeklyTrendCard } from "@/app/executive-summary/page";
+
+describe("groupRecordsByWeek weekly trend integration", () => {
+  it("groups instagram activity into weekly buckets and shows the trend card", () => {
+    const records = [
+      { tanggal: "2024-05-01", jumlah_like: 5 },
+      { tanggal: "2024-05-03", jumlah_like: 3 },
+      { tanggal: "2024-05-08", jumlah_like: 2 },
+    ];
+
+    const buckets = groupRecordsByWeek(records);
+
+    expect(buckets).toHaveLength(2);
+    expect(buckets[0].records).toHaveLength(2);
+    expect(buckets[1].records).toHaveLength(1);
+
+    const shouldShow = shouldShowWeeklyTrendCard({
+      showPlatformLoading: false,
+      platformError: "",
+      hasMonthlyPlatforms: false,
+      cardHasRecords: buckets.length > 0,
+    });
+
+    expect(shouldShow).toBe(true);
+  });
+
+  it("groups tiktok activity into weekly buckets and shows the trend card", () => {
+    const records = [
+      { created_at: "2024-06-10T07:00:00Z", komentar: 4 },
+      { created_at: "2024-06-12T07:00:00Z", komentar: 6 },
+      { created_at: "2024-06-19T07:00:00Z", komentar: 1 },
+    ];
+
+    const buckets = groupRecordsByWeek(records);
+
+    expect(buckets).toHaveLength(2);
+    expect(buckets[0].records).toHaveLength(2);
+    expect(buckets[1].records).toHaveLength(1);
+
+    const shouldShow = shouldShowWeeklyTrendCard({
+      showPlatformLoading: false,
+      platformError: "",
+      hasMonthlyPlatforms: false,
+      cardHasRecords: buckets.length > 0,
+    });
+
+    expect(shouldShow).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- normalize social activity records with explicit dates by switching the executive summary to daily recaps and filtering platform posts before grouping
- centralize weekly trend visibility logic and reuse it for Instagram and TikTok cards
- add Jest coverage that verifies dated records create weekly buckets and surface the trend cards

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dcae73d2448327aad2303f3439058b