### PR TITLE
Normalize social username parsing for claim edit form

### DIFF
--- a/cicero-dashboard/__tests__/claim-edit-social-links.test.ts
+++ b/cicero-dashboard/__tests__/claim-edit-social-links.test.ts
@@ -1,0 +1,39 @@
+import { extractInstagramUsername, extractTiktokUsername } from "../app/claim/edit/page.jsx";
+
+describe("extractInstagramUsername", () => {
+  it("normalizes instagram.com/user without protocol", () => {
+    expect(extractInstagramUsername("instagram.com/user")).toBe("user");
+  });
+
+  it("handles trailing slash and protocol", () => {
+    expect(extractInstagramUsername("https://www.instagram.com/user/")).toBe("user");
+  });
+
+  it("strips leading at symbol", () => {
+    expect(extractInstagramUsername("@user")).toBe("user");
+  });
+
+  it("returns empty string for non-instagram links", () => {
+    expect(extractInstagramUsername("https://example.com/user")).toBe("");
+  });
+});
+
+describe("extractTiktokUsername", () => {
+  it("normalizes tiktok.com/@user without protocol", () => {
+    expect(extractTiktokUsername("tiktok.com/@user")).toBe("user");
+  });
+
+  it("ignores additional path segments after username", () => {
+    expect(
+      extractTiktokUsername("https://www.tiktok.com/@user/video/1234567890")
+    ).toBe("user");
+  });
+
+  it("handles trailing slash", () => {
+    expect(extractTiktokUsername("https://tiktok.com/@user/")).toBe("user");
+  });
+
+  it("returns empty string for non-tiktok links", () => {
+    expect(extractTiktokUsername("https://example.com/@user")).toBe("");
+  });
+});

--- a/cicero-dashboard/app/claim/edit/page.jsx
+++ b/cicero-dashboard/app/claim/edit/page.jsx
@@ -4,37 +4,69 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { getClaimUserData, updateUserViaClaim } from "@/utils/api";
 
-function extractInstagramUsername(url) {
+export function extractInstagramUsername(url) {
   if (!url) return "";
-  try {
-    const link = url.trim();
-    if (!/^https?:\/\//i.test(link)) {
-      return link.replace(/^@/, "");
-    }
-    const u = new URL(link);
-    if (!u.hostname.includes("instagram.com")) return "";
-    const segments = u.pathname.split("/").filter(Boolean);
-    return segments[0] ? segments[0].replace(/^@/, "") : "";
-  } catch {
+  const link = url.trim();
+  if (!link) return "";
+
+  const lower = link.toLowerCase();
+  if (/^[a-z]+:\/\//i.test(link) && !lower.includes("instagram.com")) {
     return "";
   }
+  if (lower.includes("instagram.com")) {
+    const withProtocol = /^[a-z]+:\/\//i.test(link) ? link : `https://${link}`;
+    try {
+      const u = new URL(withProtocol);
+      if (!u.hostname.includes("instagram.com")) return "";
+      const segments = u.pathname.split("/").filter(Boolean);
+      const username = segments[0] ? segments[0].replace(/^@/, "") : "";
+      return username.split(/[?#]/)[0];
+    } catch {
+      // Fallback to string manipulation below
+    }
+  }
+
+  let normalized = link
+    .replace(/^[a-z]+:\/\//i, "")
+    .replace(/^www\./i, "")
+    .replace(/^instagram\.com\/?/i, "")
+    .replace(/^@/, "");
+
+  normalized = normalized.split(/[/?#]/)[0];
+  return normalized || "";
 }
 
-function extractTiktokUsername(url) {
+export function extractTiktokUsername(url) {
   if (!url) return "";
-  try {
-    const link = url.trim();
-    if (!/^https?:\/\//i.test(link)) {
-      return link.replace(/^@/, "");
-    }
-    const u = new URL(link);
-    if (!u.hostname.includes("tiktok.com")) return "";
-    const segments = u.pathname.split("/").filter(Boolean);
-    if (!segments[0]) return "";
-    return segments[0].startsWith("@") ? segments[0].slice(1) : segments[0];
-  } catch {
+  const link = url.trim();
+  if (!link) return "";
+
+  const lower = link.toLowerCase();
+  if (/^[a-z]+:\/\//i.test(link) && !lower.includes("tiktok.com")) {
     return "";
   }
+  if (lower.includes("tiktok.com")) {
+    const withProtocol = /^[a-z]+:\/\//i.test(link) ? link : `https://${link}`;
+    try {
+      const u = new URL(withProtocol);
+      if (!u.hostname.includes("tiktok.com")) return "";
+      const segments = u.pathname.split("/").filter(Boolean);
+      const usernameSegment = segments[0] || "";
+      const username = usernameSegment.replace(/^@/, "");
+      return username.split(/[?#]/)[0];
+    } catch {
+      // Fallback to string manipulation below
+    }
+  }
+
+  let normalized = link
+    .replace(/^[a-z]+:\/\//i, "")
+    .replace(/^www\./i, "")
+    .replace(/^tiktok\.com\/?/i, "")
+    .replace(/^@/, "");
+
+  normalized = normalized.split(/[/?#]/)[0];
+  return normalized || "";
 }
 
 function isValidInstagram(url) {


### PR DESCRIPTION
## Summary
- normalize the Instagram username extractor to strip protocol/www prefixes and domain segments before returning the handle
- update the TikTok username extractor to drop tiktok.com variants, leading @ characters, and trailing path segments
- add regression tests covering plain domain inputs and trailing slash variations for both helpers

## Testing
- npm test -- claim-edit-social-links

------
https://chatgpt.com/codex/tasks/task_e_68e1d69f3c588327a49f139b205ac54f