### PR TITLE
Handle snake case activity dates for weekly trends

### DIFF
--- a/cicero-dashboard/__tests__/executiveSummaryWeeklyTrend.test.ts
+++ b/cicero-dashboard/__tests__/executiveSummaryWeeklyTrend.test.ts
@@ -122,6 +122,35 @@ describe("groupRecordsByWeek weekly trend integration", () => {
     expect(totalComments).toBe(7);
   });
 
+  it("aggregates totals from records that only expose snake_case activity dates", () => {
+    const instagramRecords = [
+      { activity_date: "2024-07-01T00:00:00Z", rekap: { total_like: "5" } },
+      { rekap: { activity_date: "2024-07-03T00:00:00Z", total_like: "7" } },
+    ];
+    const tiktokRecords = [
+      { activity_date: "2024-07-02T07:00:00Z", rekap: { total_komentar: "2" } },
+      { rekap: { activity_date: "2024-07-04T07:00:00Z", total_komentar: "5" } },
+    ];
+
+    const instagramBuckets = groupRecordsByWeek(instagramRecords);
+    const tiktokBuckets = groupRecordsByWeek(tiktokRecords);
+
+    expect(instagramBuckets).toHaveLength(1);
+    expect(tiktokBuckets).toHaveLength(1);
+
+    const instagramTotal = sumActivityRecords(
+      instagramBuckets[0].records,
+      INSTAGRAM_LIKE_FIELD_PATHS,
+    );
+    const tiktokTotal = sumActivityRecords(
+      tiktokBuckets[0].records,
+      TIKTOK_COMMENT_FIELD_PATHS,
+    );
+
+    expect(instagramTotal).toBe(12);
+    expect(tiktokTotal).toBe(7);
+  });
+
   it("groups posts with only date/tanggal fields and shows the trend card", () => {
     const posts = [
       { tanggal: "2024-07-01", likes: 2 },

--- a/cicero-dashboard/app/executive-summary/page.jsx
+++ b/cicero-dashboard/app/executive-summary/page.jsx
@@ -782,13 +782,19 @@ const ensureRecordsHaveActivityDate = (records, options = {}) => {
 
       const isoString = resolved.parsed.toISOString();
       const dateOnly = isoString.slice(0, 10);
+      const parsedExistingActivityDate = parseDateValue(record?.activityDate);
+      const shouldOverwriteActivityDate =
+        !(record?.activityDate instanceof Date) &&
+        (!record?.activityDate || !parsedExistingActivityDate);
 
       return {
         ...record,
         activityDate:
           record?.activityDate instanceof Date
             ? record.activityDate
-            : record?.activityDate ?? isoString,
+            : shouldOverwriteActivityDate
+            ? isoString
+            : record.activityDate,
         tanggal: record?.tanggal ?? dateOnly,
       };
     })

--- a/cicero-dashboard/app/executive-summary/weeklyTrendUtils.js
+++ b/cicero-dashboard/app/executive-summary/weeklyTrendUtils.js
@@ -81,6 +81,7 @@ const parseDateValue = (value) => {
 
 const DEFAULT_ACTIVITY_DATE_PATHS = [
   "activityDate",
+  "activity_date",
   "tanggal",
   "date",
   "created_at",
@@ -92,10 +93,18 @@ const DEFAULT_ACTIVITY_DATE_PATHS = [
   "publishedAt",
   "published_at",
   "timestamp",
+  "rekap.activity_date",
+  "rekap.activityDate",
   "rekap.tanggal",
   "rekap.date",
   "rekap.created_at",
   "rekap.createdAt",
+  "tiktok.activity_date",
+  "tiktok.activityDate",
+  "tiktok_activity_date",
+  "tiktokActivityDate",
+  "rekap.tiktok_activity_date",
+  "rekap.tiktokActivityDate",
 ];
 
 const resolveRecordDate = (record, extraPaths = []) => {


### PR DESCRIPTION
## Summary
- include snake_case activity date fields from API payloads when resolving weekly trend dates
- overwrite missing or invalid activityDate values with the resolved ISO string during record normalization
- cover activity_date scenarios in the executive summary weekly trend tests

## Testing
- npm test -- executiveSummaryWeeklyTrend

------
https://chatgpt.com/codex/tasks/task_e_68dd8200d6e0832787e13845250135d1