### PR TITLE
Adjust executive summary satker tables sorting

### DIFF
--- a/cicero-dashboard/app/executive-summary/page.jsx
+++ b/cicero-dashboard/app/executive-summary/page.jsx
@@ -124,28 +124,6 @@ const compareDivisionByCompletion = (a, b) => {
   return divisionA.localeCompare(divisionB, "id-ID", { sensitivity: "base" });
 };
 
-const compareDivisionByActivePersonnel = (a, b) => {
-  const totalA = normalizeNumericInput(a?.total ?? 0);
-  const totalB = normalizeNumericInput(b?.total ?? 0);
-
-  if (totalB !== totalA) {
-    return totalB - totalA;
-  }
-
-  const completionA = parsePercent(a?.completionPercent);
-  const completionB = parsePercent(b?.completionPercent);
-
-  const completionDelta = completionB - completionA;
-  if (Math.abs(completionDelta) > 0.0001) {
-    return completionDelta;
-  }
-
-  const divisionA = typeof a?.division === "string" ? a.division : "";
-  const divisionB = typeof b?.division === "string" ? b.division : "";
-
-  return divisionA.localeCompare(divisionB, "id-ID", { sensitivity: "base" });
-};
-
 const metricValueToString = (metric, { fallback = "-" } = {}) => {
   if (!metric) {
     return fallback;
@@ -2935,7 +2913,7 @@ export default function ExecutiveSummaryPage() {
     }
 
     const sorted = [...divisionDistributionRaw].sort(
-      compareDivisionByActivePersonnel,
+      compareDivisionByCompletion,
     );
 
     return sorted.map((item, index) => ({

--- a/cicero-dashboard/components/executive-summary/PlatformLikesSummary.tsx
+++ b/cicero-dashboard/components/executive-summary/PlatformLikesSummary.tsx
@@ -189,22 +189,28 @@ const PlatformLikesSummary = ({
 
   const clientsByCompliance = useMemo(() => {
     return [...clients].sort((a, b) => {
-      const complianceA = a.complianceRate ?? 0;
-      const complianceB = b.complianceRate ?? 0;
-      const complianceDelta = complianceB - complianceA;
-      if (Math.abs(complianceDelta) > 0.0001) {
-        return complianceDelta;
-      }
       const activePersonnelA = a.activePersonnel ?? 0;
       const activePersonnelB = b.activePersonnel ?? 0;
+
       if (activePersonnelB !== activePersonnelA) {
         return activePersonnelB - activePersonnelA;
       }
+
+      const complianceA = a.complianceRate ?? 0;
+      const complianceB = b.complianceRate ?? 0;
+      const complianceDelta = complianceB - complianceA;
+
+      if (Math.abs(complianceDelta) > 0.0001) {
+        return complianceDelta;
+      }
+
       const totalPersonnelA = a.totalPersonnel ?? 0;
       const totalPersonnelB = b.totalPersonnel ?? 0;
+
       if (totalPersonnelB !== totalPersonnelA) {
         return totalPersonnelB - totalPersonnelA;
       }
+
       return (a.clientName || "").localeCompare(b.clientName || "");
     });
   }, [clients]);


### PR DESCRIPTION
## Summary
- sort the engagement distribution table by the highest active personnel counts so the most active satker appears first
- prioritize user distribution ordering by completion ratio with total personnel as a tiebreaker

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68e0028ff00c8327bb42105e00d24b72