### PR TITLE
Fix Next.js page export by making utility local

### DIFF
--- a/cicero-dashboard/app/executive-summary/page.jsx
+++ b/cicero-dashboard/app/executive-summary/page.jsx
@@ -928,7 +928,7 @@ const normalizeUserKeyFromRecord = (record = {}) => {
   return null;
 };
 
-export const computeActivityBuckets = ({
+const computeActivityBuckets = ({
   users,
   likes,
   comments,


### PR DESCRIPTION
## Summary
- scope `computeActivityBuckets` to the executive summary page module so it is no longer exported as a page field

## Testing
- not run (lint command requires interactive configuration)

------
https://chatgpt.com/codex/tasks/task_e_68dd131c47f8832798e20acbbb0f0861