### PR TITLE
Filter Ditbinmas client data in TikTok recap

### DIFF
--- a/cicero-dashboard/app/comments/tiktok/rekap/page.jsx
+++ b/cicero-dashboard/app/comments/tiktok/rekap/page.jsx
@@ -317,8 +317,12 @@ export default function RekapKomentarTiktokPage() {
         }
 
         let filteredUsers = users;
+        const clientFilterValue = isDitbinmasClient
+          ? ditbinmasClientId.toLowerCase()
+          : clientIdLower;
         const shouldFilterByClient =
-          Boolean(clientIdLower) && (!isDirectorate || isScopedDirectorateClient);
+          Boolean(clientFilterValue) &&
+          (isDitbinmasClient || !isDirectorate || isScopedDirectorateClient);
         if (shouldFilterByClient) {
           const normalizeValue = (value) =>
             String(value || "").trim().toLowerCase();
@@ -331,7 +335,7 @@ export default function RekapKomentarTiktokPage() {
               u.clientid,
             ];
             return possibleIds.some(
-              (cid) => normalizeValue(cid) === clientIdLower,
+              (cid) => normalizeValue(cid) === clientFilterValue,
             );
           });
 


### PR DESCRIPTION
## Summary
- ensure the Rekap TikTok page flags Ditbinmas client IDs for filtering just like other scoped clients
- centralize the normalized client filter ID and reuse it when trimming the fetched user list

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e26ce4d6a083279fc85a00036d228b