### PR TITLE
Restrict executive summary access to Ditbinmas

### DIFF
--- a/cicero-dashboard/app/executive-summary/page.jsx
+++ b/cicero-dashboard/app/executive-summary/page.jsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
 import {
   BarChart,
   Bar,
@@ -2582,7 +2583,30 @@ const MIN_SELECTABLE_YEAR = 2025;
 const MAX_SELECTABLE_YEAR = 2035;
 export default function ExecutiveSummaryPage() {
   useRequireAuth();
-  const { token, clientId } = useAuth();
+  const router = useRouter();
+  const { token, clientId, role } = useAuth();
+  const [isCheckingAccess, setIsCheckingAccess] = useState(true);
+  const [isAuthorized, setIsAuthorized] = useState(false);
+
+  useEffect(() => {
+    if (clientId === null || role === null) {
+      setIsAuthorized(false);
+      setIsCheckingAccess(true);
+      return;
+    }
+
+    const normalizedClientId = clientId?.toLowerCase();
+    const normalizedRole = role?.toLowerCase();
+    const allowed =
+      normalizedClientId === "ditbinmas" && normalizedRole === "ditbinmas";
+
+    if (!allowed) {
+      router.replace("/dashboard");
+    }
+
+    setIsAuthorized(allowed);
+    setIsCheckingAccess(false);
+  }, [clientId, role, router]);
   const availableYears = useMemo(() => {
     return Object.keys(monthlyData)
       .map((key) => extractYearFromMonthKey(key))
@@ -3877,6 +3901,14 @@ export default function ExecutiveSummaryPage() {
       ? "Belum ada data engagement mingguan TikTok yang siap ditampilkan."
       : ""
     : "";
+
+  if (isCheckingAccess) {
+    return null;
+  }
+
+  if (!isAuthorized) {
+    return null;
+  }
 
   return (
     <div className="space-y-8">

--- a/cicero-dashboard/components/Sidebar.jsx
+++ b/cicero-dashboard/components/Sidebar.jsx
@@ -32,7 +32,7 @@ export default function Sidebar() {
   const pathname = usePathname();
   const [open, setOpen] = useState(false);
   const [collapsed, setCollapsed] = useState(false);
-  const { role, profile } = useAuth();
+  const { role, profile, clientId } = useAuth();
   function isActive(val) {
     return val === true || val === "true" || val === 1 || val === "1";
   }
@@ -51,6 +51,8 @@ export default function Sidebar() {
   const amplifyEnabled = isActive(getStatus(profile, "client_amplify_status"));
   const tiktokEnabled = isActive(getStatus(profile, "client_tiktok_status"));
   const isOperator = role?.toLowerCase() === "operator";
+  const canSeeExecutiveSummary =
+    clientId?.toLowerCase() === "ditbinmas" && role?.toLowerCase() === "ditbinmas";
 
   const menu = [
     { label: "Dashboard", path: "/dashboard", icon: Home },
@@ -87,7 +89,9 @@ export default function Sidebar() {
           },
         ]
       : []),
-    { label: "Executive Summary", path: "/executive-summary", icon: FilePieChart },
+    ...(canSeeExecutiveSummary
+      ? [{ label: "Executive Summary", path: "/executive-summary", icon: FilePieChart }]
+      : []),
     {
       label: "Mekanisme Sistem Absensi",
       path: "/mekanisme-absensi",


### PR DESCRIPTION
## Summary
- hide the Executive Summary sidebar entry unless the Ditbinmas client with the Ditbinmas role is logged in
- protect the Executive Summary page by redirecting non-Ditbinmas users and suppressing the UI while the access check is pending

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e25fdd15cc8327ac5641c5d97dd104