### PR TITLE
Adjust executive summary trend metrics ordering

### DIFF
--- a/cicero-dashboard/app/executive-summary/page.jsx
+++ b/cicero-dashboard/app/executive-summary/page.jsx
@@ -1016,6 +1016,7 @@ const buildWeeklyEngagementTrend = (
         acc.interactions += Number.isFinite(interactionsCandidate)
           ? Math.max(0, interactionsCandidate)
           : 0;
+        acc.likes += Number.isFinite(likes) ? Math.max(0, likes) : 0;
         acc.posts += 1;
 
         return acc;
@@ -1023,6 +1024,7 @@ const buildWeeklyEngagementTrend = (
       {
         interactions: 0,
         posts: 0,
+        likes: 0,
       },
     );
 
@@ -1031,6 +1033,7 @@ const buildWeeklyEngagementTrend = (
       label: formatWeekRangeLabel(bucket.start, bucket.end),
       interactions: totals.interactions,
       posts: totals.posts,
+      likes: totals.likes,
     };
   });
 
@@ -1046,6 +1049,31 @@ const buildWeeklyEngagementTrend = (
     hasAnyPosts: safeRecords.length > 0,
     hasTrendSamples: normalizedPosts.length > 0,
   };
+};
+
+const calculateAveragePerContent = (totalLikes = 0, totalPosts = 0) => {
+  const safeLikes = Number.isFinite(totalLikes) ? Number(totalLikes) : 0;
+  const safePosts = Number.isFinite(totalPosts) ? Number(totalPosts) : 0;
+
+  if (safePosts <= 0) {
+    return 0;
+  }
+
+  return safeLikes / safePosts;
+};
+
+const resolveAverageFormatOptions = (averageValue = 0) => {
+  const safeAverage = Number.isFinite(averageValue) ? Number(averageValue) : 0;
+
+  if (safeAverage <= 0) {
+    return { maximumFractionDigits: 0 };
+  }
+
+  if (safeAverage < 10) {
+    return { maximumFractionDigits: 1, minimumFractionDigits: 1 };
+  }
+
+  return { maximumFractionDigits: 0 };
 };
 
 const normalizePlatformProfile = (profile, { label = "", followers = 0, posts = 0 } = {}) => {
@@ -3332,24 +3360,45 @@ export default function ExecutiveSummaryPage() {
     const safePreviousLikes = Math.max(0, Number(previousMonth?.likes) || 0);
     const safePreviousPosts = Math.max(0, Number(previousMonth?.posts) || 0);
 
+    const latestAverageLikes = calculateAveragePerContent(
+      safeLatestLikes,
+      safeLatestPosts,
+    );
+    const previousAverageLikes = calculateAveragePerContent(
+      safePreviousLikes,
+      safePreviousPosts,
+    );
+
     const currentMetrics = latestMonth
       ? [
-          { key: "likes", label: "Likes Personil", value: safeLatestLikes },
           {
             key: "posts",
             label: "Post Instagram",
             value: safeLatestPosts,
+          },
+          { key: "likes", label: "Likes Personil", value: safeLatestLikes },
+          {
+            key: "averageLikes",
+            label: "Rata-rata Likes / Konten",
+            value: latestAverageLikes,
+            formatOptions: resolveAverageFormatOptions(latestAverageLikes),
           },
         ]
       : [];
 
     const previousMetrics = previousMonth
       ? [
-          { key: "likes", label: "Likes Personil", value: safePreviousLikes },
           {
             key: "posts",
             label: "Post Instagram",
             value: safePreviousPosts,
+          },
+          { key: "likes", label: "Likes Personil", value: safePreviousLikes },
+          {
+            key: "averageLikes",
+            label: "Rata-rata Likes / Konten",
+            value: previousAverageLikes,
+            formatOptions: resolveAverageFormatOptions(previousAverageLikes),
           },
         ]
       : [];
@@ -3422,25 +3471,46 @@ export default function ExecutiveSummaryPage() {
     );
     const safePreviousPosts = Math.max(0, Number(previousMonth?.posts) || 0);
 
+    const latestAverageComments = calculateAveragePerContent(
+      safeLatestComments,
+      safeLatestPosts,
+    );
+    const previousAverageComments = calculateAveragePerContent(
+      safePreviousComments,
+      safePreviousPosts,
+    );
+
     const currentMetrics = latestMonth
       ? [
+          { key: "posts", label: "Post TikTok", value: safeLatestPosts },
           {
             key: "comments",
             label: "Komentar Personil",
             value: safeLatestComments,
           },
-          { key: "posts", label: "Post TikTok", value: safeLatestPosts },
+          {
+            key: "averageComments",
+            label: "Rata-rata Komentar / Konten",
+            value: latestAverageComments,
+            formatOptions: resolveAverageFormatOptions(latestAverageComments),
+          },
         ]
       : [];
 
     const previousMetrics = previousMonth
       ? [
+          { key: "posts", label: "Post TikTok", value: safePreviousPosts },
           {
             key: "comments",
             label: "Komentar Personil",
             value: safePreviousComments,
           },
-          { key: "posts", label: "Post TikTok", value: safePreviousPosts },
+          {
+            key: "averageComments",
+            label: "Rata-rata Komentar / Konten",
+            value: previousAverageComments,
+            formatOptions: resolveAverageFormatOptions(previousAverageComments),
+          },
         ]
       : [];
 

--- a/cicero-dashboard/components/executive-summary/MonthlyTrendCard.tsx
+++ b/cicero-dashboard/components/executive-summary/MonthlyTrendCard.tsx
@@ -13,6 +13,7 @@ type MonthlyMetric = {
   label: string;
   value: number;
   suffix?: string;
+  formatOptions?: Intl.NumberFormatOptions;
 };
 
 type MonthlyDeltaMetric = {
@@ -160,7 +161,10 @@ const MonthlyTrendCard: React.FC<MonthlyTrendCardProps> = ({
                   >
                     <span className="text-sm text-slate-400">{metric.label}</span>
                     <span className="text-lg font-semibold text-slate-100">
-                      {formatNumber(metric.value, { maximumFractionDigits: 0 })}
+                      {formatNumber(metric.value, {
+                        maximumFractionDigits: 0,
+                        ...(metric.formatOptions ?? {}),
+                      })}
                       {metric.suffix ?? ""}
                     </span>
                   </div>
@@ -183,7 +187,10 @@ const MonthlyTrendCard: React.FC<MonthlyTrendCardProps> = ({
                   >
                     <span className="text-sm text-slate-400">{metric.label}</span>
                     <span className="text-lg font-semibold text-slate-100">
-                      {formatNumber(metric.value, { maximumFractionDigits: 0 })}
+                      {formatNumber(metric.value, {
+                        maximumFractionDigits: 0,
+                        ...(metric.formatOptions ?? {}),
+                      })}
                       {metric.suffix ?? ""}
                     </span>
                   </div>

--- a/cicero-dashboard/components/executive-summary/PlatformEngagementTrendChart.tsx
+++ b/cicero-dashboard/components/executive-summary/PlatformEngagementTrendChart.tsx
@@ -21,6 +21,7 @@ type WeeklyEngagementPoint = {
   label?: string;
   interactions?: number | null;
   posts?: number | null;
+  likes?: number | null;
 };
 
 type PlatformEngagementTrendChartProps = {
@@ -48,16 +49,19 @@ const resolvePoint = (point?: WeeklyEngagementPoint | null) => {
       label: "",
       interactions: 0,
       posts: 0,
+      likes: 0,
     };
   }
 
   const interactions = Number(point.interactions);
   const posts = Number(point.posts);
+  const likes = Number(point.likes);
 
   return {
     label: point.label ?? point.key ?? "",
     interactions: Number.isFinite(interactions) ? Math.max(0, interactions) : 0,
     posts: Number.isFinite(posts) ? Math.max(0, posts) : 0,
+    likes: Number.isFinite(likes) ? Math.max(0, likes) : 0,
   };
 };
 
@@ -117,6 +121,26 @@ const PlatformEngagementTrendChart: React.FC<PlatformEngagementTrendChartProps> 
       ? latestPoint.interactions - (previousPoint?.interactions ?? 0)
       : null;
 
+  const formatAverageLikes = (value: number) => {
+    if (!Number.isFinite(value) || value <= 0) {
+      return formatNumber(0, { maximumFractionDigits: 0 });
+    }
+
+    const fractionDigits = value > 0 && value < 10 ? 1 : 0;
+
+    return formatNumber(value, {
+      maximumFractionDigits: fractionDigits,
+      minimumFractionDigits: fractionDigits,
+    });
+  };
+
+  const latestAverageLikes =
+    latestPoint.posts > 0 ? latestPoint.likes / latestPoint.posts : 0;
+  const previousAverageLikes =
+    previousPoint && previousPoint.posts > 0
+      ? previousPoint.likes / previousPoint.posts
+      : 0;
+
   const renderDelta = (value: number | null) => {
     if (value === null || !Number.isFinite(value)) {
       return null;
@@ -148,19 +172,29 @@ const PlatformEngagementTrendChart: React.FC<PlatformEngagementTrendChartProps> 
           <p className="mt-1 text-sm text-slate-400">{latestPoint.label}</p>
           <div className="mt-3 space-y-2 text-sm">
             <div className="flex items-baseline justify-between">
+              <span className="text-slate-400">Jumlah Konten</span>
+              <span className="text-lg font-semibold text-slate-100">
+                {formatNumber(latestPoint.posts, { maximumFractionDigits: 0 })}
+              </span>
+            </div>
+            <div className="flex items-baseline justify-between">
+              <span className="text-slate-400">Likes Personil</span>
+              <span className="text-lg font-semibold text-slate-100">
+                {formatNumber(latestPoint.likes, { maximumFractionDigits: 0 })}
+              </span>
+            </div>
+            <div className="flex items-baseline justify-between">
+              <span className="text-slate-400">Rata-rata Likes / Konten</span>
+              <span className="text-lg font-semibold text-slate-100">
+                {formatAverageLikes(latestAverageLikes)}
+              </span>
+            </div>
+            <div className="flex items-baseline justify-between">
               <span className="text-slate-400">Total Interaksi</span>
               <span className="text-lg font-semibold text-slate-100">
                 {formatNumber(latestPoint.interactions, { maximumFractionDigits: 0 })}
               </span>
             </div>
-            {typeof latestPoint.posts === "number" && latestPoint.posts > 0 ? (
-              <div className="flex items-baseline justify-between">
-                <span className="text-slate-400">Jumlah Konten</span>
-                <span className="text-lg font-semibold text-slate-100">
-                  {formatNumber(latestPoint.posts, { maximumFractionDigits: 0 })}
-                </span>
-              </div>
-            ) : null}
           </div>
         </div>
         <div className="rounded-2xl border border-slate-800/60 bg-slate-900/60 p-4">
@@ -170,19 +204,29 @@ const PlatformEngagementTrendChart: React.FC<PlatformEngagementTrendChartProps> 
               <p className="mt-1 text-sm text-slate-400">{previousPoint.label}</p>
               <div className="mt-3 space-y-2 text-sm">
                 <div className="flex items-baseline justify-between">
+                  <span className="text-slate-400">Jumlah Konten</span>
+                  <span className="text-lg font-semibold text-slate-100">
+                    {formatNumber(previousPoint.posts, { maximumFractionDigits: 0 })}
+                  </span>
+                </div>
+                <div className="flex items-baseline justify-between">
+                  <span className="text-slate-400">Likes Personil</span>
+                  <span className="text-lg font-semibold text-slate-100">
+                    {formatNumber(previousPoint.likes, { maximumFractionDigits: 0 })}
+                  </span>
+                </div>
+                <div className="flex items-baseline justify-between">
+                  <span className="text-slate-400">Rata-rata Likes / Konten</span>
+                  <span className="text-lg font-semibold text-slate-100">
+                    {formatAverageLikes(previousAverageLikes)}
+                  </span>
+                </div>
+                <div className="flex items-baseline justify-between">
                   <span className="text-slate-400">Total Interaksi</span>
                   <span className="text-lg font-semibold text-slate-100">
                     {formatNumber(previousPoint.interactions, { maximumFractionDigits: 0 })}
                   </span>
                 </div>
-                {typeof previousPoint.posts === "number" && previousPoint.posts > 0 ? (
-                  <div className="flex items-baseline justify-between">
-                    <span className="text-slate-400">Jumlah Konten</span>
-                    <span className="text-lg font-semibold text-slate-100">
-                      {formatNumber(previousPoint.posts, { maximumFractionDigits: 0 })}
-                    </span>
-                  </div>
-                ) : null}
               </div>
             </>
           ) : (


### PR DESCRIPTION
## Summary
- reorder monthly trend metrics to prioritize post counts and add average engagement per content for Instagram and TikTok cards
- extend weekly trend calculations to capture likes, presenting posts, likes, and average likes per content ahead of interaction totals
- allow monthly metric formatting overrides so average values can display fractional precision

## Testing
- not run (next lint prompts for configuration)

------
https://chatgpt.com/codex/tasks/task_e_68de075b9df083279108a3a775a29b81