### PR TITLE
Fix tooltip formatting for engagement chart

### DIFF
--- a/cicero-dashboard/components/executive-summary/PlatformEngagementTrendChart.tsx
+++ b/cicero-dashboard/components/executive-summary/PlatformEngagementTrendChart.tsx
@@ -268,27 +268,30 @@ const PlatformEngagementTrendChart: React.FC<PlatformEngagementTrendChartProps> 
                 color: "#e2e8f0",
               }}
               formatter={(value: number, name: string, payload) => {
-                if (name === "engagementRate") {
-                  return [formatPercent(value ?? 0), "Engagement Rate"];
-                }
+                const tooltipEntry =
+                  payload && typeof payload === "object"
+                    ? (payload as { dataKey?: string | undefined })
+                    : undefined;
+                const dataKey = tooltipEntry?.dataKey;
 
-                if (name === "interactions") {
+                if (
+                  dataKey === "engagementRate" ||
+                  name === "engagementRate" ||
+                  name === "Engagement Rate"
+                ) {
                   return [
-                    formatNumber(value ?? 0, { maximumFractionDigits: 0 }),
-                    "Total Interaksi",
+                    formatPercent(Number.isFinite(value) ? Number(value) : 0),
+                    "Engagement Rate",
                   ];
                 }
 
-                if (payload && typeof payload === "object" && "payload" in payload) {
-                  const dataPoint = (payload as any).payload as { interactions?: number };
-                  if (dataPoint?.interactions !== undefined) {
-                    return [
-                      formatNumber(dataPoint.interactions ?? 0, {
-                        maximumFractionDigits: 0,
-                      }),
-                      "Total Interaksi",
-                    ];
-                  }
+                if (dataKey === "interactions" || name === "interactions") {
+                  return [
+                    formatNumber(Number.isFinite(value) ? Number(value) : 0, {
+                      maximumFractionDigits: 0,
+                    }),
+                    "Total Interaksi",
+                  ];
                 }
 
                 return [value, name];


### PR DESCRIPTION
## Summary
- ensure the tooltip formatter matches the engagement series name/data key so engagement rate is shown as a percent
- simplify the interactions fallback to trigger only for the interactions data key

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcd82484d08327852fef44e790cbb3