### PR TITLE
Fix client name fallback precedence

### DIFF
--- a/cicero-dashboard/app/executive-summary/page.jsx
+++ b/cicero-dashboard/app/executive-summary/page.jsx
@@ -139,7 +139,7 @@ const aggregateLikesRecords = (records = []) => {
           record?.client ??
           record?.namaClient ??
           record?.nama ??
-          clientId || "LAINNYA",
+          (clientId || "LAINNYA"),
       ).trim() || "LAINNYA";
 
     const likes = toSafeNumber(


### PR DESCRIPTION
## Summary
- wrap the client name fallback expression in parentheses to avoid mixing nullish coalescing with logical operators

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd2db1aa44832789ef7bf6f43adb5d