### PR TITLE
Sort executive summary tables by ratios

### DIFF
--- a/cicero-dashboard/app/executive-summary/page.jsx
+++ b/cicero-dashboard/app/executive-summary/page.jsx
@@ -437,7 +437,13 @@ const computeUserInsight = (users = []) => {
   const pieTotal = pieData.reduce((acc, curr) => acc + curr.value, 0);
 
   const sortedByDivisionSize = [...divisionArray].sort((a, b) => b.total - a.total);
-  const divisionDistribution = sortedByDivisionSize.map((item, index) => ({
+  const sortedByCompletionRate = [...divisionArray].sort((a, b) => {
+    if (b.completionPercent !== a.completionPercent) {
+      return b.completionPercent - a.completionPercent;
+    }
+    return b.total - a.total;
+  });
+  const divisionDistribution = sortedByCompletionRate.map((item, index) => ({
     id: item.division ?? `division-${index}`,
     rank: index + 1,
     division: beautifyDivisionName(item.displayName ?? item.division),

--- a/cicero-dashboard/components/executive-summary/PlatformLikesSummary.tsx
+++ b/cicero-dashboard/components/executive-summary/PlatformLikesSummary.tsx
@@ -162,6 +162,19 @@ const PlatformLikesSummary = ({
       .slice(0, 3);
   }, [clients]);
 
+  const clientsByCompliance = useMemo(() => {
+    return [...clients].sort((a, b) => {
+      const complianceA = a.complianceRate ?? 0;
+      const complianceB = b.complianceRate ?? 0;
+      if (complianceB !== complianceA) {
+        return complianceB - complianceA;
+      }
+      const likesA = a.totalLikes ?? 0;
+      const likesB = b.totalLikes ?? 0;
+      return likesB - likesA;
+    });
+  }, [clients]);
+
   const standoutPersonnel = useMemo(() => {
     return topPersonnel.slice(0, 5);
   }, [topPersonnel]);
@@ -238,7 +251,7 @@ const PlatformLikesSummary = ({
                 </tr>
               </thead>
               <tbody className="divide-y divide-slate-800">
-                {clients.map((client) => {
+                {clientsByCompliance.map((client) => {
                   const compliance = formatPercent(client.complianceRate ?? 0);
                   const avgLikes = formatNumber(client.averageLikesPerUser ?? 0, {
                     maximumFractionDigits: 1,


### PR DESCRIPTION
## Summary
- sort the Executive Summary user distribution table by highest completion ratio and break ties by personnel count
- order the Executive Summary likes distribution table by highest compliance rate with likes as a secondary tiebreaker

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df1536d1b08327be4012711462f092