### PR TITLE
Refocus executive summary metrics on engagement

### DIFF
--- a/cicero-dashboard/__tests__/executiveSummaryActivityBuckets.test.ts
+++ b/cicero-dashboard/__tests__/executiveSummaryActivityBuckets.test.ts
@@ -14,9 +14,9 @@ describe("computeActivityBuckets", () => {
     const result = computeActivityBuckets({
       users: baseUsers,
       likes: [
-        { username: "Alpha" },
-        { username: "alpha" },
-        { username: "BRAVO" },
+        { username: "Alpha", jumlah_like: 12 },
+        { username: "alpha", jumlah_like: 8 },
+        { username: "BRAVO", jumlah_like: 5 },
       ],
       comments: [],
       totalIGPosts: "10",
@@ -26,13 +26,15 @@ describe("computeActivityBuckets", () => {
     expect(result.evaluatedUsers).toBe(3);
     expect(result.totalContent).toBe(15);
 
-    const instagram = findCategory(result.categories, "instagram-active");
-    const tiktok = findCategory(result.categories, "tiktok-active");
-    const passive = findCategory(result.categories, "passive");
+    const mostActive = findCategory(result.categories, "most-active");
+    const moderate = findCategory(result.categories, "moderate");
+    const low = findCategory(result.categories, "low");
+    const inactive = findCategory(result.categories, "inactive");
 
-    expect(instagram?.count).toBe(2);
-    expect(tiktok?.count).toBe(0);
-    expect(passive?.count).toBe(1);
+    expect(mostActive?.count).toBe(0);
+    expect(moderate?.count).toBe(1);
+    expect(low?.count).toBe(1);
+    expect(inactive?.count).toBe(1);
   });
 
   it("mengelompokkan personil aktif TikTok saja", () => {
@@ -40,8 +42,8 @@ describe("computeActivityBuckets", () => {
       users: baseUsers,
       likes: [],
       comments: [
-        { username: "Charlie" },
-        { username: "CHARLIE" },
+        { username: "Charlie", jumlah_komentar: 12 },
+        { username: "CHARLIE", jumlahKomentar: 6 },
       ],
       totalIGPosts: 0,
       totalTikTokPosts: "8",
@@ -50,22 +52,24 @@ describe("computeActivityBuckets", () => {
     expect(result.evaluatedUsers).toBe(3);
     expect(result.totalContent).toBe(8);
 
-    const instagram = findCategory(result.categories, "instagram-active");
-    const tiktok = findCategory(result.categories, "tiktok-active");
-    const passive = findCategory(result.categories, "passive");
+    const mostActive = findCategory(result.categories, "most-active");
+    const moderate = findCategory(result.categories, "moderate");
+    const low = findCategory(result.categories, "low");
+    const inactive = findCategory(result.categories, "inactive");
 
-    expect(instagram?.count).toBe(0);
-    expect(tiktok?.count).toBe(1);
-    expect(passive?.count).toBe(2);
+    expect(mostActive?.count).toBe(1);
+    expect(moderate?.count).toBe(0);
+    expect(low?.count).toBe(0);
+    expect(inactive?.count).toBe(2);
   });
 
   it("menggabungkan aktivitas Instagram dan TikTok", () => {
     const result = computeActivityBuckets({
       users: baseUsers,
-      likes: [{ username: "Alpha" }],
+      likes: [{ username: "Alpha", jumlah_like: 2 }],
       comments: [
-        { username: "Bravo" },
-        { username: "Alpha" },
+        { username: "Bravo", jumlah_komentar: 4 },
+        { username: "Alpha", jumlah_komentar: 1 },
       ],
       totalIGPosts: 2,
       totalTikTokPosts: 3,
@@ -74,13 +78,15 @@ describe("computeActivityBuckets", () => {
     expect(result.evaluatedUsers).toBe(3);
     expect(result.totalContent).toBe(5);
 
-    const instagram = findCategory(result.categories, "instagram-active");
-    const tiktok = findCategory(result.categories, "tiktok-active");
-    const passive = findCategory(result.categories, "passive");
+    const mostActive = findCategory(result.categories, "most-active");
+    const moderate = findCategory(result.categories, "moderate");
+    const low = findCategory(result.categories, "low");
+    const inactive = findCategory(result.categories, "inactive");
 
-    expect(instagram?.count).toBe(1);
-    expect(tiktok?.count).toBe(2);
-    expect(passive?.count).toBe(1);
+    expect(mostActive?.count).toBe(0);
+    expect(moderate?.count).toBe(2);
+    expect(low?.count).toBe(0);
+    expect(inactive?.count).toBe(1);
   });
 
   it("menghitung personil pasif ketika tidak ada aktivitas yang cocok", () => {
@@ -90,21 +96,23 @@ describe("computeActivityBuckets", () => {
         { username: "ALPHA" },
         { username: "Bravo" },
       ],
-      likes: [{ username: "Delta" }],
+      likes: [{ username: "Delta", jumlah_like: 3 }],
       comments: [],
       totalIGPosts: 1,
       totalTikTokPosts: undefined,
     });
 
-    expect(result.evaluatedUsers).toBe(2);
+    expect(result.evaluatedUsers).toBe(3);
     expect(result.totalContent).toBe(1);
 
-    const instagram = findCategory(result.categories, "instagram-active");
-    const tiktok = findCategory(result.categories, "tiktok-active");
-    const passive = findCategory(result.categories, "passive");
+    const mostActive = findCategory(result.categories, "most-active");
+    const moderate = findCategory(result.categories, "moderate");
+    const low = findCategory(result.categories, "low");
+    const inactive = findCategory(result.categories, "inactive");
 
-    expect(instagram?.count).toBe(0);
-    expect(tiktok?.count).toBe(0);
-    expect(passive?.count).toBe(2);
+    expect(mostActive?.count).toBe(1);
+    expect(moderate?.count).toBe(0);
+    expect(low?.count).toBe(0);
+    expect(inactive?.count).toBe(2);
   });
 });

--- a/cicero-dashboard/__tests__/executiveSummaryWeeklyTrend.test.tsx
+++ b/cicero-dashboard/__tests__/executiveSummaryWeeklyTrend.test.tsx
@@ -1,3 +1,7 @@
+import "@testing-library/jest-dom";
+
+import { render, screen } from "@testing-library/react";
+
 import {
   groupRecordsByMonth,
   resolveRecordDate,
@@ -8,6 +12,7 @@ import {
   TIKTOK_COMMENT_FIELD_PATHS,
   sumActivityRecords,
 } from "@/app/executive-summary/activityRecords";
+import MonthlyTrendCard from "@/components/executive-summary/MonthlyTrendCard";
 
 describe("groupRecordsByMonth monthly trend integration", () => {
   it("groups instagram activity into monthly buckets and shows the trend card", () => {
@@ -215,5 +220,60 @@ describe("groupRecordsByMonth monthly trend integration", () => {
     });
 
     expect(shouldShow).toBe(true);
+  });
+});
+
+describe("Monthly trend card metric emphasis", () => {
+  it("prioritizes personnel interactions as the primary monthly metric", () => {
+    render(
+      <MonthlyTrendCard
+        title="Instagram"
+        currentMetrics={[
+          { key: "likes", label: "Likes Personil", value: 24 },
+        ]}
+        previousMetrics={[
+          { key: "likes", label: "Likes Personil", value: 18 },
+        ]}
+        series={[
+          {
+            key: "2024-07",
+            label: "Juli 2024",
+            primary: 24,
+          },
+        ]}
+      />,
+    );
+
+    const detail = screen.getByText("Likes: 24");
+    expect(detail).toBeInTheDocument();
+    expect(detail.textContent).toBe("Likes: 24");
+  });
+
+  it("supports custom interaction labels with optional secondary metrics", () => {
+    render(
+      <MonthlyTrendCard
+        title="TikTok"
+        currentMetrics={[
+          { key: "comments", label: "Komentar Personil", value: 18 },
+        ]}
+        previousMetrics={[
+          { key: "comments", label: "Komentar Personil", value: 12 },
+        ]}
+        primaryMetricLabel="Komentar Personil"
+        secondaryMetricLabel="Post"
+        series={[
+          {
+            key: "2024-07",
+            label: "Juli 2024",
+            primary: 18,
+            secondary: 4,
+          },
+        ]}
+      />,
+    );
+
+    expect(
+      screen.getByText("Komentar Personil: 18 • Post: 4"),
+    ).toBeInTheDocument();
   });
 });

--- a/cicero-dashboard/app/executive-summary/page.jsx
+++ b/cicero-dashboard/app/executive-summary/page.jsx
@@ -3669,28 +3669,46 @@ export default function ExecutiveSummaryPage() {
     const { latestMonth, previousMonth, delta, months, hasRecords } =
       instagramMonthlyTrend ?? {};
 
-    const safeLatestPosts = Math.max(0, Number(latestMonth?.posts) || 0);
     const safeLatestLikes = Math.max(0, Number(latestMonth?.likes) || 0);
-    const safePreviousPosts = Math.max(0, Number(previousMonth?.posts) || 0);
+    const safeLatestPosts = Math.max(0, Number(latestMonth?.posts) || 0);
     const safePreviousLikes = Math.max(0, Number(previousMonth?.likes) || 0);
+    const safePreviousPosts = Math.max(0, Number(previousMonth?.posts) || 0);
 
     const currentMetrics = latestMonth
       ? [
-          { key: "posts", label: "Post Instagram", value: safeLatestPosts },
           { key: "likes", label: "Likes Personil", value: safeLatestLikes },
+          {
+            key: "posts",
+            label: "Post Instagram",
+            value: safeLatestPosts,
+          },
         ]
       : [];
 
     const previousMetrics = previousMonth
       ? [
-          { key: "posts", label: "Post Instagram", value: safePreviousPosts },
           { key: "likes", label: "Likes Personil", value: safePreviousLikes },
+          {
+            key: "posts",
+            label: "Post Instagram",
+            value: safePreviousPosts,
+          },
         ]
       : [];
 
     const deltaMetrics =
       delta && previousMonth
         ? [
+            {
+              key: "likes",
+              label: "Perubahan Likes Personil",
+              absolute: Math.round(delta.likes?.absolute ?? 0),
+              percent:
+                delta.likes?.percent !== null &&
+                delta.likes?.percent !== undefined
+                  ? delta.likes.percent
+                  : null,
+            },
             {
               key: "posts",
               label: "Perubahan Post",
@@ -3699,16 +3717,6 @@ export default function ExecutiveSummaryPage() {
                 delta.posts?.percent !== null &&
                 delta.posts?.percent !== undefined
                   ? delta.posts.percent
-                  : null,
-            },
-            {
-              key: "likes",
-              label: "Perubahan Likes",
-              absolute: Math.round(delta.likes?.absolute ?? 0),
-              percent:
-                delta.likes?.percent !== null &&
-                delta.likes?.percent !== undefined
-                  ? delta.likes.percent
                   : null,
             },
           ]
@@ -3723,8 +3731,8 @@ export default function ExecutiveSummaryPage() {
             label: formatMonthRangeLabel(month.start, month.end),
             posts,
             likes,
-            primary: posts,
-            secondary: likes,
+            primary: likes,
+            secondary: posts,
             start: month.start,
             end: month.end,
           };
@@ -3748,39 +3756,49 @@ export default function ExecutiveSummaryPage() {
     const { latestMonth, previousMonth, delta, months, hasRecords } =
       tiktokMonthlyTrend ?? {};
 
-    const safeLatestPosts = Math.max(0, Number(latestMonth?.posts) || 0);
     const safeLatestComments = Math.max(0, Number(latestMonth?.comments) || 0);
-    const safePreviousPosts = Math.max(0, Number(previousMonth?.posts) || 0);
+    const safeLatestPosts = Math.max(0, Number(latestMonth?.posts) || 0);
     const safePreviousComments = Math.max(
       0,
       Number(previousMonth?.comments) || 0,
     );
+    const safePreviousPosts = Math.max(0, Number(previousMonth?.posts) || 0);
 
     const currentMetrics = latestMonth
       ? [
-          { key: "posts", label: "Post TikTok", value: safeLatestPosts },
           {
             key: "comments",
             label: "Komentar Personil",
             value: safeLatestComments,
           },
+          { key: "posts", label: "Post TikTok", value: safeLatestPosts },
         ]
       : [];
 
     const previousMetrics = previousMonth
       ? [
-          { key: "posts", label: "Post TikTok", value: safePreviousPosts },
           {
             key: "comments",
             label: "Komentar Personil",
             value: safePreviousComments,
           },
+          { key: "posts", label: "Post TikTok", value: safePreviousPosts },
         ]
       : [];
 
     const deltaMetrics =
       delta && previousMonth
         ? [
+            {
+              key: "comments",
+              label: "Perubahan Komentar Personil",
+              absolute: Math.round(delta.comments?.absolute ?? 0),
+              percent:
+                delta.comments?.percent !== null &&
+                delta.comments?.percent !== undefined
+                  ? delta.comments.percent
+                  : null,
+            },
             {
               key: "posts",
               label: "Perubahan Post",
@@ -3789,16 +3807,6 @@ export default function ExecutiveSummaryPage() {
                 delta.posts?.percent !== null &&
                 delta.posts?.percent !== undefined
                   ? delta.posts.percent
-                  : null,
-            },
-            {
-              key: "comments",
-              label: "Perubahan Komentar",
-              absolute: Math.round(delta.comments?.absolute ?? 0),
-              percent:
-                delta.comments?.percent !== null &&
-                delta.comments?.percent !== undefined
-                  ? delta.comments.percent
                   : null,
             },
           ]
@@ -3813,8 +3821,9 @@ export default function ExecutiveSummaryPage() {
             label: formatMonthRangeLabel(month.start, month.end),
             posts,
             likes: comments,
-            primary: posts,
-            secondary: comments,
+            comments,
+            primary: comments,
+            secondary: posts,
             start: month.start,
             end: month.end,
           };
@@ -3837,8 +3846,8 @@ export default function ExecutiveSummaryPage() {
   const showPlatformLoading = platformsLoading;
   const instagramMonthlyTrendDescription =
     instagramMonthlyCardData.monthsCount < 2
-      ? "Post Instagram & likes personil per bulan. Data perbandingan belum lengkap."
-      : "Post Instagram & likes personil per bulan.";
+      ? "Likes personil & post Instagram per bulan. Data perbandingan belum lengkap."
+      : "Likes personil & post Instagram per bulan.";
   const instagramMonthlyCardError = !showPlatformLoading
     ? platformError
       ? platformError
@@ -3852,8 +3861,8 @@ export default function ExecutiveSummaryPage() {
 
   const tiktokMonthlyTrendDescription =
     tiktokMonthlyCardData.monthsCount < 2
-      ? "Post TikTok & komentar personel per bulan. Data perbandingan belum lengkap."
-      : "Post TikTok & komentar personel per bulan.";
+      ? "Komentar personel & post TikTok per bulan. Data perbandingan belum lengkap."
+      : "Komentar personel & post TikTok per bulan.";
   const tiktokMonthlyCardError = !showPlatformLoading
     ? platformError
       ? platformError
@@ -3996,6 +4005,8 @@ export default function ExecutiveSummaryPage() {
                 series={instagramMonthlyCardData.series}
                 formatNumber={formatNumber}
                 formatPercent={formatPercent}
+                primaryMetricLabel="Likes Personil"
+                secondaryMetricLabel="Post"
               />
             ) : null}
 
@@ -4010,7 +4021,8 @@ export default function ExecutiveSummaryPage() {
                 series={tiktokMonthlyCardData.series}
                 formatNumber={formatNumber}
                 formatPercent={formatPercent}
-                secondaryMetricLabel="Komentar"
+                primaryMetricLabel="Komentar Personil"
+                secondaryMetricLabel="Post"
               />
             ) : null}
           </div>
@@ -4625,3 +4637,5 @@ export default function ExecutiveSummaryPage() {
     </div>
   );
 }
+
+export { computeActivityBuckets };


### PR DESCRIPTION
## Summary
- highlight personnel likes and comments as the primary executive summary monthly metrics and adjust supporting labels/descriptions
- update the MonthlyTrendCard defaults and series formatting so likes/comments appear first and secondary metrics are optional
- refresh the weekly trend and activity bucket unit tests to cover the new metric emphasis

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68ddae5342ac8327901abb4a2cf0648b