### PR TITLE
Handle trailing whitespace in Ditbinmas role checks

### DIFF
--- a/cicero-dashboard/__tests__/tiktokRekapPage.test.tsx
+++ b/cicero-dashboard/__tests__/tiktokRekapPage.test.tsx
@@ -137,5 +137,88 @@ describe("RekapKomentarTiktokPage", () => {
     const satkerIds = mockedGetClientNames.mock.calls[0][1] as string[];
     expect(new Set(satkerIds)).toEqual(new Set(["DITBINMAS"]));
   });
+
+  it("keeps Ditbinmas client filtering active when the stored role has trailing whitespace", async () => {
+    localStorage.setItem("cicero_token", "token");
+    localStorage.setItem("client_id", "DITBINMAS");
+    localStorage.setItem("user_role", "ditbinmas   ");
+
+    mockedGetDashboardStats.mockResolvedValue({ data: { ttPosts: 2 } } as any);
+    mockedGetClientProfile.mockResolvedValue({ client_type: "DIREKTORAT" } as any);
+    mockedGetUserDirectory.mockResolvedValue({
+      data: [
+        { role: "ditbinmas", client_id: "CLIENT_A" },
+        { role: "ditbinmas", client_id: "CLIENT_B" },
+      ],
+    } as any);
+    mockedGetClientNames.mockResolvedValue({
+      CLIENT_A: "Client A",
+      CLIENT_B: "Client B",
+      DITBINMAS: "Ditbinmas",
+    } as any);
+
+    mockedGetRekapKomentarTiktok.mockImplementation(async (_, clientId) => {
+      if (clientId === "CLIENT_A") {
+        return {
+          data: [
+            {
+              user_id: "user-a-id",
+              client_id: "CLIENT_A",
+              nama: "Client A Personel",
+              username: "user-a",
+              jumlah_komentar: 5,
+            },
+          ],
+        } as any;
+      }
+      if (clientId === "CLIENT_B") {
+        return {
+          data: [
+            {
+              user_id: "user-b-id",
+              client_id: "CLIENT_B",
+              nama: "Client B Personel",
+              username: "user-b",
+              jumlah_komentar: 3,
+            },
+          ],
+        } as any;
+      }
+      if (clientId === "DITBINMAS") {
+        return {
+          data: [
+            {
+              user_id: "user-root",
+              client_id: "DITBINMAS",
+              nama: "Ditbinmas Admin",
+              username: "root-user",
+              jumlah_komentar: 2,
+            },
+          ],
+        } as any;
+      }
+      return { data: [] } as any;
+    });
+
+    render(React.createElement(RekapKomentarTiktokPage));
+
+    const rootPerson = await screen.findByText("Ditbinmas Admin");
+    expect(rootPerson).toBeInTheDocument();
+
+    expect(screen.queryByText("Client A Personel")).not.toBeInTheDocument();
+    expect(screen.queryByText("Client B Personel")).not.toBeInTheDocument();
+
+    await waitFor(() => expect(mockedGetRekapKomentarTiktok).toHaveBeenCalled());
+    const requestedClientIds = mockedGetRekapKomentarTiktok.mock.calls.map(
+      (call) => call[1],
+    );
+    expect(new Set(requestedClientIds)).toEqual(
+      new Set(["DITBINMAS", "CLIENT_A", "CLIENT_B"]),
+    );
+
+    await waitFor(() => expect(mockedGetClientNames).toHaveBeenCalled());
+    const satkerIds = mockedGetClientNames.mock.calls[0][1] as string[];
+    expect(new Set(satkerIds)).toEqual(new Set(["DITBINMAS"]));
+  });
 });
 

--- a/cicero-dashboard/app/comments/tiktok/rekap/page.jsx
+++ b/cicero-dashboard/app/comments/tiktok/rekap/page.jsx
@@ -186,7 +186,7 @@ export default function RekapKomentarTiktokPage() {
       typeof window !== "undefined"
         ? localStorage.getItem("user_role")
         : null;
-    const roleLower = String(role || "").toLowerCase();
+    const roleLower = String(role || "").trim().toLowerCase();
     const normalizedClientId = String(userClientId || "").trim();
     const clientIdUpper = normalizedClientId.toUpperCase();
     const clientIdLower = normalizedClientId.toLowerCase();

--- a/cicero-dashboard/hooks/useTiktokCommentsData.ts
+++ b/cicero-dashboard/hooks/useTiktokCommentsData.ts
@@ -72,7 +72,7 @@ export default function useTiktokCommentsData({
       return () => controller.abort();
     }
 
-    const roleLower = String(role).toLowerCase();
+    const roleLower = String(role).trim().toLowerCase();
     const isDitbinmasRoleValue = roleLower === "ditbinmas";
     setIsDitbinmasRole(isDitbinmasRoleValue);
     const normalizedClientId = String(userClientId || "").trim();


### PR DESCRIPTION
## Summary
- trim stored user role values before lowercasing them in the TikTok rekap page and shared comments hook so Ditbinmas users keep scoped filtering
- extend the TikTok rekap page tests with coverage for Ditbinmas roles containing trailing whitespace

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e27475308883278a505e2169e9fe58