### PR TITLE
Ensure division distribution sorting honors completion ratio priority

### DIFF
--- a/cicero-dashboard/app/executive-summary/page.jsx
+++ b/cicero-dashboard/app/executive-summary/page.jsx
@@ -111,12 +111,8 @@ const compareDivisionByCompletion = (a, b) => {
     return completionDelta;
   }
 
-  const totalA = Number.isFinite(a?.total)
-    ? a.total
-    : Number.parseFloat(a?.total) || 0;
-  const totalB = Number.isFinite(b?.total)
-    ? b.total
-    : Number.parseFloat(b?.total) || 0;
+  const totalA = normalizeNumericInput(a?.total ?? 0);
+  const totalB = normalizeNumericInput(b?.total ?? 0);
 
   if (totalB !== totalA) {
     return totalB - totalA;


### PR DESCRIPTION
## Summary
- sanitize division total values before comparison so that sorting by completion ratio can fall back to numeric totals accurately

## Testing
- Not run (next lint prompts for configuration in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68dffebcb3cc8327a2d84181809831f8