### PR TITLE
Move personnel activity card into platform performance segment

### DIFF
--- a/cicero-dashboard/app/executive-summary/page.jsx
+++ b/cicero-dashboard/app/executive-summary/page.jsx
@@ -4120,66 +4120,20 @@ export default function ExecutiveSummaryPage() {
               data={likesSummary}
               formatNumber={formatNumber}
               formatPercent={formatPercent}
+              personnelActivity={{
+                loading: userInsightState.loading,
+                error: userInsightState.error,
+                categories: activityCategories,
+                totalEvaluated,
+                totalContentEvaluated,
+                hasSummary: Boolean(activityBuckets),
+              }}
             />
           ) : (
             <div className="rounded-3xl border border-slate-800/60 bg-slate-900/60 p-6 text-sm text-slate-400">
               Belum ada data rekap likes untuk periode ini.
             </div>
           )}
-
-          <div className="rounded-3xl border border-cyan-500/20 bg-slate-950/70 p-6 shadow-[0_20px_45px_rgba(56,189,248,0.18)]">
-            <h2 className="text-sm font-semibold uppercase tracking-[0.35em] text-cyan-200/80">
-              Aktivitas Personil
-            </h2>
-            {!userInsightState.loading && !userInsightState.error && activityBuckets ? (
-              <p className="mt-2 text-xs text-slate-400">
-                {formatNumber(totalEvaluated, { maximumFractionDigits: 0 })} personil dievaluasi
-                {totalContentEvaluated > 0
-                  ? ` dari ${formatNumber(totalContentEvaluated, { maximumFractionDigits: 0 })} konten`
-                  : " (tidak ada konten yang terbit)"}
-                .
-              </p>
-            ) : null}
-            <div className="mt-5 space-y-5">
-              {userInsightState.loading ? (
-                <div className="rounded-2xl border border-slate-800/60 bg-slate-900/60 px-4 py-3 text-sm text-slate-400">
-                  Memuat aktivitas personil…
-                </div>
-              ) : userInsightState.error ? (
-                <div className="rounded-2xl border border-rose-500/40 bg-rose-500/10 px-4 py-3 text-sm text-rose-200">
-                  {userInsightState.error}
-                </div>
-              ) : activityCategories.length > 0 ? (
-                activityCategories.map((category) => {
-                  const percent =
-                    totalEvaluated > 0 ? (category.count / totalEvaluated) * 100 : 0;
-                  return (
-                    <div
-                      key={category.key}
-                      className="flex items-center justify-between rounded-2xl bg-slate-900/60 px-4 py-3"
-                    >
-                      <div>
-                        <p className="text-sm font-medium text-slate-200">{category.label}</p>
-                        <p className="text-xs text-slate-400">{category.description}</p>
-                      </div>
-                      <div className="text-right">
-                        <p className="text-xl font-semibold text-white">
-                          {formatNumber(category.count, { maximumFractionDigits: 0 })}
-                        </p>
-                        {totalEvaluated > 0 ? (
-                          <p className="text-xs text-cyan-300">{formatPercent(percent)}</p>
-                        ) : null}
-                      </div>
-                    </div>
-                  );
-                })
-              ) : (
-                <div className="rounded-2xl border border-slate-800/60 bg-slate-900/60 px-4 py-3 text-sm text-slate-400">
-                  Aktivitas personil belum tersedia untuk periode ini.
-                </div>
-              )}
-            </div>
-          </div>
         </div>
       </section>
 

--- a/cicero-dashboard/components/executive-summary/PlatformLikesSummary.tsx
+++ b/cicero-dashboard/components/executive-summary/PlatformLikesSummary.tsx
@@ -50,10 +50,27 @@ interface LikesSummaryData {
   lastUpdated: Date | string | null;
 }
 
