### PR TITLE
Add month labels to executive summary monthly trend cards

### DIFF
--- a/cicero-dashboard/app/executive-summary/page.jsx
+++ b/cicero-dashboard/app/executive-summary/page.jsx
@@ -3456,6 +3456,12 @@ export default function ExecutiveSummaryPage() {
       : [];
 
     const monthsCount = Array.isArray(months) ? months.length : 0;
+    const currentPeriodLabel = latestMonth
+      ? formatMonthRangeLabel(latestMonth.start, latestMonth.end)
+      : null;
+    const previousPeriodLabel = previousMonth
+      ? formatMonthRangeLabel(previousMonth.start, previousMonth.end)
+      : null;
 
     return {
       currentMetrics,
@@ -3463,6 +3469,8 @@ export default function ExecutiveSummaryPage() {
       deltaMetrics,
       series,
       monthsCount,
+      currentPeriodLabel,
+      previousPeriodLabel,
       hasComparison: Boolean(previousMonth),
       hasRecords: Boolean(hasRecords),
     };
@@ -3565,6 +3573,12 @@ export default function ExecutiveSummaryPage() {
       : [];
 
     const monthsCount = Array.isArray(months) ? months.length : 0;
+    const currentPeriodLabel = latestMonth
+      ? formatMonthRangeLabel(latestMonth.start, latestMonth.end)
+      : null;
+    const previousPeriodLabel = previousMonth
+      ? formatMonthRangeLabel(previousMonth.start, previousMonth.end)
+      : null;
 
     return {
       currentMetrics,
@@ -3572,6 +3586,8 @@ export default function ExecutiveSummaryPage() {
       deltaMetrics,
       series,
       monthsCount,
+      currentPeriodLabel,
+      previousPeriodLabel,
       hasComparison: Boolean(previousMonth),
       hasRecords: Boolean(hasRecords),
     };
@@ -3767,6 +3783,8 @@ export default function ExecutiveSummaryPage() {
                 previousMetrics={instagramMonthlyCardData.previousMetrics}
                 deltaMetrics={instagramMonthlyCardData.deltaMetrics}
                 series={instagramMonthlyCardData.series}
+                currentPeriodLabel={instagramMonthlyCardData.currentPeriodLabel}
+                previousPeriodLabel={instagramMonthlyCardData.previousPeriodLabel}
                 formatNumber={formatNumber}
                 formatPercent={formatPercent}
                 primaryMetricLabel="Likes Personil"
@@ -3783,6 +3801,8 @@ export default function ExecutiveSummaryPage() {
                 previousMetrics={tiktokMonthlyCardData.previousMetrics}
                 deltaMetrics={tiktokMonthlyCardData.deltaMetrics}
                 series={tiktokMonthlyCardData.series}
+                currentPeriodLabel={tiktokMonthlyCardData.currentPeriodLabel}
+                previousPeriodLabel={tiktokMonthlyCardData.previousPeriodLabel}
                 formatNumber={formatNumber}
                 formatPercent={formatPercent}
                 primaryMetricLabel="Komentar Personil"

--- a/cicero-dashboard/components/executive-summary/MonthlyTrendCard.tsx
+++ b/cicero-dashboard/components/executive-summary/MonthlyTrendCard.tsx
@@ -55,6 +55,8 @@ type MonthlyTrendCardProps = {
   formatPercent?: FormatPercentFn;
   primaryMetricLabel?: string;
   secondaryMetricLabel?: string;
+  currentPeriodLabel?: string | null;
+  previousPeriodLabel?: string | null;
 };
 
 const defaultNumberFormatter: FormatNumberFn = (value, options) => {
@@ -114,6 +116,8 @@ const MonthlyTrendCard: React.FC<MonthlyTrendCardProps> = ({
   formatPercent = defaultPercentFormatter,
   primaryMetricLabel = "Likes",
   secondaryMetricLabel = "Komentar",
+  currentPeriodLabel = null,
+  previousPeriodLabel = null,
 }) => {
   if (loading) {
     return (
@@ -152,6 +156,11 @@ const MonthlyTrendCard: React.FC<MonthlyTrendCardProps> = ({
             <p className="text-xs uppercase tracking-[0.3em] text-slate-500">
               Bulan Berjalan
             </p>
+            {currentPeriodLabel ? (
+              <p className="mt-1 text-sm font-semibold text-slate-300">
+                {currentPeriodLabel}
+              </p>
+            ) : null}
             <div className="mt-3 space-y-2">
               {hasCurrentMetrics ? (
                 currentMetrics.map((metric) => (
@@ -178,6 +187,11 @@ const MonthlyTrendCard: React.FC<MonthlyTrendCardProps> = ({
             <p className="text-xs uppercase tracking-[0.3em] text-slate-500">
               Bulan Sebelumnya
             </p>
+            {previousPeriodLabel ? (
+              <p className="mt-1 text-sm font-semibold text-slate-300">
+                {previousPeriodLabel}
+              </p>
+            ) : null}
             <div className="mt-3 space-y-2">
               {hasPreviousMetrics ? (
                 previousMetrics.map((metric) => (


### PR DESCRIPTION
## Summary
- show the formatted month and year for the current and previous periods on the executive summary monthly trend cards
- expose the derived period labels from the Instagram and TikTok monthly trend calculations so the cards can display them

## Testing
- npm run lint *(fails: prompts to configure ESLint interactively)*

------
https://chatgpt.com/codex/tasks/task_e_68de100cc31883278751bf423af1b81f