### PR TITLE
Fix Instagram weekly trend date handling

### DIFF
--- a/cicero-dashboard/__tests__/executiveSummaryWeeklyTrend.test.ts
+++ b/cicero-dashboard/__tests__/executiveSummaryWeeklyTrend.test.ts
@@ -68,6 +68,48 @@ describe("groupRecordsByWeek weekly trend integration", () => {
     expect(totalLikes).toBe(12);
   });
 
+  it("uses activityDate ISO values when grouping instagram likes by week", () => {
+    const records = [
+      {
+        tanggal: "31/05/2024",
+        activityDate: "2024-05-31T00:00:00.000Z",
+        jumlah_like: 5,
+      },
+      {
+        tanggal: "01/06/2024",
+        activityDate: "2024-06-01T00:00:00.000Z",
+        rekap: { total_like: "7" },
+      },
+    ];
+
+    const weeklyLikes = groupRecordsByWeek(records, {
+      datePaths: [
+        "activityDate",
+        "tanggal",
+        "date",
+        "created_at",
+        "createdAt",
+        "updated_at",
+        "updatedAt",
+        "time",
+        "waktu",
+        "rekap.tanggal",
+        "rekap.date",
+        "rekap.created_at",
+        "rekap.createdAt",
+      ],
+    });
+
+    expect(weeklyLikes).toHaveLength(1);
+
+    const totalLikes = sumActivityRecords(
+      weeklyLikes[0].records,
+      INSTAGRAM_LIKE_FIELD_PATHS,
+    );
+
+    expect(totalLikes).toBe(12);
+  });
+
   it("aggregates tiktok comments from daily activity records", () => {
     const records = [
       { created_at: "2024-06-10T07:00:00Z", komentar: 4 },

--- a/cicero-dashboard/app/executive-summary/page.jsx
+++ b/cicero-dashboard/app/executive-summary/page.jsx
@@ -1983,6 +1983,12 @@ const sumActivityRecords = (records, fields) => {
   }, 0);
 };
 
+export {
+  INSTAGRAM_LIKE_FIELD_PATHS,
+  TIKTOK_COMMENT_FIELD_PATHS,
+  sumActivityRecords,
+};
+
 const monthlyData = {
   "2024-11": {
     monthLabel: "November 2024",
@@ -3476,21 +3482,21 @@ export default function ExecutiveSummaryPage() {
       : [];
 
     const weeklyLikes = groupRecordsByWeek(likesRecords, {
-      getDate: (record) =>
-        record?.tanggal ??
-        record?.date ??
-        record?.created_at ??
-        record?.createdAt ??
-        record?.activityDate ??
-        record?.updated_at ??
-        record?.updatedAt ??
-        record?.waktu ??
-        record?.time ??
-        record?.rekap?.tanggal ??
-        record?.rekap?.date ??
-        record?.rekap?.created_at ??
-        record?.rekap?.createdAt ??
-        null,
+      datePaths: [
+        "activityDate",
+        "tanggal",
+        "date",
+        "created_at",
+        "createdAt",
+        "updated_at",
+        "updatedAt",
+        "time",
+        "waktu",
+        "rekap.tanggal",
+        "rekap.date",
+        "rekap.created_at",
+        "rekap.createdAt",
+      ],
     });
 
     const hasRecords = weeklyPosts.length > 0 || weeklyLikes.length > 0;


### PR DESCRIPTION
## Summary
- ensure instagram weekly likes grouping prioritizes the ISO activityDate values when aggregating
- export activity aggregation helpers and cover localized tanggal formats in the weekly trend test suite

## Testing
- npm test -- --runTestsByPath __tests__/executiveSummaryWeeklyTrend.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dd70eb0494832787823b3ecc36b99c