### PR TITLE
Simplify executive summary user distribution layout

### DIFF
--- a/cicero-dashboard/app/executive-summary/page.jsx
+++ b/cicero-dashboard/app/executive-summary/page.jsx
@@ -3736,165 +3736,61 @@ export default function ExecutiveSummaryPage() {
                   </div>
                   <div className="overflow-hidden rounded-2xl border border-slate-800/60 bg-slate-950/60">
                     {divisionDistribution.length > 0 ? (
-                      <div className="relative">
-                        <table className="min-w-full divide-y divide-slate-800 text-left">
-                          <thead className="sticky top-0 z-10 bg-gradient-to-r from-slate-950/90 via-slate-900/80 to-slate-950/90 text-[11px] uppercase tracking-[0.28em] text-slate-300 backdrop-blur supports-[backdrop-filter]:bg-slate-900/70">
-                            <tr className="text-xs text-slate-300">
-                              <th scope="col" className="w-20 px-4 py-4 text-[10px] font-semibold uppercase tracking-[0.35em] text-slate-400">
-                                Peringkat
-                              </th>
-                              <th scope="col" className="min-w-[200px] px-4 py-4 text-[10px] font-semibold uppercase tracking-[0.35em] text-slate-400">
-                                Satker / Polres
-                              </th>
-                              <th scope="col" className="w-40 px-4 py-4 text-[10px] font-semibold uppercase tracking-[0.35em] text-slate-400">
-                                Porsi Personil
-                              </th>
-                              <th scope="col" className="w-36 px-4 py-4 text-[10px] font-semibold uppercase tracking-[0.35em] text-slate-400">
-                                Instagram
-                              </th>
-                              <th scope="col" className="w-36 px-4 py-4 text-[10px] font-semibold uppercase tracking-[0.35em] text-slate-400">
-                                TikTok
-                              </th>
-                              <th scope="col" className="w-40 px-4 py-4 text-[10px] font-semibold uppercase tracking-[0.35em] text-slate-400">
-                                Rasio Kelengkapan
-                              </th>
-                            </tr>
-                          </thead>
-                          <tbody className="divide-y divide-slate-800 text-sm text-slate-200">
-                            {divisionDistribution.map((row) => {
-                              const totalShare = maxDistributionTotal
-                                ? Math.min(
-                                    Math.max((row.total / maxDistributionTotal) * 100, row.total > 0 ? 6 : 0),
-                                    100,
-                                  )
-                                : 0;
+                      <div className="divide-y divide-slate-800 text-sm text-slate-200">
+                        <div className="grid grid-cols-[minmax(3rem,4rem)_minmax(0,1.4fr)_repeat(3,minmax(0,1fr))_minmax(0,1fr)] gap-4 px-4 py-3 text-[11px] font-semibold uppercase tracking-[0.35em] text-slate-400">
+                          <span>Peringkat</span>
+                          <span>Satker / Polres</span>
+                          <span className="text-right">Total Personil</span>
+                          <span className="text-right">Instagram</span>
+                          <span className="text-right">TikTok</span>
+                          <span className="text-right">Rasio Kelengkapan</span>
+                        </div>
+                        {divisionDistribution.map((row) => {
+                          const instagramPercent = Math.min(Math.max(row.instagramPercent, 0), 100);
+                          const tiktokPercent = Math.min(Math.max(row.tiktokPercent, 0), 100);
+                          const completionPercent = Math.min(Math.max(row.completionPercent, 0), 100);
 
-                              const rankColors = [
-                                "from-amber-400/30 to-amber-500/20 text-amber-200 border-amber-400/40",
-                                "from-slate-200/20 to-slate-400/10 text-slate-100 border-slate-300/40",
-                                "from-orange-300/20 to-orange-500/10 text-orange-200 border-orange-400/40",
-                              ];
-                              const rankIndex = Math.max(Math.min(row.rank - 1, rankColors.length - 1), 0);
-                              const rankStyle = row.rank <= 3 ? rankColors[rankIndex] : "from-slate-800/40 to-slate-900/40 text-slate-300 border-slate-700";
-
-                              const completionPercent = Math.min(Math.max(row.completionPercent, 0), 100);
-                              const completionLevel = completionPercent >= 80 ? "text-emerald-300" : completionPercent >= 60 ? "text-cyan-200" : "text-amber-300";
-
-                              return (
-                                <tr key={row.id || row.division} className="transition-colors hover:bg-slate-900/50">
-                                  <td className="px-4 py-4 align-top">
-                                    <div
-                                      className={`inline-flex min-w-[3.5rem] items-center justify-center rounded-full border bg-gradient-to-br px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.35em] shadow-[0_8px_20px_rgba(15,23,42,0.35)] ${rankStyle}`}
-                                    >
-                                      {String(row.rank).padStart(2, "0")}
-                                    </div>
-                                  </td>
-                                  <td className="px-4 py-4">
-                                    <div className="space-y-2">
-                                      <div className="flex items-center gap-2">
-                                        <p className="font-semibold text-slate-100">{row.division}</p>
-                                        {row.rank <= 5 ? (
-                                          <span className="inline-flex items-center rounded-full bg-cyan-500/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.35em] text-cyan-200">
-                                            TOP {row.rank}
-                                          </span>
-                                        ) : null}
-                                      </div>
-                                      <div className="flex items-center gap-3 text-xs text-slate-400">
-                                        <span className="rounded-full bg-slate-900/80 px-2 py-0.5 font-semibold text-slate-200">
-                                          {formatNumber(row.total, { maximumFractionDigits: 0 })} personil
-                                        </span>
-                                        <span>•</span>
-                                        <span>{formatPercent(row.sharePercent)} dari total</span>
-                                      </div>
-                                    </div>
-                                  </td>
-                                  <td className="px-4 py-4">
-                                    <div className="space-y-2">
-                                      <div className="flex items-center justify-between text-xs text-slate-400">
-                                        <span className="tabular-nums text-base font-semibold text-slate-100">
-                                          {formatNumber(row.total, { maximumFractionDigits: 0 })}
-                                        </span>
-                                        <span>Porsi</span>
-                                      </div>
-                                      <div className="relative h-2 overflow-hidden rounded-full bg-slate-900/80">
-                                        <span
-                                          className="absolute inset-y-0 left-0 rounded-full bg-gradient-to-r from-cyan-400/80 via-sky-400/80 to-fuchsia-400/70"
-                                          style={{ width: `${totalShare}%` }}
-                                        />
-                                      </div>
-                                      <p className="text-[11px] text-slate-400">{formatPercent(row.sharePercent)} proporsi nasional</p>
-                                    </div>
-                                  </td>
-                                  <td className="px-4 py-4">
-                                    <div className="space-y-2">
-                                      <div className="flex items-baseline justify-between text-xs text-slate-400">
-                                        <span className="tabular-nums text-base font-semibold text-slate-100">
-                                          {formatNumber(row.instagramFilled, { maximumFractionDigits: 0 })}
-                                        </span>
-                                        <span>Profil</span>
-                                      </div>
-                                      <div className="relative h-2 overflow-hidden rounded-full bg-slate-900/80">
-                                        <span
-                                          className="absolute inset-y-0 left-0 rounded-full bg-gradient-to-r from-fuchsia-400/70 to-fuchsia-500/60"
-                                          style={{ width: `${Math.min(Math.max(row.instagramPercent, 0), 100)}%` }}
-                                        />
-                                      </div>
-                                      <p className="text-[11px] text-slate-400">{formatPercent(row.instagramPercent)} akun terisi</p>
-                                    </div>
-                                  </td>
-                                  <td className="px-4 py-4">
-                                    <div className="space-y-2">
-                                      <div className="flex items-baseline justify-between text-xs text-slate-400">
-                                        <span className="tabular-nums text-base font-semibold text-slate-100">
-                                          {formatNumber(row.tiktokFilled, { maximumFractionDigits: 0 })}
-                                        </span>
-                                        <span>Profil</span>
-                                      </div>
-                                      <div className="relative h-2 overflow-hidden rounded-full bg-slate-900/80">
-                                        <span
-                                          className="absolute inset-y-0 left-0 rounded-full bg-gradient-to-r from-sky-400/70 to-cyan-400/70"
-                                          style={{ width: `${Math.min(Math.max(row.tiktokPercent, 0), 100)}%` }}
-                                        />
-                                      </div>
-                                      <p className="text-[11px] text-slate-400">{formatPercent(row.tiktokPercent)} akun terisi</p>
-                                    </div>
-                                  </td>
-                                  <td className="px-4 py-4">
-                                    <div className="space-y-3">
-                                      <div className="flex items-center justify-between text-xs text-slate-400">
-                                        <span className={`text-base font-semibold ${completionLevel}`}>
-                                          {formatPercent(row.completionPercent)}
-                                        </span>
-                                        <span>Kelengkapan</span>
-                                      </div>
-                                      <div className="h-2 overflow-hidden rounded-full bg-slate-900/80">
-                                        <span
-                                          className="block h-full rounded-full bg-gradient-to-r from-emerald-400/80 via-cyan-400/80 to-sky-400/80"
-                                          style={{ width: `${completionPercent}%` }}
-                                        />
-                                      </div>
-                                      <div className="flex flex-wrap gap-2 text-[10px] uppercase tracking-[0.35em] text-slate-400">
-                                        {completionPercent >= 80 ? (
-                                          <span className="inline-flex items-center rounded-full bg-emerald-500/10 px-2 py-0.5 text-emerald-300">
-                                            Sangat Baik
-                                          </span>
-                                        ) : completionPercent >= 60 ? (
-                                          <span className="inline-flex items-center rounded-full bg-cyan-500/10 px-2 py-0.5 text-cyan-200">
-                                            Perlu Optimasi
-                                          </span>
-                                        ) : (
-                                          <span className="inline-flex items-center rounded-full bg-amber-500/10 px-2 py-0.5 text-amber-300">
-                                            Prioritas
-                                          </span>
-                                        )}
-                                      </div>
-                                    </div>
-                                  </td>
-                                </tr>
-                              );
-                            })}
-                          </tbody>
-                        </table>
+                          return (
+                            <div
+                              key={row.id || row.division}
+                              className="grid grid-cols-[minmax(3rem,4rem)_minmax(0,1.4fr)_repeat(3,minmax(0,1fr))_minmax(0,1fr)] items-start gap-4 px-4 py-4 transition-colors hover:bg-slate-900/50"
+                            >
+                              <div className="tabular-nums text-sm font-semibold text-slate-300">
+                                {String(row.rank).padStart(2, "0")}
+                              </div>
+                              <div className="space-y-1">
+                                <p className="font-semibold text-slate-100">{row.division}</p>
+                                <p className="text-xs text-slate-400">
+                                  {formatPercent(row.sharePercent)} dari total personil
+                                </p>
+                              </div>
+                              <div className="text-right">
+                                <p className="tabular-nums text-base font-semibold text-slate-100">
+                                  {formatNumber(row.total, { maximumFractionDigits: 0 })}
+                                </p>
+                                <p className="text-xs text-slate-400">Personil</p>
+                              </div>
+                              <div className="text-right">
+                                <p className="tabular-nums text-base font-semibold text-slate-100">
+                                  {formatNumber(row.instagramFilled, { maximumFractionDigits: 0 })}
+                                </p>
+                                <p className="text-xs text-slate-400">{formatPercent(instagramPercent)}</p>
+                              </div>
+                              <div className="text-right">
+                                <p className="tabular-nums text-base font-semibold text-slate-100">
+                                  {formatNumber(row.tiktokFilled, { maximumFractionDigits: 0 })}
+                                </p>
+                                <p className="text-xs text-slate-400">{formatPercent(tiktokPercent)}</p>
+                              </div>
+                              <div className="text-right">
+                                <p className="tabular-nums text-base font-semibold text-slate-100">
+                                  {formatPercent(completionPercent)}
+                                </p>
+                                <p className="text-xs text-slate-400">Kelengkapan</p>
+                              </div>
+                            </div>
+                          );
+                        })}
                       </div>
                     ) : (
                       <div className="flex h-48 items-center justify-center text-sm text-slate-400">


### PR DESCRIPTION
## Summary
- replace the "Distribusi User per Satker" table with a simplified grid layout styled like the likes summary component
- present personnel, Instagram, TikTok, and completion metrics as textual columns using the existing formatting helpers

## Testing
- pnpm lint *(fails: prompts for ESLint configuration in this environment)*
- pnpm dev *(manual verification of /executive-summary; Google Fonts could not be fetched but the page rendered with fallbacks)*

------
https://chatgpt.com/codex/tasks/task_e_68df0b9d5f08832795dd4d8051ec4f45