### PR TITLE
Adjust monthly trend card height

### DIFF
--- a/cicero-dashboard/components/executive-summary/MonthlyTrendCard.tsx
+++ b/cicero-dashboard/components/executive-summary/MonthlyTrendCard.tsx
@@ -251,7 +251,10 @@ const MonthlyTrendCard: React.FC<MonthlyTrendCardProps> = ({
   }
 
   return (
-    <div className="rounded-3xl border border-slate-800/70 bg-slate-950/70 p-6 shadow-[0_18px_38px_rgba(15,23,42,0.35)]">
+    <div
+      className="rounded-3xl border border-slate-800/70 bg-slate-950/70 p-6 shadow-[0_18px_38px_rgba(15,23,42,0.35)]"
+      style={{ minHeight: "calc(100% + 2px)" }}
+    >
       <div>
         <p className="text-xs font-semibold uppercase tracking-[0.35em] text-cyan-200/80">
           Monthly Trend


### PR DESCRIPTION
## Summary
- increase the minimum height of the monthly trend card on the Executive Summary page to add 2px of vertical space

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68e13bae0a188327b0399c23820ed257