### PR TITLE
Improve satker ranking tie-breakers

### DIFF
--- a/cicero-dashboard/app/executive-summary/page.jsx
+++ b/cicero-dashboard/app/executive-summary/page.jsx
@@ -119,6 +119,27 @@ const compareDivisionByCompletion = (a, b) => {
     return totalB - totalA;
   }
 
+  const shareA = parsePercent(a?.sharePercent);
+  const shareB = parsePercent(b?.sharePercent);
+
+  if (shareB !== shareA) {
+    return shareB - shareA;
+  }
+
+  const instagramFilledA = normalizeNumericInput(a?.instagramFilled ?? a?.igFilled ?? 0);
+  const instagramFilledB = normalizeNumericInput(b?.instagramFilled ?? b?.igFilled ?? 0);
+
+  if (instagramFilledB !== instagramFilledA) {
+    return instagramFilledB - instagramFilledA;
+  }
+
+  const tiktokFilledA = normalizeNumericInput(a?.tiktokFilled ?? a?.ttFilled ?? 0);
+  const tiktokFilledB = normalizeNumericInput(b?.tiktokFilled ?? b?.ttFilled ?? 0);
+
+  if (tiktokFilledB !== tiktokFilledA) {
+    return tiktokFilledB - tiktokFilledA;
+  }
+
   const divisionA = typeof a?.division === "string" ? a.division : "";
   const divisionB = typeof b?.division === "string" ? b.division : "";
 


### PR DESCRIPTION
## Summary
- refine the ranking comparator for the "Distribusi User per Satker" table to break ties using personnel totals first and other metrics if needed

## Testing
- npm run lint *(fails: command requires interactive configuration and was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68e1c121942883278f760314e7d9f4aa