### PR TITLE
Fix missing createEmptyLikesSummary export/import

### DIFF
--- a/cicero-dashboard/app/executive-summary/dataTransforms.js
+++ b/cicero-dashboard/app/executive-summary/dataTransforms.js
@@ -284,6 +284,7 @@ const prepareTrendActivityRecords = (records, options = {}) => {
 };
 
 export {
+  createEmptyLikesSummary,
   aggregateLikesRecords,
   ensureRecordsHaveActivityDate,
   prepareTrendActivityRecords,

--- a/cicero-dashboard/app/executive-summary/page.jsx
+++ b/cicero-dashboard/app/executive-summary/page.jsx
@@ -41,6 +41,7 @@ import {
   mergeAvailableMonthOptions,
 } from "./monthOptions";
 import {
+  createEmptyLikesSummary,
   aggregateLikesRecords,
   ensureRecordsHaveActivityDate,
   prepareTrendActivityRecords,


### PR DESCRIPTION
## Summary
- export the `createEmptyLikesSummary` helper from the executive summary data transforms module
- import the helper on the executive summary page so prerendering can access it

## Testing
- npm run build *(fails: Next.js cannot download Google Fonts in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68ddbe1309608327b849e45f5d30bc3c