### PR TITLE
Switch executive summary activity trends to monthly

### DIFF
--- a/cicero-dashboard/__tests__/executiveSummaryWeeklyTrend.test.ts
+++ b/cicero-dashboard/__tests__/executiveSummaryWeeklyTrend.test.ts
@@ -1,5 +1,5 @@
 import {
-  groupRecordsByWeek,
+  groupRecordsByMonth,
   resolveRecordDate,
   shouldShowWeeklyTrendCard,
 } from "@/app/executive-summary/weeklyTrendUtils";
@@ -9,47 +9,51 @@ import {
   sumActivityRecords,
 } from "@/app/executive-summary/activityRecords";
 
-describe("groupRecordsByWeek weekly trend integration", () => {
-  it("groups instagram activity into weekly buckets and shows the trend card", () => {
+describe("groupRecordsByMonth monthly trend integration", () => {
+  it("groups instagram activity into monthly buckets and shows the trend card", () => {
     const records = [
       { tanggal: "2024-05-01", jumlah_like: 5 },
-      { tanggal: "2024-05-03", jumlah_like: 3 },
-      { tanggal: "2024-05-08", jumlah_like: 2 },
+      { tanggal: "2024-05-21", jumlah_like: 3 },
+      { tanggal: "2024-06-08", jumlah_like: 2 },
     ];
 
-    const buckets = groupRecordsByWeek(records);
+    const buckets = groupRecordsByMonth(records);
 
     expect(buckets).toHaveLength(2);
+    expect(buckets[0].key).toBe("2024-05");
     expect(buckets[0].records).toHaveLength(2);
+    expect(buckets[1].key).toBe("2024-06");
     expect(buckets[1].records).toHaveLength(1);
 
     const shouldShow = shouldShowWeeklyTrendCard({
       showPlatformLoading: false,
       platformError: "",
-      hasMonthlyPlatforms: false,
+      hasMonthlyPlatforms: true,
       cardHasRecords: buckets.length > 0,
     });
 
     expect(shouldShow).toBe(true);
   });
 
-  it("groups tiktok activity into weekly buckets and shows the trend card", () => {
+  it("groups tiktok activity into monthly buckets and shows the trend card", () => {
     const records = [
       { created_at: "2024-06-10T07:00:00Z", komentar: 4 },
       { created_at: "2024-06-12T07:00:00Z", komentar: 6 },
-      { created_at: "2024-06-19T07:00:00Z", komentar: 1 },
+      { created_at: "2024-07-19T07:00:00Z", komentar: 1 },
     ];
 
-    const buckets = groupRecordsByWeek(records);
+    const buckets = groupRecordsByMonth(records);
 
     expect(buckets).toHaveLength(2);
+    expect(buckets[0].key).toBe("2024-06");
     expect(buckets[0].records).toHaveLength(2);
+    expect(buckets[1].key).toBe("2024-07");
     expect(buckets[1].records).toHaveLength(1);
 
     const shouldShow = shouldShowWeeklyTrendCard({
       showPlatformLoading: false,
       platformError: "",
-      hasMonthlyPlatforms: false,
+      hasMonthlyPlatforms: true,
       cardHasRecords: buckets.length > 0,
     });
 
@@ -79,7 +83,7 @@ describe("groupRecordsByWeek weekly trend integration", () => {
     expect(totalLikes).toBe(9);
   });
 
-  it("uses activityDate ISO values when grouping instagram likes by week", () => {
+  it("uses activityDate ISO values when grouping instagram likes by month", () => {
     const records = [
       {
         tanggal: "31/05/2024",
@@ -93,7 +97,7 @@ describe("groupRecordsByWeek weekly trend integration", () => {
       },
     ];
 
-    const weeklyLikes = groupRecordsByWeek(records, {
+    const monthlyLikes = groupRecordsByMonth(records, {
       datePaths: [
         "activityDate",
         "tanggal",
@@ -111,11 +115,14 @@ describe("groupRecordsByWeek weekly trend integration", () => {
       ],
     });
 
-    expect(weeklyLikes).toHaveLength(1);
+    expect(monthlyLikes).toHaveLength(2);
+    expect(monthlyLikes[0].key).toBe("2024-05");
+    expect(monthlyLikes[1].key).toBe("2024-06");
 
-    const totalLikes = sumActivityRecords(
-      weeklyLikes[0].records,
-      INSTAGRAM_LIKE_FIELD_PATHS,
+    const totalLikes = monthlyLikes.reduce(
+      (sum, bucket) =>
+        sum + sumActivityRecords(bucket.records, INSTAGRAM_LIKE_FIELD_PATHS),
+      0,
     );
 
     expect(totalLikes).toBe(12);
@@ -154,8 +161,8 @@ describe("groupRecordsByWeek weekly trend integration", () => {
       { rekap: { activity_date: "2024-07-04T07:00:00Z", total_komentar: "5" } },
     ];
 
-    const instagramBuckets = groupRecordsByWeek(instagramRecords);
-    const tiktokBuckets = groupRecordsByWeek(tiktokRecords);
+    const instagramBuckets = groupRecordsByMonth(instagramRecords);
+    const tiktokBuckets = groupRecordsByMonth(tiktokRecords);
 
     expect(instagramBuckets).toHaveLength(1);
     expect(tiktokBuckets).toHaveLength(1);
@@ -176,11 +183,11 @@ describe("groupRecordsByWeek weekly trend integration", () => {
   it("groups posts with only date/tanggal fields and shows the trend card", () => {
     const posts = [
       { tanggal: "2024-07-01", likes: 2 },
-      { date: "2024-07-02", likes: 1 },
-      { tanggal: "2024-07-09", likes: 5 },
+      { date: "2024-07-22", likes: 1 },
+      { tanggal: "2024-08-09", likes: 5 },
     ];
 
-    const buckets = groupRecordsByWeek(posts, {
+    const buckets = groupRecordsByMonth(posts, {
       getDate: (post) => {
         const resolved = resolveRecordDate(post, [
           "publishedAt",
@@ -195,13 +202,15 @@ describe("groupRecordsByWeek weekly trend integration", () => {
     });
 
     expect(buckets).toHaveLength(2);
+    expect(buckets[0].key).toBe("2024-07");
     expect(buckets[0].records).toHaveLength(2);
+    expect(buckets[1].key).toBe("2024-08");
     expect(buckets[1].records).toHaveLength(1);
 
     const shouldShow = shouldShowWeeklyTrendCard({
       showPlatformLoading: false,
       platformError: "",
-      hasMonthlyPlatforms: false,
+      hasMonthlyPlatforms: true,
       cardHasRecords: buckets.length > 0,
     });
 

--- a/cicero-dashboard/app/executive-summary/page.jsx
+++ b/cicero-dashboard/app/executive-summary/page.jsx
@@ -33,7 +33,7 @@ import {
   calculateRatePerDay,
 } from "@/lib/normalizeNumericInput";
 import PlatformLikesSummary from "@/components/executive-summary/PlatformLikesSummary";
-import WeeklyTrendCard from "@/components/executive-summary/WeeklyTrendCard";
+import MonthlyTrendCard from "@/components/executive-summary/MonthlyTrendCard";
 import {
   buildMonthKey,
   extractYearFromMonthKey,
@@ -44,9 +44,9 @@ import {
   pickNestedString,
   parseDateValue,
   resolveRecordDate,
-  groupRecordsByWeek,
+  groupRecordsByMonth,
   shouldShowWeeklyTrendCard,
-  formatWeekRangeLabel,
+  formatMonthRangeLabel,
 } from "./weeklyTrendUtils";
 import {
   INSTAGRAM_LIKE_FIELD_PATHS,
@@ -3399,7 +3399,7 @@ export default function ExecutiveSummaryPage() {
       ? platformPostsState
       : { instagram: [], tiktok: [] };
 
-  const instagramWeeklyTrend = useMemo(() => {
+  const instagramMonthlyTrend = useMemo(() => {
     const instagramPosts = filterRecordsWithResolvableDate(
       Array.isArray(platformPosts?.instagram) ? platformPosts.instagram : [],
       {
@@ -3415,7 +3415,7 @@ export default function ExecutiveSummaryPage() {
       },
     );
 
-    const weeklyPosts = groupRecordsByWeek(instagramPosts, {
+    const monthlyPosts = groupRecordsByMonth(instagramPosts, {
       getDate: (post) => {
         if (post?.publishedAt instanceof Date) {
           return post.publishedAt;
@@ -3434,7 +3434,7 @@ export default function ExecutiveSummaryPage() {
       ? filterRecordsWithResolvableDate(platformActivity.likes)
       : [];
 
-    const weeklyLikes = groupRecordsByWeek(likesRecords, {
+    const monthlyLikes = groupRecordsByMonth(likesRecords, {
       datePaths: [
         "activityDate",
         "tanggal",
@@ -3452,10 +3452,10 @@ export default function ExecutiveSummaryPage() {
       ],
     });
 
-    const hasRecords = weeklyPosts.length > 0 || weeklyLikes.length > 0;
+    const hasRecords = monthlyPosts.length > 0 || monthlyLikes.length > 0;
     const buckets = new Map();
 
-    weeklyPosts.forEach((group) => {
+    monthlyPosts.forEach((group) => {
       const key = group.key;
       if (!buckets.has(key)) {
         buckets.set(key, {
@@ -3470,7 +3470,7 @@ export default function ExecutiveSummaryPage() {
       entry.posts += group.records.length;
     });
 
-    weeklyLikes.forEach((group) => {
+    monthlyLikes.forEach((group) => {
       const key = group.key;
       if (!buckets.has(key)) {
         buckets.set(key, {
@@ -3489,22 +3489,22 @@ export default function ExecutiveSummaryPage() {
       entry.likes += Math.max(0, Math.round(totalLikes) || 0);
     });
 
-    const weeks = Array.from(buckets.values()).sort(
+    const months = Array.from(buckets.values()).sort(
       (a, b) => a.start.getTime() - b.start.getTime(),
     );
 
-    if (weeks.length === 0) {
+    if (months.length === 0) {
       return {
-        weeks: [],
-        latestWeek: null,
-        previousWeek: null,
+        months: [],
+        latestMonth: null,
+        previousMonth: null,
         delta: null,
         hasRecords,
       };
     }
 
-    const latestWeek = weeks[weeks.length - 1];
-    const previousWeek = weeks.length > 1 ? weeks[weeks.length - 2] : null;
+    const latestMonth = months[months.length - 1];
+    const previousMonth = months.length > 1 ? months[months.length - 2] : null;
 
     const computeDelta = (latestValue, previousValue) => {
       const safeLatest = Number.isFinite(latestValue) ? latestValue : 0;
@@ -3516,23 +3516,23 @@ export default function ExecutiveSummaryPage() {
       return { absolute, percent };
     };
 
-    const delta = previousWeek
+    const delta = previousMonth
       ? {
-          posts: computeDelta(latestWeek.posts, previousWeek.posts),
-          likes: computeDelta(latestWeek.likes, previousWeek.likes),
+          posts: computeDelta(latestMonth.posts, previousMonth.posts),
+          likes: computeDelta(latestMonth.likes, previousMonth.likes),
         }
       : null;
 
     return {
-      weeks,
-      latestWeek,
-      previousWeek,
+      months,
+      latestMonth,
+      previousMonth,
       delta,
       hasRecords,
     };
   }, [platformPosts?.instagram, platformActivity]);
 
-  const tiktokWeeklyTrend = useMemo(() => {
+  const tiktokMonthlyTrend = useMemo(() => {
     const tiktokPosts = filterRecordsWithResolvableDate(
       Array.isArray(platformPosts?.tiktok) ? platformPosts.tiktok : [],
       {
@@ -3548,7 +3548,7 @@ export default function ExecutiveSummaryPage() {
       },
     );
 
-    const weeklyPosts = groupRecordsByWeek(tiktokPosts, {
+    const monthlyPosts = groupRecordsByMonth(tiktokPosts, {
       getDate: (post) => {
         if (post?.publishedAt instanceof Date) {
           return post.publishedAt;
@@ -3567,7 +3567,7 @@ export default function ExecutiveSummaryPage() {
       ? filterRecordsWithResolvableDate(platformActivity.comments)
       : [];
 
-    const weeklyComments = groupRecordsByWeek(commentRecords, {
+    const monthlyComments = groupRecordsByMonth(commentRecords, {
       datePaths: [
         "tanggal",
         "date",
@@ -3585,10 +3585,10 @@ export default function ExecutiveSummaryPage() {
       ],
     });
 
-    const hasRecords = weeklyPosts.length > 0 || weeklyComments.length > 0;
+    const hasRecords = monthlyPosts.length > 0 || monthlyComments.length > 0;
     const buckets = new Map();
 
-    weeklyPosts.forEach((group) => {
+    monthlyPosts.forEach((group) => {
       const key = group.key;
       if (!buckets.has(key)) {
         buckets.set(key, {
@@ -3603,7 +3603,7 @@ export default function ExecutiveSummaryPage() {
       entry.posts += group.records.length;
     });
 
-    weeklyComments.forEach((group) => {
+    monthlyComments.forEach((group) => {
       const key = group.key;
       if (!buckets.has(key)) {
         buckets.set(key, {
@@ -3622,22 +3622,22 @@ export default function ExecutiveSummaryPage() {
       entry.comments += Math.max(0, Math.round(totalComments) || 0);
     });
 
-    const weeks = Array.from(buckets.values()).sort(
+    const months = Array.from(buckets.values()).sort(
       (a, b) => a.start.getTime() - b.start.getTime(),
     );
 
-    if (weeks.length === 0) {
+    if (months.length === 0) {
       return {
-        weeks: [],
-        latestWeek: null,
-        previousWeek: null,
+        months: [],
+        latestMonth: null,
+        previousMonth: null,
         delta: null,
         hasRecords,
       };
     }
 
-    const latestWeek = weeks[weeks.length - 1];
-    const previousWeek = weeks.length > 1 ? weeks[weeks.length - 2] : null;
+    const latestMonth = months[months.length - 1];
+    const previousMonth = months.length > 1 ? months[months.length - 2] : null;
 
     const computeDelta = (latestValue, previousValue) => {
       const safeLatest = Number.isFinite(latestValue) ? latestValue : 0;
@@ -3649,39 +3649,39 @@ export default function ExecutiveSummaryPage() {
       return { absolute, percent };
     };
 
-    const delta = previousWeek
+    const delta = previousMonth
       ? {
-          posts: computeDelta(latestWeek.posts, previousWeek.posts),
-          comments: computeDelta(latestWeek.comments, previousWeek.comments),
+          posts: computeDelta(latestMonth.posts, previousMonth.posts),
+          comments: computeDelta(latestMonth.comments, previousMonth.comments),
         }
       : null;
 
     return {
-      weeks,
-      latestWeek,
-      previousWeek,
+      months,
+      latestMonth,
+      previousMonth,
       delta,
       hasRecords,
     };
   }, [platformPosts?.tiktok, platformActivity]);
 
-  const instagramWeeklyCardData = useMemo(() => {
-    const { latestWeek, previousWeek, delta, weeks, hasRecords } =
-      instagramWeeklyTrend ?? {};
+  const instagramMonthlyCardData = useMemo(() => {
+    const { latestMonth, previousMonth, delta, months, hasRecords } =
+      instagramMonthlyTrend ?? {};
 
-    const safeLatestPosts = Math.max(0, Number(latestWeek?.posts) || 0);
-    const safeLatestLikes = Math.max(0, Number(latestWeek?.likes) || 0);
-    const safePreviousPosts = Math.max(0, Number(previousWeek?.posts) || 0);
-    const safePreviousLikes = Math.max(0, Number(previousWeek?.likes) || 0);
+    const safeLatestPosts = Math.max(0, Number(latestMonth?.posts) || 0);
+    const safeLatestLikes = Math.max(0, Number(latestMonth?.likes) || 0);
+    const safePreviousPosts = Math.max(0, Number(previousMonth?.posts) || 0);
+    const safePreviousLikes = Math.max(0, Number(previousMonth?.likes) || 0);
 
-    const currentMetrics = latestWeek
+    const currentMetrics = latestMonth
       ? [
           { key: "posts", label: "Post Instagram", value: safeLatestPosts },
           { key: "likes", label: "Likes Personil", value: safeLatestLikes },
         ]
       : [];
 
-    const previousMetrics = previousWeek
+    const previousMetrics = previousMonth
       ? [
           { key: "posts", label: "Post Instagram", value: safePreviousPosts },
           { key: "likes", label: "Likes Personil", value: safePreviousLikes },
@@ -3689,7 +3689,7 @@ export default function ExecutiveSummaryPage() {
       : [];
 
     const deltaMetrics =
-      delta && previousWeek
+      delta && previousMonth
         ? [
             {
               key: "posts",
@@ -3714,47 +3714,49 @@ export default function ExecutiveSummaryPage() {
           ]
         : [];
 
-    const series = Array.isArray(weeks)
-      ? weeks.slice(-6).map((week) => {
-          const posts = Math.max(0, Number(week.posts) || 0);
-          const likes = Math.max(0, Number(week.likes) || 0);
+    const series = Array.isArray(months)
+      ? months.slice(-6).map((month) => {
+          const posts = Math.max(0, Number(month.posts) || 0);
+          const likes = Math.max(0, Number(month.likes) || 0);
           return {
-            key: week.key,
-            label: formatWeekRangeLabel(week.start, week.end),
+            key: month.key,
+            label: formatMonthRangeLabel(month.start, month.end),
             posts,
             likes,
             primary: posts,
             secondary: likes,
+            start: month.start,
+            end: month.end,
           };
         })
       : [];
 
-    const weeksCount = Array.isArray(weeks) ? weeks.length : 0;
+    const monthsCount = Array.isArray(months) ? months.length : 0;
 
     return {
       currentMetrics,
       previousMetrics,
       deltaMetrics,
       series,
-      weeksCount,
-      hasComparison: Boolean(previousWeek),
+      monthsCount,
+      hasComparison: Boolean(previousMonth),
       hasRecords: Boolean(hasRecords),
     };
-  }, [instagramWeeklyTrend]);
+  }, [instagramMonthlyTrend]);
 
-  const tiktokWeeklyCardData = useMemo(() => {
-    const { latestWeek, previousWeek, delta, weeks, hasRecords } =
-      tiktokWeeklyTrend ?? {};
+  const tiktokMonthlyCardData = useMemo(() => {
+    const { latestMonth, previousMonth, delta, months, hasRecords } =
+      tiktokMonthlyTrend ?? {};
 
-    const safeLatestPosts = Math.max(0, Number(latestWeek?.posts) || 0);
-    const safeLatestComments = Math.max(0, Number(latestWeek?.comments) || 0);
-    const safePreviousPosts = Math.max(0, Number(previousWeek?.posts) || 0);
+    const safeLatestPosts = Math.max(0, Number(latestMonth?.posts) || 0);
+    const safeLatestComments = Math.max(0, Number(latestMonth?.comments) || 0);
+    const safePreviousPosts = Math.max(0, Number(previousMonth?.posts) || 0);
     const safePreviousComments = Math.max(
       0,
-      Number(previousWeek?.comments) || 0,
+      Number(previousMonth?.comments) || 0,
     );
 
-    const currentMetrics = latestWeek
+    const currentMetrics = latestMonth
       ? [
           { key: "posts", label: "Post TikTok", value: safeLatestPosts },
           {
@@ -3765,7 +3767,7 @@ export default function ExecutiveSummaryPage() {
         ]
       : [];
 
-    const previousMetrics = previousWeek
+    const previousMetrics = previousMonth
       ? [
           { key: "posts", label: "Post TikTok", value: safePreviousPosts },
           {
@@ -3777,7 +3779,7 @@ export default function ExecutiveSummaryPage() {
       : [];
 
     const deltaMetrics =
-      delta && previousWeek
+      delta && previousMonth
         ? [
             {
               key: "posts",
@@ -3802,76 +3804,78 @@ export default function ExecutiveSummaryPage() {
           ]
         : [];
 
-    const series = Array.isArray(weeks)
-      ? weeks.slice(-6).map((week) => {
-          const posts = Math.max(0, Number(week.posts) || 0);
-          const comments = Math.max(0, Number(week.comments) || 0);
+    const series = Array.isArray(months)
+      ? months.slice(-6).map((month) => {
+          const posts = Math.max(0, Number(month.posts) || 0);
+          const comments = Math.max(0, Number(month.comments) || 0);
           return {
-            key: week.key,
-            label: formatWeekRangeLabel(week.start, week.end),
+            key: month.key,
+            label: formatMonthRangeLabel(month.start, month.end),
             posts,
             likes: comments,
             primary: posts,
             secondary: comments,
+            start: month.start,
+            end: month.end,
           };
         })
       : [];
 
-    const weeksCount = Array.isArray(weeks) ? weeks.length : 0;
+    const monthsCount = Array.isArray(months) ? months.length : 0;
 
     return {
       currentMetrics,
       previousMetrics,
       deltaMetrics,
       series,
-      weeksCount,
-      hasComparison: Boolean(previousWeek),
+      monthsCount,
+      hasComparison: Boolean(previousMonth),
       hasRecords: Boolean(hasRecords),
     };
-  }, [tiktokWeeklyTrend]);
+  }, [tiktokMonthlyTrend]);
 
   const showPlatformLoading = platformsLoading;
-  const instagramWeeklyTrendDescription =
-    instagramWeeklyCardData.weeksCount < 2
-      ? "Post Instagram & likes personil per minggu. Data perbandingan belum lengkap."
-      : "Post Instagram & likes personil per minggu.";
-  const instagramWeeklyCardError = !showPlatformLoading
+  const instagramMonthlyTrendDescription =
+    instagramMonthlyCardData.monthsCount < 2
+      ? "Post Instagram & likes personil per bulan. Data perbandingan belum lengkap."
+      : "Post Instagram & likes personil per bulan.";
+  const instagramMonthlyCardError = !showPlatformLoading
     ? platformError
       ? platformError
-      : instagramWeeklyCardData.weeksCount === 0 &&
-        instagramWeeklyCardData.hasRecords
-      ? "Belum ada data aktivitas Instagram mingguan yang terekam."
-      : instagramWeeklyCardData.weeksCount === 1
-      ? "Belum cukup data mingguan Instagram untuk dibandingkan."
+      : instagramMonthlyCardData.monthsCount === 0 &&
+        instagramMonthlyCardData.hasRecords
+      ? "Belum ada data aktivitas Instagram bulanan yang terekam."
+      : instagramMonthlyCardData.monthsCount === 1
+      ? "Belum cukup data bulanan Instagram untuk dibandingkan."
       : ""
     : "";
 
-  const tiktokWeeklyTrendDescription =
-    tiktokWeeklyCardData.weeksCount < 2
-      ? "Post TikTok & komentar personel per minggu. Data perbandingan belum lengkap."
-      : "Post TikTok & komentar personel per minggu.";
-  const tiktokWeeklyCardError = !showPlatformLoading
+  const tiktokMonthlyTrendDescription =
+    tiktokMonthlyCardData.monthsCount < 2
+      ? "Post TikTok & komentar personel per bulan. Data perbandingan belum lengkap."
+      : "Post TikTok & komentar personel per bulan.";
+  const tiktokMonthlyCardError = !showPlatformLoading
     ? platformError
       ? platformError
-      : tiktokWeeklyCardData.weeksCount === 0 &&
-        tiktokWeeklyCardData.hasRecords
-      ? "Belum ada data aktivitas TikTok mingguan yang terekam."
-      : tiktokWeeklyCardData.weeksCount === 1
-      ? "Belum cukup data mingguan TikTok untuk dibandingkan."
+      : tiktokMonthlyCardData.monthsCount === 0 &&
+        tiktokMonthlyCardData.hasRecords
+      ? "Belum ada data aktivitas TikTok bulanan yang terekam."
+      : tiktokMonthlyCardData.monthsCount === 1
+      ? "Belum cukup data bulanan TikTok untuk dibandingkan."
       : ""
     : "";
 
   const shouldShowInstagramTrendCard = shouldShowWeeklyTrendCard({
     showPlatformLoading,
     platformError,
-    hasMonthlyPlatforms: false,
-    cardHasRecords: instagramWeeklyCardData.hasRecords,
+    hasMonthlyPlatforms: true,
+    cardHasRecords: instagramMonthlyCardData.hasRecords,
   });
   const shouldShowTiktokTrendCard = shouldShowWeeklyTrendCard({
     showPlatformLoading,
     platformError,
-    hasMonthlyPlatforms: false,
-    cardHasRecords: tiktokWeeklyCardData.hasRecords,
+    hasMonthlyPlatforms: true,
+    cardHasRecords: tiktokMonthlyCardData.hasRecords,
   });
 
   return (
@@ -3967,43 +3971,43 @@ export default function ExecutiveSummaryPage() {
       {!showPlatformLoading &&
       (shouldShowInstagramTrendCard || shouldShowTiktokTrendCard) ? (
         <section
-          aria-label="Tren Aktivitas Mingguan"
+          aria-label="Tren Aktivitas Bulanan"
           className="space-y-6 rounded-3xl border border-cyan-500/20 bg-slate-950/70 p-6 shadow-[0_20px_45px_rgba(56,189,248,0.18)]"
         >
           <div className="space-y-2">
             <h2 className="text-sm font-semibold uppercase tracking-[0.35em] text-cyan-200/80">
-              Tren Aktivitas Mingguan
+              Tren Aktivitas Bulanan
             </h2>
             <p className="text-sm text-slate-300">
-              Ringkasan performa konten dan interaksi personel berdasarkan data mingguan
+              Ringkasan performa konten dan interaksi personel berdasarkan data bulanan
               terbaru.
             </p>
           </div>
 
           <div className="grid gap-4 lg:grid-cols-2">
             {shouldShowInstagramTrendCard ? (
-              <WeeklyTrendCard
+              <MonthlyTrendCard
                 title="Instagram"
-                description={instagramWeeklyTrendDescription}
-                error={instagramWeeklyCardError}
-                currentMetrics={instagramWeeklyCardData.currentMetrics}
-                previousMetrics={instagramWeeklyCardData.previousMetrics}
-                deltaMetrics={instagramWeeklyCardData.deltaMetrics}
-                series={instagramWeeklyCardData.series}
+                description={instagramMonthlyTrendDescription}
+                error={instagramMonthlyCardError}
+                currentMetrics={instagramMonthlyCardData.currentMetrics}
+                previousMetrics={instagramMonthlyCardData.previousMetrics}
+                deltaMetrics={instagramMonthlyCardData.deltaMetrics}
+                series={instagramMonthlyCardData.series}
                 formatNumber={formatNumber}
                 formatPercent={formatPercent}
               />
             ) : null}
 
             {shouldShowTiktokTrendCard ? (
-              <WeeklyTrendCard
+              <MonthlyTrendCard
                 title="TikTok"
-                description={tiktokWeeklyTrendDescription}
-                error={tiktokWeeklyCardError}
-                currentMetrics={tiktokWeeklyCardData.currentMetrics}
-                previousMetrics={tiktokWeeklyCardData.previousMetrics}
-                deltaMetrics={tiktokWeeklyCardData.deltaMetrics}
-                series={tiktokWeeklyCardData.series}
+                description={tiktokMonthlyTrendDescription}
+                error={tiktokMonthlyCardError}
+                currentMetrics={tiktokMonthlyCardData.currentMetrics}
+                previousMetrics={tiktokMonthlyCardData.previousMetrics}
+                deltaMetrics={tiktokMonthlyCardData.deltaMetrics}
+                series={tiktokMonthlyCardData.series}
                 formatNumber={formatNumber}
                 formatPercent={formatPercent}
                 secondaryMetricLabel="Komentar"

--- a/cicero-dashboard/components/executive-summary/MonthlyTrendCard.tsx
+++ b/cicero-dashboard/components/executive-summary/MonthlyTrendCard.tsx
@@ -8,38 +8,40 @@ type FormatNumberFn = (
 ) => string;
 type FormatPercentFn = (value: number) => string;
 
-type WeeklyMetric = {
+type MonthlyMetric = {
   key: string;
   label: string;
   value: number;
   suffix?: string;
 };
 
-type WeeklyDeltaMetric = {
+type MonthlyDeltaMetric = {
   key: string;
   label: string;
   absolute: number | null;
   percent?: number | null;
 };
 
-type WeeklyTrendSeriesPoint = {
+type MonthlyTrendSeriesPoint = {
   key: string;
   label?: string;
+  start?: Date | string | null;
+  end?: Date | string | null;
   posts?: number;
   likes?: number;
   primary?: number;
   secondary?: number;
 };
 
-type WeeklyTrendCardProps = {
+type MonthlyTrendCardProps = {
   title: string;
   description?: string;
   loading?: boolean;
   error?: string;
-  currentMetrics?: WeeklyMetric[];
-  previousMetrics?: WeeklyMetric[];
-  deltaMetrics?: WeeklyDeltaMetric[];
-  series?: WeeklyTrendSeriesPoint[];
+  currentMetrics?: MonthlyMetric[];
+  previousMetrics?: MonthlyMetric[];
+  deltaMetrics?: MonthlyDeltaMetric[];
+  series?: MonthlyTrendSeriesPoint[];
   formatNumber?: FormatNumberFn;
   formatPercent?: FormatPercentFn;
   primaryMetricLabel?: string;
@@ -64,7 +66,33 @@ const defaultPercentFormatter: FormatPercentFn = (value) => {
   }).format(safeValue)}%`;
 };
 
-const WeeklyTrendCard: React.FC<WeeklyTrendCardProps> = ({
+const resolveMonthLabel = (item: MonthlyTrendSeriesPoint): string => {
+  if (item.label) {
+    return item.label;
+  }
+
+  const candidate = item.start ?? null;
+  if (candidate instanceof Date && !Number.isNaN(candidate.valueOf())) {
+    return new Intl.DateTimeFormat("id-ID", {
+      month: "long",
+      year: "numeric",
+    }).format(candidate);
+  }
+
+  if (typeof candidate === "string") {
+    const parsed = new Date(candidate);
+    if (!Number.isNaN(parsed.valueOf())) {
+      return new Intl.DateTimeFormat("id-ID", {
+        month: "long",
+        year: "numeric",
+      }).format(parsed);
+    }
+  }
+
+  return item.key;
+};
+
+const MonthlyTrendCard: React.FC<MonthlyTrendCardProps> = ({
   title,
   description,
   loading = false,
@@ -81,7 +109,7 @@ const WeeklyTrendCard: React.FC<WeeklyTrendCardProps> = ({
   if (loading) {
     return (
       <div className="rounded-3xl border border-slate-800/70 bg-slate-950/70 p-6 text-sm text-slate-400">
-        Memuat tren mingguan…
+        Memuat tren bulanan…
       </div>
     );
   }
@@ -95,7 +123,7 @@ const WeeklyTrendCard: React.FC<WeeklyTrendCardProps> = ({
     <div className="rounded-3xl border border-slate-800/70 bg-slate-950/70 p-6 shadow-[0_18px_38px_rgba(15,23,42,0.35)]">
       <div>
         <p className="text-xs font-semibold uppercase tracking-[0.35em] text-cyan-200/80">
-          Weekly Trend
+          Monthly Trend
         </p>
         <h3 className="mt-2 text-2xl font-semibold text-slate-50">{title}</h3>
         {description ? (
@@ -113,7 +141,7 @@ const WeeklyTrendCard: React.FC<WeeklyTrendCardProps> = ({
         <div className="mt-6 grid gap-4 md:grid-cols-2">
           <div className="rounded-2xl border border-slate-800/60 bg-slate-900/60 p-4">
             <p className="text-xs uppercase tracking-[0.3em] text-slate-500">
-              Minggu Berjalan
+              Bulan Berjalan
             </p>
             <div className="mt-3 space-y-2">
               {hasCurrentMetrics ? (
@@ -130,13 +158,13 @@ const WeeklyTrendCard: React.FC<WeeklyTrendCardProps> = ({
                   </div>
                 ))
               ) : (
-                <p className="text-sm text-slate-500">Belum ada data minggu ini.</p>
+                <p className="text-sm text-slate-500">Belum ada data bulan ini.</p>
               )}
             </div>
           </div>
           <div className="rounded-2xl border border-slate-800/60 bg-slate-900/60 p-4">
             <p className="text-xs uppercase tracking-[0.3em] text-slate-500">
-              Minggu Sebelumnya
+              Bulan Sebelumnya
             </p>
             <div className="mt-3 space-y-2">
               {hasPreviousMetrics ? (
@@ -160,7 +188,7 @@ const WeeklyTrendCard: React.FC<WeeklyTrendCardProps> = ({
         </div>
       ) : (
         <div className="mt-6 rounded-2xl border border-slate-800/60 bg-slate-900/60 px-4 py-3 text-sm text-slate-400">
-          Belum ada data mingguan yang dapat ditampilkan.
+          Belum ada data bulanan yang dapat ditampilkan.
         </div>
       )}
 
@@ -215,7 +243,7 @@ const WeeklyTrendCard: React.FC<WeeklyTrendCardProps> = ({
       {hasSeries ? (
         <div className="mt-6 space-y-3">
           <p className="text-xs uppercase tracking-[0.3em] text-slate-500">
-            Rekap Mingguan
+            Rekap Bulanan
           </p>
           <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
             {series.map((item) => (
@@ -224,7 +252,7 @@ const WeeklyTrendCard: React.FC<WeeklyTrendCardProps> = ({
                 className="rounded-2xl border border-slate-800/60 bg-slate-900/60 px-3 py-2 text-xs text-slate-300"
               >
                 <p className="font-semibold text-slate-200">
-                  {item.label ?? item.key}
+                  {resolveMonthLabel(item)}
                 </p>
                 <p className="mt-1 text-slate-400">
                   {primaryMetricLabel}: {" "}
@@ -244,4 +272,4 @@ const WeeklyTrendCard: React.FC<WeeklyTrendCardProps> = ({
   );
 };
 
-export default WeeklyTrendCard;
+export default MonthlyTrendCard;


### PR DESCRIPTION
## Summary
- add a monthly record grouping helper and apply it to the executive summary activity aggregations
- replace the weekly trend card with a monthly-focused component and update copy to reference monthly data
- refresh executive summary tests to validate the new monthly bucketing behaviour

## Testing
- npm test -- --runTestsByPath __tests__/executiveSummaryWeeklyTrend.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68ddaacc278c83278791c391213064b3