### PR TITLE
Redesign monthly trend card with charted summary

### DIFF
--- a/cicero-dashboard/__tests__/executiveSummaryWeeklyTrend.test.tsx
+++ b/cicero-dashboard/__tests__/executiveSummaryWeeklyTrend.test.tsx
@@ -18,6 +18,16 @@ import {
 } from "@/app/executive-summary/dataTransforms";
 import MonthlyTrendCard from "@/components/executive-summary/MonthlyTrendCard";
 
+beforeAll(() => {
+  const ResizeObserverMock = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+
+  (global as any).ResizeObserver = ResizeObserverMock;
+});
+
 describe("groupRecordsByMonth monthly trend integration", () => {
   it("groups instagram activity into monthly buckets and shows the trend card", () => {
     const records = [
@@ -320,6 +330,7 @@ describe("Monthly trend card metric emphasis", () => {
         previousMetrics={[
           { key: "likes", label: "Likes Personil", value: 18 },
         ]}
+        primaryMetricLabel="Likes Personil"
         series={[
           {
             key: "2024-07",
@@ -330,9 +341,8 @@ describe("Monthly trend card metric emphasis", () => {
       />,
     );
 
-    const detail = screen.getByText("Likes: 24");
+    const detail = screen.getByText(/Likes Personil: 24/);
     expect(detail).toBeInTheDocument();
-    expect(detail.textContent).toBe("Likes: 24");
   });
 
   it("supports custom interaction labels with optional secondary metrics", () => {
@@ -359,7 +369,7 @@ describe("Monthly trend card metric emphasis", () => {
     );
 
     expect(
-      screen.getByText("Komentar Personil: 18 • Post: 4"),
+      screen.getByText(/Komentar Personil: 18 • Post: 4/),
     ).toBeInTheDocument();
   });
 

--- a/cicero-dashboard/components/executive-summary/MonthlyTrendCard.tsx
+++ b/cicero-dashboard/components/executive-summary/MonthlyTrendCard.tsx
@@ -1,6 +1,15 @@
 "use client";
 
-import React from "react";
+import React, { useMemo } from "react";
+import {
+  ResponsiveContainer,
+  AreaChart,
+  Area,
+  CartesianGrid,
+  XAxis,
+  YAxis,
+  Tooltip,
+} from "recharts";
 
 type FormatNumberFn = (
   value: number,
@@ -65,7 +74,7 @@ const defaultNumberFormatter: FormatNumberFn = (value, options) => {
     maximumFractionDigits: 0,
     minimumFractionDigits: 0,
     ...(options ?? {}),
-  }).format(numericValue);
+  }).format(Math.max(0, numericValue));
 };
 
 const defaultPercentFormatter: FormatPercentFn = (value) => {
@@ -103,6 +112,79 @@ const resolveMonthLabel = (item: MonthlyTrendSeriesPoint): string => {
   return item.key;
 };
 
+const toNullableNumber = (value?: number | null): number | null => {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  const numericValue = Number(value);
+  return Number.isFinite(numericValue) ? numericValue : null;
+};
+
+const resolveSeriesValue = (
+  item: MonthlyTrendSeriesPoint,
+  candidates: SeriesValueKey[],
+  exclude?: SeriesValueKey,
+) => {
+  for (const candidate of candidates) {
+    if (exclude && candidate === exclude) {
+      continue;
+    }
+
+    const value = (() => {
+      switch (candidate) {
+        case "primary":
+          return toNullableNumber(item.primary);
+        case "secondary":
+          return toNullableNumber(item.secondary);
+        case "likes":
+          return toNullableNumber(item.likes);
+        case "comments":
+          return toNullableNumber(item.comments);
+        case "posts":
+          return toNullableNumber(item.posts);
+        default:
+          return null;
+      }
+    })();
+
+    if (value !== null) {
+      return { value, key: candidate } as const;
+    }
+  }
+
+  return { value: null, key: null } as const;
+};
+
+const renderMetricsList = (
+  metrics: MonthlyMetric[],
+  formatNumber: FormatNumberFn,
+  emptyLabel: string,
+) => {
+  if (metrics.length === 0) {
+    return <p className="text-sm text-slate-500">{emptyLabel}</p>;
+  }
+
+  return (
+    <div className="mt-3 space-y-2 text-sm">
+      {metrics.map((metric) => (
+        <div
+          key={metric.key}
+          className="flex items-baseline justify-between text-slate-100"
+        >
+          <span className="text-slate-400">{metric.label}</span>
+          <span className="text-lg font-semibold text-slate-100">
+            {formatNumber(metric.value, {
+              maximumFractionDigits: 0,
+              ...(metric.formatOptions ?? {}),
+            })}
+            {metric.suffix ?? ""}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+};
+
 const MonthlyTrendCard: React.FC<MonthlyTrendCardProps> = ({
   title,
   description,
@@ -119,6 +201,47 @@ const MonthlyTrendCard: React.FC<MonthlyTrendCardProps> = ({
   currentPeriodLabel = null,
   previousPeriodLabel = null,
 }) => {
+  const hasCurrentMetrics = currentMetrics.length > 0;
+  const hasPreviousMetrics = previousMetrics.length > 0;
+  const hasDelta = deltaMetrics.length > 0;
+
+  const chartData = useMemo(() => {
+    if (!Array.isArray(series) || series.length === 0) {
+      return [] as Array<{
+        key: string;
+        label: string;
+        primary: number;
+        secondary: number | null;
+      }>;
+    }
+
+    return series.map((item) => {
+      const primary = resolveSeriesValue(item, [
+        "primary",
+        "likes",
+        "comments",
+      ]);
+      const secondary = resolveSeriesValue(
+        item,
+        ["secondary", "posts", "likes", "comments"],
+        primary.key ?? undefined,
+      );
+
+      return {
+        key: item.key,
+        label: resolveMonthLabel(item),
+        primary: Math.max(0, primary.value ?? 0),
+        secondary:
+          secondary.value !== null ? Math.max(0, secondary.value) : null,
+      };
+    });
+  }, [series]);
+
+  const hasTrend = chartData.length > 0;
+  const hasTrendData = hasTrend
+    ? chartData.some((point) => point.primary > 0 || (point.secondary ?? 0) > 0)
+    : false;
+
   if (loading) {
     return (
       <div className="rounded-3xl border border-slate-800/70 bg-slate-950/70 p-6 text-sm text-slate-400">
@@ -126,11 +249,6 @@ const MonthlyTrendCard: React.FC<MonthlyTrendCardProps> = ({
       </div>
     );
   }
-
-  const hasCurrentMetrics = currentMetrics.length > 0;
-  const hasPreviousMetrics = previousMetrics.length > 0;
-  const hasDelta = deltaMetrics.length > 0;
-  const hasSeries = Array.isArray(series) && series.length > 0;
 
   return (
     <div className="rounded-3xl border border-slate-800/70 bg-slate-950/70 p-6 shadow-[0_18px_38px_rgba(15,23,42,0.35)]">
@@ -157,62 +275,32 @@ const MonthlyTrendCard: React.FC<MonthlyTrendCardProps> = ({
               Bulan Berjalan
             </p>
             {currentPeriodLabel ? (
-              <p className="mt-1 text-sm font-semibold text-slate-300">
-                {currentPeriodLabel}
-              </p>
+              <p className="mt-1 text-sm text-slate-400">{currentPeriodLabel}</p>
             ) : null}
-            <div className="mt-3 space-y-2">
-              {hasCurrentMetrics ? (
-                currentMetrics.map((metric) => (
-                  <div
-                    key={metric.key}
-                    className="flex items-baseline justify-between text-slate-100"
-                  >
-                    <span className="text-sm text-slate-400">{metric.label}</span>
-                    <span className="text-lg font-semibold text-slate-100">
-                      {formatNumber(metric.value, {
-                        maximumFractionDigits: 0,
-                        ...(metric.formatOptions ?? {}),
-                      })}
-                      {metric.suffix ?? ""}
-                    </span>
-                  </div>
-                ))
-              ) : (
-                <p className="text-sm text-slate-500">Belum ada data bulan ini.</p>
-              )}
-            </div>
+            {renderMetricsList(
+              currentMetrics,
+              formatNumber,
+              "Belum ada data bulan ini.",
+            )}
           </div>
           <div className="rounded-2xl border border-slate-800/60 bg-slate-900/60 p-4">
             <p className="text-xs uppercase tracking-[0.3em] text-slate-500">
               Bulan Sebelumnya
             </p>
             {previousPeriodLabel ? (
-              <p className="mt-1 text-sm font-semibold text-slate-300">
-                {previousPeriodLabel}
-              </p>
+              <p className="mt-1 text-sm text-slate-400">{previousPeriodLabel}</p>
             ) : null}
-            <div className="mt-3 space-y-2">
-              {hasPreviousMetrics ? (
-                previousMetrics.map((metric) => (
-                  <div
-                    key={metric.key}
-                    className="flex items-baseline justify-between text-slate-100"
-                  >
-                    <span className="text-sm text-slate-400">{metric.label}</span>
-                    <span className="text-lg font-semibold text-slate-100">
-                      {formatNumber(metric.value, {
-                        maximumFractionDigits: 0,
-                        ...(metric.formatOptions ?? {}),
-                      })}
-                      {metric.suffix ?? ""}
-                    </span>
-                  </div>
-                ))
-              ) : (
-                <p className="text-sm text-slate-500">Belum ada pembanding.</p>
-              )}
-            </div>
+            {hasPreviousMetrics ? (
+              renderMetricsList(
+                previousMetrics,
+                formatNumber,
+                "Belum ada pembanding.",
+              )
+            ) : (
+              <p className="mt-3 text-sm text-slate-500">
+                Belum ada pembanding.
+              </p>
+            )}
           </div>
         </div>
       ) : (
@@ -224,24 +312,48 @@ const MonthlyTrendCard: React.FC<MonthlyTrendCardProps> = ({
       {hasDelta ? (
         <div className="mt-6 grid gap-3 md:grid-cols-2">
           {deltaMetrics.map((delta) => {
-            const rawAbsolute =
+            const safeAbsolute =
               delta.absolute !== null && delta.absolute !== undefined
                 ? Number(delta.absolute)
-                : 0;
-            const absolute = Number.isFinite(rawAbsolute) ? rawAbsolute : 0;
-            const isPositive = absolute > 0;
-            const isNegative = absolute < 0;
-            const sign = isPositive ? "+" : isNegative ? "−" : "±";
-            const accent = isPositive
-              ? "text-emerald-300"
-              : isNegative
-              ? "text-rose-300"
-              : "text-slate-200";
-            const absValue = Math.abs(absolute);
-            const percentLabel =
-              delta.percent !== null && delta.percent !== undefined
-                ? `${sign}${formatPercent(Math.abs(Number(delta.percent) || 0))}`
                 : null;
+            const absoluteValue =
+              safeAbsolute !== null && Number.isFinite(safeAbsolute)
+                ? safeAbsolute
+                : null;
+            const percentValue =
+              delta.percent !== null && delta.percent !== undefined
+                ? Number(delta.percent)
+                : null;
+
+            const accent = (() => {
+              if (absoluteValue === null || absoluteValue === 0) {
+                return "text-slate-200";
+              }
+              return absoluteValue > 0 ? "text-emerald-300" : "text-rose-300";
+            })();
+
+            const prefix = (() => {
+              if (absoluteValue === null || absoluteValue === 0) {
+                return "±";
+              }
+              return absoluteValue > 0 ? "+" : "−";
+            })();
+
+            const formattedAbsolute =
+              absoluteValue !== null
+                ? `${prefix}${formatNumber(Math.abs(absoluteValue), {
+                    maximumFractionDigits: 0,
+                  })}`
+                : "–";
+
+            const percentLabel = (() => {
+              if (percentValue === null || !Number.isFinite(percentValue)) {
+                return "Tidak ada perbandingan persentase.";
+              }
+
+              const safePercent = Math.abs(percentValue);
+              return `${prefix}${formatPercent(safePercent)}`;
+            })();
 
             return (
               <div
@@ -252,130 +364,128 @@ const MonthlyTrendCard: React.FC<MonthlyTrendCardProps> = ({
                   {delta.label}
                 </p>
                 <p className={`mt-2 text-lg font-semibold ${accent}`}>
-                  {Number.isFinite(absValue)
-                    ? `${sign}${formatNumber(absValue, { maximumFractionDigits: 0 })}`
-                    : "–"}
+                  {formattedAbsolute}
                 </p>
-                {percentLabel ? (
-                  <p className="text-xs text-slate-400">{percentLabel}</p>
-                ) : (
-                  <p className="text-xs text-slate-500">
-                    Tidak ada perbandingan persentase.
-                  </p>
-                )}
+                <p className="text-xs text-slate-400">{percentLabel}</p>
               </div>
             );
           })}
         </div>
       ) : null}
 
-      {hasSeries ? (
+      {hasTrend ? (
         <div className="mt-6 space-y-3">
           <p className="text-xs uppercase tracking-[0.3em] text-slate-500">
-            Rekap Bulanan
+            Tren {primaryMetricLabel}
           </p>
-          <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
-            {series.map((item) => {
-              const toNullableNumber = (value?: number | null): number | null => {
-                if (value === null || value === undefined) {
-                  return null;
-                }
-                const numericValue = Number(value);
-                return Number.isFinite(numericValue) ? numericValue : null;
-              };
-
-              const getNumericField = (field: SeriesValueKey): number | null => {
-                switch (field) {
-                  case "primary":
-                    return toNullableNumber(item.primary);
-                  case "secondary":
-                    return toNullableNumber(item.secondary);
-                  case "likes":
-                    return toNullableNumber(item.likes);
-                  case "comments":
-                    return toNullableNumber(item.comments);
-                  case "posts":
-                    return toNullableNumber(item.posts);
-                  default:
-                    return null;
-                }
-              };
-
-              const primaryCandidates: SeriesValueKey[] = [
-                "primary",
-                "likes",
-                "comments",
-                "posts",
-              ];
-
-              let primaryValue: number | null = null;
-              let primaryKey: SeriesValueKey | null = null;
-
-              for (const candidate of primaryCandidates) {
-                const candidateValue = getNumericField(candidate);
-                if (candidateValue !== null) {
-                  primaryValue = candidateValue;
-                  primaryKey = candidate;
-                  break;
-                }
-              }
-
-              const secondaryCandidates: SeriesValueKey[] = [
-                "secondary",
-                "posts",
-                "likes",
-                "comments",
-              ];
-
-              let secondaryValue: number | null = null;
-
-              for (const candidate of secondaryCandidates) {
-                if (primaryKey && candidate === primaryKey) {
-                  continue;
-                }
-                const candidateValue = getNumericField(candidate);
-                if (candidateValue !== null) {
-                  secondaryValue = candidateValue;
-                  break;
-                }
-              }
-
-              const segments: string[] = [];
-
-              if (primaryValue !== null) {
-                segments.push(
-                  `${primaryMetricLabel}: ${formatNumber(primaryValue, {
-                    maximumFractionDigits: 0,
-                  })}`,
-                );
-              }
-
-              if (secondaryValue !== null) {
-                segments.push(
-                  `${secondaryMetricLabel}: ${formatNumber(secondaryValue, {
-                    maximumFractionDigits: 0,
-                  })}`,
-                );
-              }
-
-              const detailLabel =
-                segments.length > 0
-                  ? segments.join(" • ")
-                  : "Tidak ada data tersedia.";
-
-              return (
-                <div
-                  key={item.key}
-                  className="rounded-2xl border border-slate-800/60 bg-slate-900/60 px-3 py-2 text-xs text-slate-300"
+          <div className="h-64">
+            {hasTrendData ? (
+              <ResponsiveContainer width="100%" height="100%">
+                <AreaChart
+                  data={chartData}
+                  margin={{ top: 10, right: 20, left: 0, bottom: 0 }}
                 >
-                  <p className="font-semibold text-slate-200">
-                    {resolveMonthLabel(item)}
-                  </p>
-                  <p className="mt-1 text-slate-400">{detailLabel}</p>
-                </div>
-              );
-            })}
+                  <CartesianGrid
+                    strokeDasharray="3 3"
+                    stroke="rgba(148,163,184,0.2)"
+                  />
+                  <XAxis
+                    dataKey="label"
+                    stroke="#94a3b8"
+                    tick={{ fill: "#cbd5f5", fontSize: 12 }}
+                  />
+                  <YAxis
+                    stroke="#94a3b8"
+                    tick={{ fill: "#cbd5f5", fontSize: 12 }}
+                    tickFormatter={(value) =>
+                      formatNumber(Number.isFinite(value) ? Number(value) : 0, {
+                        maximumFractionDigits: 0,
+                      })
+                    }
+                  />
+                  <Tooltip
+                    cursor={{ stroke: "rgba(56,189,248,0.45)", strokeWidth: 2 }}
+                    contentStyle={{
+                      backgroundColor: "rgba(15,23,42,0.92)",
+                      borderRadius: 16,
+                      borderColor: "rgba(148,163,184,0.4)",
+                      color: "#e2e8f0",
+                    }}
+                    formatter={(value: number, name: string, payload) => {
+                      const entry =
+                        payload && typeof payload === "object"
+                          ? (payload as { dataKey?: string | undefined })
+                          : undefined;
+                      const dataKey = entry?.dataKey;
+
+                      if (dataKey === "primary") {
+                        return [
+                          formatNumber(Number.isFinite(value) ? Number(value) : 0, {
+                            maximumFractionDigits: 0,
+                          }),
+                          primaryMetricLabel,
+                        ];
+                      }
+
+                      if (dataKey === "secondary") {
+                        return [
+                          formatNumber(Number.isFinite(value) ? Number(value) : 0, {
+                            maximumFractionDigits: 0,
+                          }),
+                          secondaryMetricLabel,
+                        ];
+                      }
+
+                      return [value, name];
+                    }}
+                  />
+                  <defs>
+                    <linearGradient id="monthlyPrimaryGradient" x1="0" y1="0" x2="0" y2="1">
+                      <stop offset="5%" stopColor="#38bdf8" stopOpacity={0.7} />
+                      <stop offset="95%" stopColor="#38bdf8" stopOpacity={0.1} />
+                    </linearGradient>
+                  </defs>
+                  <Area
+                    type="monotone"
+                    dataKey="primary"
+                    name={primaryMetricLabel}
+                    stroke="#38bdf8"
+                    fill="url(#monthlyPrimaryGradient)"
+                    strokeWidth={3}
+                    dot={{
+                      stroke: "#38bdf8",
+                      strokeWidth: 2,
+                      fill: "#0f172a",
+                    }}
+                    activeDot={{ r: 6 }}
+                  />
+                </AreaChart>
+              </ResponsiveContainer>
+            ) : (
+              <div className="flex h-full items-center justify-center rounded-2xl border border-slate-800/60 bg-slate-900/60 text-sm text-slate-400">
+                Belum ada tren bulanan yang dapat ditampilkan.
+              </div>
+            )}
           </div>
+
+          <ul className="space-y-2 text-xs text-slate-400">
+            {chartData.map((point) => (
+              <li key={point.key}>
+                <span className="font-semibold text-slate-200">
+                  {point.label}
+                </span>
+                {": "}
+                {primaryMetricLabel}: {formatNumber(point.primary, {
+                  maximumFractionDigits: 0,
+                })}
+                {point.secondary !== null
+                  ? ` • ${secondaryMetricLabel}: ${formatNumber(point.secondary, {
+                      maximumFractionDigits: 0,
+                    })}`
+                  : null}
+              </li>
+            ))}
+          </ul>
         </div>
       ) : null}
     </div>


### PR DESCRIPTION
## Summary
- redesign the monthly trend card to mirror the weekly trend presentation, including responsive charts and refined metric comparisons
- expose monthly trend data through a recharts area chart with textual fallbacks and clearer delta messaging
- update executive summary tests with a ResizeObserver mock and refreshed expectations for the new monthly layout

## Testing
- npm test -- --runTestsByPath __tests__/executiveSummaryWeeklyTrend.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68de124484408327a47906ffa4b5283a