### PR TITLE
Fix parsing of localized dates for monthly trend metrics

### DIFF
--- a/cicero-dashboard/__tests__/executiveSummaryWeeklyTrend.test.tsx
+++ b/cicero-dashboard/__tests__/executiveSummaryWeeklyTrend.test.tsx
@@ -362,4 +362,27 @@ describe("Monthly trend card metric emphasis", () => {
       screen.getByText("Komentar Personil: 18 • Post: 4"),
     ).toBeInTheDocument();
   });
+
+  it("groups activity records that only provide Indonesian month labels", () => {
+    const records = [
+      { periode: "Mei 2024", jumlah_like: "5" },
+      { periode: "Juni 2024", jumlah_like: 7 },
+      { periode: "15 Juli 2024", jumlah_like: 3 },
+    ];
+
+    const buckets = groupRecordsByMonth(records);
+
+    expect(buckets).toHaveLength(3);
+    expect(buckets.map((bucket) => bucket.key)).toEqual([
+      "2024-05",
+      "2024-06",
+      "2024-07",
+    ]);
+
+    const totals = buckets.map((bucket) =>
+      sumActivityRecords(bucket.records, INSTAGRAM_LIKE_FIELD_PATHS),
+    );
+
+    expect(totals).toEqual([5, 7, 3]);
+  });
 });


### PR DESCRIPTION
## Summary
- enhance the trend date parser so Indonesian month labels and localized formats resolve to proper timestamps
- expand the default activity date paths to pick up monthly metadata fields in trend records
- add coverage ensuring monthly buckets populate when records only provide Indonesian month values

## Testing
- npm test -- --runTestsByPath __tests__/executiveSummaryWeeklyTrend.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68de0a062a34832782e6de86cc86104e