### PR TITLE
Remove redundant data source note from user insight section

### DIFF
--- a/cicero-dashboard/app/executive-summary/page.jsx
+++ b/cicero-dashboard/app/executive-summary/page.jsx
@@ -4034,9 +4034,6 @@ export default function ExecutiveSummaryPage() {
             <h2 className="text-sm font-semibold uppercase tracking-[0.35em] text-cyan-200/80">
               Insight User / Personil Ditbinmas dan Binmas Polres Jajaran Polda Jatim.
             </h2>
-            <p className="mt-2 max-w-2xl text-sm text-slate-300">
-              Data ini diambil langsung dari Database User / Personil.
-            </p>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- remove the redundant explanation about the data source from the user insight section on the Executive Summary page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1bcea9390832781126b39e7939a9d