+interface ActivityCategory {
+  key: string;
+  label: string;
+  description: string;
+  count: number;
+}
+
+interface PersonnelActivitySummary {
+  loading: boolean;
+  error?: string | null;
+  categories: ActivityCategory[];
+  totalEvaluated: number;
+  totalContentEvaluated: number;
+  hasSummary: boolean;
+}
+
 interface PlatformLikesSummaryProps {
   data: LikesSummaryData;
   formatNumber: (value: number, options?: Intl.NumberFormatOptions) => string;
   formatPercent: (value: number) => string;
+  personnelActivity?: PersonnelActivitySummary | null;
 }
 
 const formatDateTime = (value: Date | string | null) => {
@@ -78,6 +95,7 @@ const PlatformLikesSummary = ({
   data,
   formatNumber,
   formatPercent,
+  personnelActivity,
 }: PlatformLikesSummaryProps) => {
   const clients = Array.isArray(data?.clients) ? data.clients : [];
   const topPersonnel = Array.isArray(data?.topPersonnel) ? data.topPersonnel : [];
@@ -162,6 +180,11 @@ const PlatformLikesSummary = ({
       })
       .slice(0, 5);
   }, [topPersonnel]);
+
+  const activitySummary = personnelActivity ?? null;
+  const activityCategories = activitySummary?.categories ?? [];
+  const totalEvaluated = activitySummary?.totalEvaluated ?? 0;
+  const totalContentEvaluated = activitySummary?.totalContentEvaluated ?? 0;
 
   const lastUpdatedLabel = formatDateTime(data?.lastUpdated);
 
@@ -419,6 +442,61 @@ const PlatformLikesSummary = ({
                   );
                 })}
               </ul>
+            </div>
+          ) : null}
+
+          {activitySummary ? (
+            <div className="rounded-3xl border border-cyan-500/20 bg-slate-950/70 p-6 shadow-[0_20px_45px_rgba(56,189,248,0.18)]">
+              <h3 className="text-sm font-semibold uppercase tracking-[0.3em] text-cyan-200/80">
+                Aktivitas Personil
+              </h3>
+              {!activitySummary.loading && !activitySummary.error && activitySummary.hasSummary ? (
+                <p className="mt-2 text-xs text-slate-400">
+                  {formatNumber(totalEvaluated, { maximumFractionDigits: 0 })} personil dievaluasi
+                  {totalContentEvaluated > 0
+                    ? ` dari ${formatNumber(totalContentEvaluated, { maximumFractionDigits: 0 })} konten`
+                    : " (tidak ada konten yang terbit)"}
+                  .
+                </p>
+              ) : null}
+              <div className="mt-5 space-y-5">
+                {activitySummary.loading ? (
+                  <div className="rounded-2xl border border-slate-800/60 bg-slate-900/60 px-4 py-3 text-sm text-slate-400">
+                    Memuat aktivitas personil…
+                  </div>
+                ) : activitySummary.error ? (
+                  <div className="rounded-2xl border border-rose-500/40 bg-rose-500/10 px-4 py-3 text-sm text-rose-200">
+                    {activitySummary.error}
+                  </div>
+                ) : activityCategories.length > 0 ? (
+                  activityCategories.map((category) => {
+                    const percent = totalEvaluated > 0 ? (category.count / totalEvaluated) * 100 : 0;
+                    return (
+                      <div
+                        key={category.key}
+                        className="flex items-center justify-between rounded-2xl bg-slate-900/60 px-4 py-3"
+                      >
+                        <div>
+                          <p className="text-sm font-medium text-slate-200">{category.label}</p>
+                          <p className="text-xs text-slate-400">{category.description}</p>
+                        </div>
+                        <div className="text-right">
+                          <p className="text-xl font-semibold text-white">
+                            {formatNumber(category.count, { maximumFractionDigits: 0 })}
+                          </p>
+                          {totalEvaluated > 0 ? (
+                            <p className="text-xs text-cyan-300">{formatPercent(percent)}</p>
+                          ) : null}
+                        </div>
+                      </div>
+                    );
+                  })
+                ) : (
+                  <div className="rounded-2xl border border-slate-800/60 bg-slate-900/60 px-4 py-3 text-sm text-slate-400">
+                    Aktivitas personil belum tersedia untuk periode ini.
+                  </div>
+                )}
+              </div>
             </div>
           ) : null}
         </div>


### PR DESCRIPTION
## Summary
- embed the personnel activity card within the "Rincian Kinerja Platform" segment after the top-likes personnel list
- expose personnel activity data to the platform summary component so the card can render alongside other performance tiles

## Testing
- not run (requires interactive lint configuration prompt)


------
https://chatgpt.com/codex/tasks/task_e_68de0463d6888327bbeb79287a3457f4