### PR TITLE
Adjust daily trend chart container width on executive summary

### DIFF
--- a/cicero-dashboard/components/executive-summary/DailyTrendChart.tsx
+++ b/cicero-dashboard/components/executive-summary/DailyTrendChart.tsx
@@ -190,7 +190,7 @@ const DailyTrendChart: React.FC<DailyTrendChartProps> = ({
   ];
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 w-full min-w-0">
       <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
         {summaryCards.map((card) => (
           <div
@@ -244,7 +244,7 @@ const DailyTrendChart: React.FC<DailyTrendChartProps> = ({
         </div>
       ) : null}
 
-      <div className="h-80">
+      <div className="h-80 w-full min-w-0">
         <ResponsiveContainer width="100%" height="100%">
           <LineChart data={data} margin={{ top: 10, right: 24, left: 0, bottom: 0 }}>
             <CartesianGrid strokeDasharray="3 3" stroke="rgba(148,163,184,0.2)" />


### PR DESCRIPTION
## Summary
- ensure the daily trend chart container expands with the page by enforcing full-width and min-width styles on the wrapper and chart container

## Testing
- not run (lint command prompts for configuration)


------
https://chatgpt.com/codex/tasks/task_e_68e1b878d75c832783b982fafda1647b