### PR TITLE
Adjust monthly trend card height

### DIFF
--- a/cicero-dashboard/components/executive-summary/MonthlyTrendCard.tsx
+++ b/cicero-dashboard/components/executive-summary/MonthlyTrendCard.tsx
@@ -253,7 +253,7 @@ const MonthlyTrendCard: React.FC<MonthlyTrendCardProps> = ({
   return (
     <div
       className="rounded-3xl border border-slate-800/70 bg-slate-950/70 p-6 shadow-[0_18px_38px_rgba(15,23,42,0.35)]"
-      style={{ minHeight: "calc(100% + 2px)" }}
+      style={{ minHeight: "calc(100% + 2px)", height: "calc(100% + 2px)" }}
     >
       <div>
         <p className="text-xs font-semibold uppercase tracking-[0.35em] text-cyan-200/80">


### PR DESCRIPTION
## Summary
- ensure the executive summary monthly trend card renders 2px taller by setting its height in addition to the existing minimum height

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e13d44050c8327814b35843b957f83