### PR TITLE
Fix satker names in likes distribution table

### DIFF
--- a/cicero-dashboard/app/executive-summary/dataTransforms.js
+++ b/cicero-dashboard/app/executive-summary/dataTransforms.js
@@ -468,7 +468,6 @@ const aggregateLikesRecords = (records = [], options = {}) => {
           source?.satker ??
           source?.satuan_kerja ??
           source?.nama_satuan_kerja ??
-          source?.nama ??
           clientId,
       ) || "LAINNYA";
 


### PR DESCRIPTION
## Summary
- ensure the likes recap aggregation no longer falls back to personnel names when resolving client names
- keep the likes distribution table showing satker names as intended

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df1cdddd6083279f7fa9a66759acdc