### PR TITLE
Default executive summary to current month option

### DIFF
--- a/cicero-dashboard/app/executive-summary/page.jsx
+++ b/cicero-dashboard/app/executive-summary/page.jsx
@@ -3486,25 +3486,14 @@ export default function ExecutiveSummaryPage() {
       data.platformAnalytics.platforms.length > 0;
 
     const monthOptionKeys = new Set(monthOptions.map((option) => option.key));
-    const currentMonthHasOption = monthOptionKeys.has(currentMonthKey);
-
-    if (currentMonthHasOption && hasCuratedData(monthlyData[currentMonthKey])) {
+    if (monthOptionKeys.has(currentMonthKey)) {
       return currentMonthKey;
     }
 
-    const availableDataKeys = Object.keys(monthlyData)
-      .filter((key) => monthOptionKeys.has(key))
-      .sort()
-      .reverse();
-
-    for (const key of availableDataKeys) {
-      if (hasCuratedData(monthlyData[key])) {
-        return key;
+    for (const option of monthOptions) {
+      if (hasCuratedData(monthlyData[option.key])) {
+        return option.key;
       }
-    }
-
-    if (currentMonthHasOption) {
-      return currentMonthKey;
     }
 
     return monthOptions[0]?.key ?? currentMonthKey;


### PR DESCRIPTION
## Summary
- always default the executive summary view to the current month when it exists in the available options
- preserve curated month fallback only when the current month option is unavailable
- keep derived year and month index logic aligned with the updated default month selection

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68dce2a6ac3c832799176e971a4562eb