### PR TITLE
Fix weekly trend grouping for dated posts

### DIFF
--- a/cicero-dashboard/__tests__/executiveSummaryWeeklyTrend.test.ts
+++ b/cicero-dashboard/__tests__/executiveSummaryWeeklyTrend.test.ts
@@ -1,5 +1,6 @@
 import {
   groupRecordsByWeek,
+  resolveRecordDate,
   shouldShowWeeklyTrendCard,
 } from "@/app/executive-summary/weeklyTrendUtils";
 
@@ -35,6 +36,41 @@ describe("groupRecordsByWeek weekly trend integration", () => {
     ];
 
     const buckets = groupRecordsByWeek(records);
+
+    expect(buckets).toHaveLength(2);
+    expect(buckets[0].records).toHaveLength(2);
+    expect(buckets[1].records).toHaveLength(1);
+
+    const shouldShow = shouldShowWeeklyTrendCard({
+      showPlatformLoading: false,
+      platformError: "",
+      hasMonthlyPlatforms: false,
+      cardHasRecords: buckets.length > 0,
+    });
+
+    expect(shouldShow).toBe(true);
+  });
+
+  it("groups posts with only date/tanggal fields and shows the trend card", () => {
+    const posts = [
+      { tanggal: "2024-07-01", likes: 2 },
+      { date: "2024-07-02", likes: 1 },
+      { tanggal: "2024-07-09", likes: 5 },
+    ];
+
+    const buckets = groupRecordsByWeek(posts, {
+      getDate: (post) => {
+        const resolved = resolveRecordDate(post, [
+          "publishedAt",
+          "published_at",
+          "timestamp",
+          "createdAt",
+          "created_at",
+        ]);
+
+        return resolved?.parsed ?? null;
+      },
+    });
 
     expect(buckets).toHaveLength(2);
     expect(buckets[0].records).toHaveLength(2);

--- a/cicero-dashboard/app/executive-summary/page.jsx
+++ b/cicero-dashboard/app/executive-summary/page.jsx
@@ -4093,16 +4093,15 @@ export default function ExecutiveSummaryPage() {
 
     const weeklyPosts = groupRecordsByWeek(instagramPosts, {
       getDate: (post) => {
-        if (post?.publishedAt instanceof Date) {
-          return post.publishedAt;
-        }
-        return (
-          post?.createdAt ??
-          post?.created_at ??
-          post?.timestamp ??
-          post?.published_at ??
-          null
-        );
+        const resolved = resolveRecordDate(post, [
+          "publishedAt",
+          "published_at",
+          "timestamp",
+          "createdAt",
+          "created_at",
+        ]);
+
+        return resolved?.parsed ?? null;
       },
     });
 
@@ -4245,16 +4244,15 @@ export default function ExecutiveSummaryPage() {
 
     const weeklyPosts = groupRecordsByWeek(tiktokPosts, {
       getDate: (post) => {
-        if (post?.publishedAt instanceof Date) {
-          return post.publishedAt;
-        }
-        return (
-          post?.createdAt ??
-          post?.created_at ??
-          post?.timestamp ??
-          post?.published_at ??
-          null
-        );
+        const resolved = resolveRecordDate(post, [
+          "publishedAt",
+          "published_at",
+          "timestamp",
+          "createdAt",
+          "created_at",
+        ]);
+
+        return resolved?.parsed ?? null;
       },
     });
 


### PR DESCRIPTION
## Summary
- ensure instagram and tiktok weekly post grouping resolves dates via resolveRecordDate so tanggal/date/activityDate fields are honored
- add a unit test covering posts that only provide tanggal/date fields to keep the weekly trend card visible

## Testing
- npm test -- --runTestsByPath __tests__/executiveSummaryWeeklyTrend.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dcbf7116788327983f1a00d2384263