### PR TITLE
Add Ditbinmas scope selection for Instagram likes

### DIFF
--- a/cicero-dashboard/app/likes/instagram/rekap/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/rekap/page.jsx
@@ -67,6 +67,7 @@ export default function RekapLikesIGPage() {
   const currentMonth = getLocalMonthString();
   const [dailyDate, setDailyDate] = useState(today);
   const [monthlyDate, setMonthlyDate] = useState(currentMonth);
+  const [ditbinmasScope, setDitbinmasScope] = useState("client");
   const [dateRange, setDateRange] = useState({
     startDate: today,
     endDate: today,
@@ -165,11 +166,13 @@ export default function RekapLikesIGPage() {
     rekapSummary,
     igPosts,
     clientName,
+    isDitbinmasRole,
   } = useInstagramLikesData({
     viewBy,
     customDate: normalizedCustomDate,
     fromDate: normalizedRange.startDate,
     toDate: normalizedRange.endDate,
+    scope: ditbinmasScope,
   });
 
   const rekapRef = useRef(null);
@@ -182,6 +185,17 @@ export default function RekapLikesIGPage() {
         : dailyDate;
 
   const viewOptions = VIEW_OPTIONS;
+  const ditbinmasScopeOptions = [
+    { value: "client", label: "Client Saya" },
+    { value: "all", label: "Seluruh Client Ditbinmas" },
+  ];
+
+  const handleDitbinmasScopeChange = (event) => {
+    const { value } = event.target || {};
+    if (value === "client" || value === "all") {
+      setDitbinmasScope(value);
+    }
+  };
 
   if (loading) return <Loader />;
   if (error)
@@ -220,13 +234,33 @@ export default function RekapLikesIGPage() {
                 </Link>
               </div>
               <div className="rounded-2xl border border-white/10 bg-white/5 p-4 shadow-inner backdrop-blur">
-                <ViewDataSelector
-                  value={viewBy}
-                  onChange={handleViewChange}
-                  options={viewOptions}
-                  date={selectorDateValue}
-                  onDateChange={handleDateChange}
-                />
+                <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+                  <ViewDataSelector
+                    value={viewBy}
+                    onChange={handleViewChange}
+                    options={viewOptions}
+                    date={selectorDateValue}
+                    onDateChange={handleDateChange}
+                  />
+                  {isDitbinmasRole && (
+                    <div className="flex w-full flex-col gap-2 md:w-64">
+                      <label className="text-sm font-semibold text-slate-200">
+                        Lingkup Data
+                      </label>
+                      <select
+                        value={ditbinmasScope}
+                        onChange={handleDitbinmasScopeChange}
+                        className="w-full rounded-xl border border-white/20 bg-slate-900/60 px-3 py-2 text-sm text-slate-100 shadow-inner outline-none transition focus:border-sky-400/60 focus:ring-2 focus:ring-sky-400/30"
+                      >
+                        {ditbinmasScopeOptions.map((option) => (
+                          <option key={option.value} value={option.value}>
+                            {option.label}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                  )}
+                </div>
               </div>
             </div>
           </div>

--- a/cicero-dashboard/hooks/useInstagramLikesData.ts
+++ b/cicero-dashboard/hooks/useInstagramLikesData.ts
@@ -15,6 +15,7 @@ interface Options {
   customDate: string;
   fromDate: string;
   toDate: string;
+  scope?: "client" | "all";
 }
 
 interface RekapSummary {
@@ -31,6 +32,7 @@ export default function useInstagramLikesData({
   customDate,
   fromDate,
   toDate,
+  scope = "client",
 }: Options) {
   const [chartData, setChartData] = useState<any[]>([]);
   const [igPosts, setIgPosts] = useState<any[]>([]);
@@ -104,6 +106,7 @@ export default function useInstagramLikesData({
               },
               controller.signal,
               userClientId,
+              scope,
             );
           if (controller.signal.aborted) return;
           setChartData(users);
@@ -326,7 +329,7 @@ export default function useInstagramLikesData({
     fetchData();
 
     return () => controller.abort();
-  }, [viewBy, customDate, fromDate, toDate]);
+  }, [viewBy, customDate, fromDate, toDate, scope]);
 
   return {
     chartData,

--- a/cicero-dashboard/utils/absensiLikes.ts
+++ b/cicero-dashboard/utils/absensiLikes.ts
@@ -12,6 +12,7 @@ export async function fetchDitbinmasAbsensiLikes(
   { periode, date, startDate, endDate }: FetchParams,
   signal?: AbortSignal,
   loginClientId?: string,
+  scope: "client" | "all" = "client",
 ) {
   const clientId = "DITBINMAS";
 
@@ -82,7 +83,7 @@ export async function fetchDitbinmasAbsensiLikes(
   const normalizedLoginClientId = String(loginClientId || "")
     .trim()
     .toLowerCase();
-  if (normalizedLoginClientId) {
+  if (scope === "client" && normalizedLoginClientId) {
     const normalizeValue = (value: unknown) =>
       String(value || "")
         .trim()


### PR DESCRIPTION
## Summary
- add a scope option to the Instagram likes data hook and propagate it to the Ditbinmas fetch helper
- ensure the Ditbinmas absensi helper only filters to the logged in client when the scope is limited to that client
- expose a Ditbinmas-only scope selector on the Instagram likes recap page so users can toggle between client and full Ditbinmas data

## Testing
- Not run (requires interactive ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_e_68e279321c9c83278e3d176928002ac6