### PR TITLE
Fix executive summary page invalid export

### DIFF
--- a/cicero-dashboard/app/executive-summary/page.jsx
+++ b/cicero-dashboard/app/executive-summary/page.jsx
@@ -106,7 +106,7 @@ const formatPercent = (value) => {
 
 const EMPTY_ACTIVITY = Object.freeze({ likes: [], comments: [] });
 
-export const POST_DATE_PATHS = Object.freeze([
+const POST_DATE_PATHS = Object.freeze([
   "publishedAt",
   "published_at",
   "timestamp",


### PR DESCRIPTION
## Summary
- remove the unsupported `POST_DATE_PATHS` export from the executive summary page to satisfy Next.js page constraints

## Testing
- not run (lint command prompts for configuration)

------
https://chatgpt.com/codex/tasks/task_e_68de24e52e8c8327ade1075b8fb41e50