### PR TITLE
Update weekly trend cards with platform-specific metrics

### DIFF
--- a/cicero-dashboard/app/executive-summary/page.jsx
+++ b/cicero-dashboard/app/executive-summary/page.jsx
@@ -877,6 +877,7 @@ const buildWeeklyEngagementTrend = (
           ? Math.max(0, interactionsCandidate)
           : 0;
         acc.likes += Number.isFinite(likes) ? Math.max(0, likes) : 0;
+        acc.comments += Number.isFinite(comments) ? Math.max(0, comments) : 0;
         acc.posts += 1;
 
         return acc;
@@ -885,6 +886,7 @@ const buildWeeklyEngagementTrend = (
         interactions: 0,
         posts: 0,
         likes: 0,
+        comments: 0,
       },
     );
 
@@ -894,6 +896,7 @@ const buildWeeklyEngagementTrend = (
       interactions: totals.interactions,
       posts: totals.posts,
       likes: totals.likes,
+      comments: totals.comments,
     };
   });
 
@@ -3646,6 +3649,7 @@ export default function ExecutiveSummaryPage() {
           <div className="grid gap-4 lg:grid-cols-2">
             {shouldShowInstagramWeeklyTrendCard ? (
               <PlatformEngagementTrendChart
+                platformKey="instagram"
                 platformLabel="Instagram"
                 series={instagramWeeklyTrendCardData.series}
                 latest={instagramWeeklyTrendCardData.latestWeek}
@@ -3658,6 +3662,7 @@ export default function ExecutiveSummaryPage() {
 
             {shouldShowTiktokWeeklyTrendCard ? (
               <PlatformEngagementTrendChart
+                platformKey="tiktok"
                 platformLabel="TikTok"
                 series={tiktokWeeklyTrendCardData.series}
                 latest={tiktokWeeklyTrendCardData.latestWeek}


### PR DESCRIPTION
## Summary
- track personnel comments in the weekly trend aggregation for Instagram data
- enhance the weekly trend chart to show platform-specific metrics and remove the average likes/comment rows
- pass platform identifiers so the executive summary cards render the appropriate likes and comments labels

## Testing
- npm run lint *(fails: Next.js lint prompts for configuration interactively)*

------
https://chatgpt.com/codex/tasks/task_e_68df3856da848327976d9e16555c7d9b