### PR TITLE
Sort satker distribution by completion ratio

### DIFF
--- a/cicero-dashboard/app/executive-summary/page.jsx
+++ b/cicero-dashboard/app/executive-summary/page.jsx
@@ -814,7 +814,8 @@ const computeUserInsight = (users = []) => {
   const pieTotal = pieData.reduce((acc, curr) => acc + curr.value, 0);
 
   const sortedByDivisionSize = [...divisionArray].sort((a, b) => b.total - a.total);
-  const divisionDistribution = sortedByDivisionSize.map((item, index) => ({
+  const sortedByCompletion = [...divisionArray].sort(compareDivisionByCompletion);
+  const divisionDistribution = sortedByCompletion.map((item, index) => ({
     id: item.division ?? `division-${index}`,
     rank: index + 1,
     division: beautifyDivisionName(item.displayName ?? item.division),
@@ -4419,7 +4420,7 @@ export default function ExecutiveSummaryPage() {
                         Distribusi User per Satker
                       </h3>
                       <p className="mt-1 text-xs text-slate-400">
-                        Urutan lengkap setiap satker berdasarkan jumlah personil dan rasio kelengkapan akun.
+                        Diurutkan berdasarkan kelengkapan dan total personil.
                       </p>
                     </div>
                     {userSummary?.totalUsers ? (


### PR DESCRIPTION
## Summary
- sort the executive summary satker distribution data by completion ratio with total personnel as the tie breaker
- refresh the table description to clarify the new ordering criteria

## Testing
- npm run lint *(fails: interactive ESLint configuration prompt from Next.js)*

------
https://chatgpt.com/codex/tasks/task_e_68e1bf714b848327ab0be5553cfb55a2