### PR TITLE
Align monthly trend date resolution with shared post date paths

### DIFF
--- a/cicero-dashboard/__tests__/executiveSummaryWeeklyTrend.test.tsx
+++ b/cicero-dashboard/__tests__/executiveSummaryWeeklyTrend.test.tsx
@@ -7,6 +7,7 @@ import {
   resolveRecordDate,
   shouldShowWeeklyTrendCard,
 } from "@/app/executive-summary/weeklyTrendUtils";
+import { POST_DATE_PATHS } from "@/app/executive-summary/page";
 import {
   INSTAGRAM_LIKE_FIELD_PATHS,
   TIKTOK_COMMENT_FIELD_PATHS,
@@ -30,6 +31,29 @@ beforeAll(() => {
 });
 
 describe("groupRecordsByMonth monthly trend integration", () => {
+  it("retains instagram posts when only tanggal is provided", () => {
+    const records = [
+      { id: 1, tanggal: "2024-05-03" },
+      { id: 2, tanggal: "2024-05-22" },
+      { id: 3, tanggal: "2024-06-01" },
+    ];
+
+    const filtered = records.filter((record) =>
+      Boolean(resolveRecordDate(record, POST_DATE_PATHS)),
+    );
+
+    const buckets = groupRecordsByMonth(filtered, {
+      datePaths: POST_DATE_PATHS,
+    });
+
+    expect(filtered).toHaveLength(3);
+    expect(buckets).toHaveLength(2);
+    expect(buckets[0].key).toBe("2024-05");
+    expect(buckets[0].records).toHaveLength(2);
+    expect(buckets[1].key).toBe("2024-06");
+    expect(buckets[1].records).toHaveLength(1);
+  });
+
   it("groups instagram activity into monthly buckets and shows the trend card", () => {
     const records = [
       { tanggal: "2024-05-01", jumlah_like: 5 },

--- a/cicero-dashboard/app/executive-summary/page.jsx
+++ b/cicero-dashboard/app/executive-summary/page.jsx
@@ -106,6 +106,18 @@ const formatPercent = (value) => {
 
 const EMPTY_ACTIVITY = Object.freeze({ likes: [], comments: [] });
 
+export const POST_DATE_PATHS = Object.freeze([
+  "publishedAt",
+  "published_at",
+  "timestamp",
+  "createdAt",
+  "created_at",
+  "activityDate",
+  "activity_date",
+  "date",
+  "tanggal",
+]);
+
 const CompletionTooltip = ({ active, payload }) => {
   if (!active || !payload || payload.length === 0) {
     return null;
@@ -2868,29 +2880,13 @@ export default function ExecutiveSummaryPage() {
         const instagramPostsSanitized = ensureRecordsHaveActivityDate(
           instagramPostsRaw,
           {
-            extraPaths: [
-              "publishedAt",
-              "published_at",
-              "timestamp",
-              "createdAt",
-              "created_at",
-              "date",
-              "tanggal",
-            ],
+            extraPaths: POST_DATE_PATHS,
           },
         );
         const tiktokPostsSanitized = ensureRecordsHaveActivityDate(
           tiktokPostsRaw,
           {
-            extraPaths: [
-              "publishedAt",
-              "published_at",
-              "timestamp",
-              "createdAt",
-              "created_at",
-              "date",
-              "tanggal",
-            ],
+            extraPaths: POST_DATE_PATHS,
           },
         );
 
@@ -3124,31 +3120,12 @@ export default function ExecutiveSummaryPage() {
     const instagramPosts = filterRecordsWithResolvableDate(
       Array.isArray(platformPosts?.instagram) ? platformPosts.instagram : [],
       {
-        extraPaths: [
-          "publishedAt",
-          "published_at",
-          "timestamp",
-          "createdAt",
-          "created_at",
-          "date",
-          "tanggal",
-        ],
+        extraPaths: POST_DATE_PATHS,
       },
     );
 
     const monthlyPosts = groupRecordsByMonth(instagramPosts, {
-      getDate: (post) => {
-        if (post?.publishedAt instanceof Date) {
-          return post.publishedAt;
-        }
-        return (
-          post?.createdAt ??
-          post?.created_at ??
-          post?.timestamp ??
-          post?.published_at ??
-          null
-        );
-      },
+      datePaths: POST_DATE_PATHS,
     });
 
     const likesRecords = Array.isArray(platformTrendActivity?.likes)
@@ -3257,15 +3234,7 @@ export default function ExecutiveSummaryPage() {
     const instagramPosts = filterRecordsWithResolvableDate(
       Array.isArray(platformPosts?.instagram) ? platformPosts.instagram : [],
       {
-        extraPaths: [
-          "publishedAt",
-          "published_at",
-          "timestamp",
-          "createdAt",
-          "created_at",
-          "date",
-          "tanggal",
-        ],
+        extraPaths: POST_DATE_PATHS,
       },
     );
 
@@ -3279,31 +3248,12 @@ export default function ExecutiveSummaryPage() {
     const tiktokPosts = filterRecordsWithResolvableDate(
       Array.isArray(platformPosts?.tiktok) ? platformPosts.tiktok : [],
       {
-        extraPaths: [
-          "publishedAt",
-          "published_at",
-          "timestamp",
-          "createdAt",
-          "created_at",
-          "date",
-          "tanggal",
-        ],
+        extraPaths: POST_DATE_PATHS,
       },
     );
 
     const monthlyPosts = groupRecordsByMonth(tiktokPosts, {
-      getDate: (post) => {
-        if (post?.publishedAt instanceof Date) {
-          return post.publishedAt;
-        }
-        return (
-          post?.createdAt ??
-          post?.created_at ??
-          post?.timestamp ??
-          post?.published_at ??
-          null
-        );
-      },
+      datePaths: POST_DATE_PATHS,
     });
 
     const commentRecords = Array.isArray(platformTrendActivity?.comments)
@@ -3412,15 +3362,7 @@ export default function ExecutiveSummaryPage() {
     const tiktokPosts = filterRecordsWithResolvableDate(
       Array.isArray(platformPosts?.tiktok) ? platformPosts.tiktok : [],
       {
-        extraPaths: [
-          "publishedAt",
-          "published_at",
-          "timestamp",
-          "createdAt",
-          "created_at",
-          "date",
-          "tanggal",
-        ],
+        extraPaths: POST_DATE_PATHS,
       },
     );
 


### PR DESCRIPTION
## Summary
- introduce a shared POST_DATE_PATHS constant so Instagram and TikTok posts use the same date extraction hints
- update monthly trend sanitization and grouping to rely on resolveRecordDate with the shared paths instead of custom date logic
- add a regression test to ensure posts that only contain `tanggal` are still counted in monthly buckets

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de22d19ba08327b97a04d1c2af3aab