### PR TITLE
Fix comment aggregation in executive summary

### DIFF
--- a/cicero-dashboard/app/executive-summary/page.jsx
+++ b/cicero-dashboard/app/executive-summary/page.jsx
@@ -43,6 +43,7 @@ import {
 } from "./monthOptions";
 import {
   createEmptyLikesSummary,
+  mergeActivityRecords,
   aggregateLikesRecords,
   ensureRecordsHaveActivityDate,
   prepareTrendActivityRecords,
@@ -2752,7 +2753,11 @@ export default function ExecutiveSummaryPage() {
           totalTikTokPosts,
         });
 
-        const likesSummary = aggregateLikesRecords(likesRaw);
+        const mergedActivityRecords = mergeActivityRecords(
+          likesRaw,
+          commentsRaw,
+        );
+        const likesSummary = aggregateLikesRecords(mergedActivityRecords);
         const instagramPostsSanitized = ensureRecordsHaveActivityDate(
           instagramPostsRaw,
           {


### PR DESCRIPTION
## Summary
- merge instagram like and tiktok comment records before building the executive summary satker table so comment totals populate correctly
- expose the merge helper via the executive summary data transforms and consume it when preparing the likes summary

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ddd49dd3d08327ba2a9a69e81eefd3