### PR TITLE
Restore weekly trend helper definition

### DIFF
--- a/cicero-dashboard/app/executive-summary/page.jsx
+++ b/cicero-dashboard/app/executive-summary/page.jsx
@@ -91,9 +91,7 @@ const formatPercent = (value) => {
   })}%`;
 };
 
-
-  }
-
+const computePlatformWeeklyTrend = (platform, posts = []) => {
   const followerCountRaw = Number(platform?.followers);
   const followerCount = Number.isFinite(followerCountRaw) ? followerCountRaw : 0;
 
@@ -1094,10 +1092,6 @@ const buildLikesSummaryFromRecords = (records = []) => {
   };
 };
 
-
-
-
-};
 
 
 const monthlyData = {


### PR DESCRIPTION
## Summary
- reinstate the `computePlatformWeeklyTrend` helper wrapper so the weekly aggregation logic executes in context
- remove an orphaned closing brace near the monthly data block to keep the module syntax valid

## Testing
- npm run build *(fails: next/font cannot download Geist fonts from fonts.gstatic.com in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dcf3799b4c832785c7cd76d90a0610