### PR TITLE
Add activity bucket helper and tests

### DIFF
--- a/cicero-dashboard/__tests__/executiveSummaryActivityBuckets.test.ts
+++ b/cicero-dashboard/__tests__/executiveSummaryActivityBuckets.test.ts
@@ -1,0 +1,110 @@
+import { computeActivityBuckets } from "@/app/executive-summary/page";
+
+describe("computeActivityBuckets", () => {
+  const baseUsers = [
+    { username: "Alpha" },
+    { username: "Bravo" },
+    { username: "Charlie" },
+  ];
+
+  const findCategory = (categories: any[], key: string) =>
+    categories.find((category) => category.key === key);
+
+  it("mengelompokkan personil aktif Instagram saja", () => {
+    const result = computeActivityBuckets({
+      users: baseUsers,
+      likes: [
+        { username: "Alpha" },
+        { username: "alpha" },
+        { username: "BRAVO" },
+      ],
+      comments: [],
+      totalIGPosts: "10",
+      totalTikTokPosts: 5,
+    });
+
+    expect(result.evaluatedUsers).toBe(3);
+    expect(result.totalContent).toBe(15);
+
+    const instagram = findCategory(result.categories, "instagram-active");
+    const tiktok = findCategory(result.categories, "tiktok-active");
+    const passive = findCategory(result.categories, "passive");
+
+    expect(instagram?.count).toBe(2);
+    expect(tiktok?.count).toBe(0);
+    expect(passive?.count).toBe(1);
+  });
+
+  it("mengelompokkan personil aktif TikTok saja", () => {
+    const result = computeActivityBuckets({
+      users: baseUsers,
+      likes: [],
+      comments: [
+        { username: "Charlie" },
+        { username: "CHARLIE" },
+      ],
+      totalIGPosts: 0,
+      totalTikTokPosts: "8",
+    });
+
+    expect(result.evaluatedUsers).toBe(3);
+    expect(result.totalContent).toBe(8);
+
+    const instagram = findCategory(result.categories, "instagram-active");
+    const tiktok = findCategory(result.categories, "tiktok-active");
+    const passive = findCategory(result.categories, "passive");
+
+    expect(instagram?.count).toBe(0);
+    expect(tiktok?.count).toBe(1);
+    expect(passive?.count).toBe(2);
+  });
+
+  it("menggabungkan aktivitas Instagram dan TikTok", () => {
+    const result = computeActivityBuckets({
+      users: baseUsers,
+      likes: [{ username: "Alpha" }],
+      comments: [
+        { username: "Bravo" },
+        { username: "Alpha" },
+      ],
+      totalIGPosts: 2,
+      totalTikTokPosts: 3,
+    });
+
+    expect(result.evaluatedUsers).toBe(3);
+    expect(result.totalContent).toBe(5);
+
+    const instagram = findCategory(result.categories, "instagram-active");
+    const tiktok = findCategory(result.categories, "tiktok-active");
+    const passive = findCategory(result.categories, "passive");
+
+    expect(instagram?.count).toBe(1);
+    expect(tiktok?.count).toBe(2);
+    expect(passive?.count).toBe(1);
+  });
+
+  it("menghitung personil pasif ketika tidak ada aktivitas yang cocok", () => {
+    const result = computeActivityBuckets({
+      users: [
+        { username: "Alpha" },
+        { username: "ALPHA" },
+        { username: "Bravo" },
+      ],
+      likes: [{ username: "Delta" }],
+      comments: [],
+      totalIGPosts: 1,
+      totalTikTokPosts: undefined,
+    });
+
+    expect(result.evaluatedUsers).toBe(2);
+    expect(result.totalContent).toBe(1);
+
+    const instagram = findCategory(result.categories, "instagram-active");
+    const tiktok = findCategory(result.categories, "tiktok-active");
+    const passive = findCategory(result.categories, "passive");
+
+    expect(instagram?.count).toBe(0);
+    expect(tiktok?.count).toBe(0);
+    expect(passive?.count).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add a computeActivityBuckets helper to classify personnel activity based on Instagram likes and TikTok comments
- derive evaluated user counts, total content, and category metadata for the executive summary view
- add targeted unit tests covering Instagram-only, TikTok-only, combined, and passive scenarios

## Testing
- npm test -- --runTestsByPath __tests__/executiveSummaryActivityBuckets.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dd108be32883279b413f9e049264e8