### PR TITLE
Ensure executive summary platform recaps respect month filters

### DIFF
--- a/cicero-dashboard/app/executive-summary/page.jsx
+++ b/cicero-dashboard/app/executive-summary/page.jsx
@@ -2475,9 +2475,9 @@ export default function ExecutiveSummaryPage() {
               token,
               clientId,
               activityPeriodeParam,
-              undefined,
-              undefined,
-              undefined,
+              tanggalParam,
+              startDateParam,
+              endDateParam,
               controller.signal,
             ).catch((error) => {
               console.warn("Gagal memuat rekap likes IG", error);
@@ -2487,9 +2487,9 @@ export default function ExecutiveSummaryPage() {
               token,
               clientId,
               activityPeriodeParam,
-              undefined,
-              undefined,
-              undefined,
+              tanggalParam,
+              startDateParam,
+              endDateParam,
               controller.signal,
             ).catch((error) => {
               console.warn("Gagal memuat rekap komentar TikTok", error);


### PR DESCRIPTION
## Summary
- pass the selected month date parameters to the Instagram likes recap request
- pass the same date filters to the TikTok comments recap call so both endpoints respect the chosen month

## Testing
- `npm run lint` *(fails: command prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68de392e190c832795cfe09ad8e78422