### PR TITLE
Show TikTok comments in weekly trend card

### DIFF
--- a/cicero-dashboard/components/executive-summary/PlatformEngagementTrendChart.tsx
+++ b/cicero-dashboard/components/executive-summary/PlatformEngagementTrendChart.tsx
@@ -130,7 +130,8 @@ const PlatformEngagementTrendChart: React.FC<PlatformEngagementTrendChartProps> 
   const resolvedPlatformKey = platformKey?.toLowerCase?.() ?? "";
   const shouldShowLikes =
     resolvedPlatformKey === "instagram" || resolvedPlatformKey === "tiktok";
-  const shouldShowComments = resolvedPlatformKey === "instagram";
+  const shouldShowComments =
+    resolvedPlatformKey === "instagram" || resolvedPlatformKey === "tiktok";
 
   const buildMetricRows = (point: ReturnType<typeof resolvePoint>) => {
     const rows: { label: string; value: string }[] = [


### PR DESCRIPTION
## Summary
- ensure the weekly TikTok engagement card now surfaces personnel comment totals alongside likes

## Testing
- npm test -- --runTestsByPath __tests__/executiveSummaryWeeklyTrend.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68df41da0f548327802c10f0169880e1