### PR TITLE
Use interaction fallback for weekly engagement rate

### DIFF
--- a/cicero-dashboard/app/executive-summary/page.jsx
+++ b/cicero-dashboard/app/executive-summary/page.jsx
@@ -116,6 +116,9 @@ const buildPlatformWeeklyEngagement = (platform) => {
     return { series: [], latest: null, previous: null };
   }
 
+  const followerCountRaw = Number(platform?.followers);
+  const followerCount = Number.isFinite(followerCountRaw) ? followerCountRaw : 0;
+
   const weeklyGroups = groupRecordsByWeek(posts, {
     getDate: (post) => {
       if (post?.publishedAt instanceof Date) {
@@ -189,8 +192,19 @@ const buildPlatformWeeklyEngagement = (platform) => {
       { interactions: 0, engagementSum: 0, engagementCount: 0, postCount: 0 },
     );
 
-    const averageEngagement =
+    let averageEngagement =
       totals.engagementCount > 0 ? totals.engagementSum / totals.engagementCount : 0;
+
+    if (totals.engagementCount === 0) {
+      const fallbackEngagement =
+        followerCount > 0
+          ? (totals.interactions / followerCount) * 100
+          : totals.postCount > 0
+          ? totals.interactions / totals.postCount
+          : 0;
+
+      averageEngagement = Math.max(0, fallbackEngagement);
+    }
 
     return {
       key: group.key,


### PR DESCRIPTION
## Summary
- capture each platform's follower count before building weekly trend data
- backfill missing engagement rates with interaction-derived fallbacks so the trend line stays populated
- align fallback values with existing percent formatting used by the weekly engagement chart

## Testing
- npm install
- npm run dev


------
https://chatgpt.com/codex/tasks/task_e_68dcba0398f083278e628c53b445b65c