### PR TITLE
Refactor executive summary activity helpers

### DIFF
--- a/cicero-dashboard/__tests__/executiveSummaryWeeklyTrend.test.ts
+++ b/cicero-dashboard/__tests__/executiveSummaryWeeklyTrend.test.ts
@@ -7,7 +7,7 @@ import {
   INSTAGRAM_LIKE_FIELD_PATHS,
   TIKTOK_COMMENT_FIELD_PATHS,
   sumActivityRecords,
-} from "@/app/executive-summary/page";
+} from "@/app/executive-summary/activityRecords";
 
 describe("groupRecordsByWeek weekly trend integration", () => {
   it("groups instagram activity into weekly buckets and shows the trend card", () => {

--- a/cicero-dashboard/app/executive-summary/activityRecords.ts
+++ b/cicero-dashboard/app/executive-summary/activityRecords.ts
@@ -1,0 +1,107 @@
+import { normalizeFormattedNumber } from "@/lib/normalizeNumericInput";
+import { pickNestedValue } from "./weeklyTrendUtils";
+
+type ActivityRecord = Record<string, unknown> | null | undefined;
+
+type FieldPath = string;
+
+const INSTAGRAM_LIKE_FIELD_PATHS: FieldPath[] = [
+  "jumlah_like",
+  "jumlahLike",
+  "total_like",
+  "totalLike",
+  "totalLikes",
+  "likes",
+  "like_count",
+  "metrics.likes",
+  "rekap.jumlah_like",
+  "rekap.total_like",
+];
+
+const TIKTOK_COMMENT_FIELD_PATHS: FieldPath[] = [
+  "jumlah_komentar",
+  "jumlahKomentar",
+  "total_komentar",
+  "totalKomentar",
+  "komentar",
+  "comments",
+  "comment_count",
+  "metrics.comments",
+  "rekap.jumlah_komentar",
+  "rekap.total_komentar",
+];
+
+const extractNumericValue = (...candidates: unknown[]): number => {
+  for (const candidate of candidates) {
+    if (candidate === undefined || candidate === null) {
+      continue;
+    }
+
+    if (Array.isArray(candidate)) {
+      return candidate.length;
+    }
+
+    if (typeof candidate === "number") {
+      if (Number.isFinite(candidate)) {
+        return candidate;
+      }
+      continue;
+    }
+
+    if (typeof candidate === "object") {
+      const valueProperty = (candidate as { value?: unknown }).value;
+      if (valueProperty !== undefined) {
+        const nested = Number(valueProperty);
+        if (Number.isFinite(nested)) {
+          return nested;
+        }
+      }
+    }
+
+    const normalized = normalizeFormattedNumber(candidate as any);
+    const numeric = Number(normalized);
+    if (Number.isFinite(numeric)) {
+      return numeric;
+    }
+  }
+
+  return 0;
+};
+
+const sumActivityRecords = (
+  records: unknown,
+  fields: FieldPath[],
+): number => {
+  if (!Array.isArray(records) || records.length === 0) {
+    return 0;
+  }
+
+  if (!Array.isArray(fields) || fields.length === 0) {
+    return 0;
+  }
+
+  const safeRecords = records as ActivityRecord[];
+
+  return safeRecords.reduce((total, record) => {
+    if (!record || typeof record !== "object") {
+      return total;
+    }
+
+    const candidates = fields
+      .map((path) => pickNestedValue(record, [path]))
+      .filter((value) => value !== undefined && value !== null);
+
+    if (candidates.length === 0) {
+      return total;
+    }
+
+    const value = extractNumericValue(...candidates);
+    if (!Number.isFinite(value)) {
+      return total;
+    }
+
+    return total + Math.max(0, Number(value) || 0);
+  }, 0);
+};
+
+export { INSTAGRAM_LIKE_FIELD_PATHS, TIKTOK_COMMENT_FIELD_PATHS, sumActivityRecords };

--- a/cicero-dashboard/app/executive-summary/page.jsx
+++ b/cicero-dashboard/app/executive-summary/page.jsx
@@ -48,6 +48,11 @@ import {
   shouldShowWeeklyTrendCard,
   formatWeekRangeLabel,
 } from "./weeklyTrendUtils";
+import {
+  INSTAGRAM_LIKE_FIELD_PATHS,
+  TIKTOK_COMMENT_FIELD_PATHS,
+  sumActivityRecords,
+} from "./activityRecords";
 
 const clamp = (value, min, max) => {
   if (!Number.isFinite(value)) {
@@ -1790,19 +1795,6 @@ const computeActivityBuckets = ({
   };
 };
 
-const INSTAGRAM_LIKE_FIELD_PATHS = [
-  "jumlah_like",
-  "jumlahLike",
-  "total_like",
-  "totalLike",
-  "totalLikes",
-  "likes",
-  "like_count",
-  "metrics.likes",
-  "rekap.jumlah_like",
-  "rekap.total_like",
-];
-
 const INSTAGRAM_COMMENT_FIELD_PATHS = [
   "jumlah_komentar",
   "jumlahKomentar",
@@ -1825,19 +1817,6 @@ const TIKTOK_LIKE_FIELD_PATHS = [
   "metrics.likes",
   "rekap.jumlah_like",
   "rekap.total_like",
-];
-
-const TIKTOK_COMMENT_FIELD_PATHS = [
-  "jumlah_komentar",
-  "jumlahKomentar",
-  "total_komentar",
-  "totalKomentar",
-  "komentar",
-  "comments",
-  "comment_count",
-  "metrics.comments",
-  "rekap.jumlah_komentar",
-  "rekap.total_komentar",
 ];
 
 const INSTAGRAM_FOLLOWER_PATHS = [
@@ -1956,38 +1935,6 @@ const TIKTOK_BIO_PATHS = [
   "tiktok.bio",
 ];
 
-const sumActivityRecords = (records, fields) => {
-  if (!Array.isArray(records) || records.length === 0) {
-    return 0;
-  }
-
-  return records.reduce((total, record) => {
-    if (!record || typeof record !== "object") {
-      return total;
-    }
-
-    const candidates = fields
-      .map((path) => pickNestedValue(record, [path]))
-      .filter((value) => value !== undefined && value !== null);
-
-    if (candidates.length === 0) {
-      return total;
-    }
-
-    const value = extractNumericValue(...candidates);
-    if (!Number.isFinite(value)) {
-      return total;
-    }
-
-    return total + Math.max(0, Number(value) || 0);
-  }, 0);
-};
-
-export {
-  INSTAGRAM_LIKE_FIELD_PATHS,
-  TIKTOK_COMMENT_FIELD_PATHS,
-  sumActivityRecords,
-};
 
 const monthlyData = {
   "2024-11": {


### PR DESCRIPTION
## Summary
- extract the Instagram like constants, TikTok comment constants, and summation helper into a dedicated `activityRecords` module
- update the executive summary page and associated tests to consume the helpers from the new module and keep the page export clean

## Testing
- npm run build *(fails: Next.js cannot download Google Fonts in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd77989d188327ad5483dd38c3cfe7