### PR TITLE
Ensure Ditbinmas recap filters to scoped client data

### DIFF
--- a/cicero-dashboard/__tests__/tiktokRekapPage.test.tsx
+++ b/cicero-dashboard/__tests__/tiktokRekapPage.test.tsx
@@ -115,13 +115,15 @@ describe("RekapKomentarTiktokPage", () => {
 
     render(React.createElement(RekapKomentarTiktokPage));
 
-    const subordinatePerson = await screen.findByText("Client B Personel");
-    expect(subordinatePerson).toBeInTheDocument();
+    const rootPerson = await screen.findByText("Ditbinmas Admin");
+    expect(rootPerson).toBeInTheDocument();
 
-    const subordinateRow = subordinatePerson.closest("tr");
-    expect(subordinateRow).not.toBeNull();
-    expect(subordinateRow).toHaveTextContent("Client B");
-    expect(subordinateRow).toHaveTextContent("user-b");
+    const rootRow = rootPerson.closest("tr");
+    expect(rootRow).not.toBeNull();
+    expect(rootRow).toHaveTextContent("Ditbinmas");
+    expect(rootRow).toHaveTextContent("root-user");
+
+    expect(screen.queryByText("Client B Personel")).not.toBeInTheDocument();
 
     await waitFor(() => expect(mockedGetRekapKomentarTiktok).toHaveBeenCalled());
     const requestedClientIds = mockedGetRekapKomentarTiktok.mock.calls.map(
@@ -133,9 +135,7 @@ describe("RekapKomentarTiktokPage", () => {
 
     await waitFor(() => expect(mockedGetClientNames).toHaveBeenCalled());
     const satkerIds = mockedGetClientNames.mock.calls[0][1] as string[];
-    expect(new Set(satkerIds)).toEqual(
-      new Set(["DITBINMAS", "CLIENT_A", "CLIENT_B"]),
-    );
+    expect(new Set(satkerIds)).toEqual(new Set(["DITBINMAS"]));
   });
 });
 

--- a/cicero-dashboard/app/comments/tiktok/rekap/page.jsx
+++ b/cicero-dashboard/app/comments/tiktok/rekap/page.jsx
@@ -318,21 +318,16 @@ export default function RekapKomentarTiktokPage() {
 
         let filteredUsers = users;
         const shouldFilterByClient =
-          Boolean(clientIdLower) && (!isDirectorate || isScopedDirectorateClient);
+          Boolean(clientIdLower) &&
+          (isDitbinmasRole || !isDirectorate || isScopedDirectorateClient);
         if (shouldFilterByClient) {
           const normalizeValue = (value) =>
             String(value || "").trim().toLowerCase();
           filteredUsers = users.filter((u) => {
-            const possibleIds = [
-              u.client_id,
-              u.clientId,
-              u.client,
-              u.clientID,
-              u.clientid,
-            ];
-            return possibleIds.some(
-              (cid) => normalizeValue(cid) === clientIdLower,
+            const userClient = normalizeValue(
+              u.client_id || u.clientId || u.client || u.clientID || "",
             );
+            return userClient === clientIdLower;
           });
 
         }


### PR DESCRIPTION
## Summary
- align the TikTok rekap page filtering logic with the hook implementation so Ditbinmas roles always scope by their stored client ID using normalized comparisons
- update the Ditbinmas-focused test fixture to expect only scoped personnel details and ensure client name lookups are derived from the filtered set

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e270d22cec8327ba549cea49c07168