### PR TITLE
Prioritize rank ordering on TikTok and Instagram rekap views

### DIFF
--- a/cicero-dashboard/app/comments/tiktok/rekap/page.jsx
+++ b/cicero-dashboard/app/comments/tiktok/rekap/page.jsx
@@ -16,6 +16,7 @@ import ViewDataSelector, {
   VIEW_OPTIONS,
 } from "@/components/ViewDataSelector";
 import { ArrowLeft } from "lucide-react";
+import { compareUsersByPangkatAndNrp } from "@/utils/pangkat";
 
 function getLocalDateString(date = new Date()) {
   const year = date.getFullYear();
@@ -371,6 +372,10 @@ export default function RekapKomentarTiktokPage() {
           return { ...u, nama_client: cName, client_name: cName, client: cName };
         });
 
+        const sortedUsers = [...enrichedUsers].sort(
+          compareUsersByPangkatAndNrp,
+        );
+
         // Sumber utama TikTok Post Hari Ini dari statsRes
         const totalTiktokPost =
           statsData?.ttPosts ||
@@ -397,7 +402,7 @@ export default function RekapKomentarTiktokPage() {
           totalBelumKomentar,
           totalTiktokPost,
         });
-        setChartData(enrichedUsers);
+        setChartData(sortedUsers);
       } catch (err) {
         if (err?.name === "AbortError") {
           return;

--- a/cicero-dashboard/components/RekapKomentarTiktok.jsx
+++ b/cicero-dashboard/components/RekapKomentarTiktok.jsx
@@ -4,6 +4,11 @@ import usePersistentState from "@/hooks/usePersistentState";
 import { AlertTriangle, Music, User, Check, X, Minus, UserX } from "lucide-react";
 import { showToast } from "@/utils/showToast";
 import { cn } from "@/lib/utils";
+import {
+  compareUsersByPangkatAndNrp,
+  getUserJabatanPriority,
+  getUserPangkatRank,
+} from "@/utils/pangkat";
 
 function bersihkanSatfung(divisi = "") {
   return divisi
@@ -108,13 +113,25 @@ export default function RekapKomentarTiktok({
 
   const sorted = useMemo(() => {
     return [...filtered].sort((a, b) => {
+      const jabatanDiff =
+        getUserJabatanPriority(a) - getUserJabatanPriority(b);
+      if (jabatanDiff !== 0) {
+        return jabatanDiff;
+      }
+
+      const pangkatDiff = getUserPangkatRank(a) - getUserPangkatRank(b);
+      if (pangkatDiff !== 0) {
+        return pangkatDiff;
+      }
+
       const aCom = Number(a.jumlah_komentar);
       const bCom = Number(b.jumlah_komentar);
 
       if (aCom > 0 && bCom === 0) return -1;
       if (aCom === 0 && bCom > 0) return 1;
       if (aCom !== bCom) return bCom - aCom;
-      return (a.nama || "").localeCompare(b.nama || "");
+
+      return compareUsersByPangkatAndNrp(a, b);
     });
   }, [filtered]);
 

--- a/cicero-dashboard/components/RekapLikesIG.jsx
+++ b/cicero-dashboard/components/RekapLikesIG.jsx
@@ -58,7 +58,7 @@ const RekapLikesIG = forwardRef(function RekapLikesIG(
       };
     };
 
-    const compareByClientId = (a, b) => {
+    const compareByClientIdOnly = (a, b) => {
       const clientA = getClientIdentifier(a);
       const clientB = getClientIdentifier(b);
 
@@ -83,10 +83,24 @@ const RekapLikesIG = forwardRef(function RekapLikesIG(
         return clientA.hasValue ? -1 : 1;
       }
 
-      return compareUsersByPangkatAndNrp(a, b);
+      return 0;
     };
 
-    return [...users].sort(compareByClientId);
+    const compareUsers = (a, b) => {
+      const rankDiff = compareUsersByPangkatAndNrp(a, b);
+      if (rankDiff !== 0) {
+        return rankDiff;
+      }
+
+      const clientDiff = compareByClientIdOnly(a, b);
+      if (clientDiff !== 0) {
+        return clientDiff;
+      }
+
+      return 0;
+    };
+
+    return [...users].sort(compareUsers);
   }, [users]);
 
   const totalUser = sortedUsers.length;

--- a/cicero-dashboard/hooks/useInstagramLikesData.ts
+++ b/cicero-dashboard/hooks/useInstagramLikesData.ts
@@ -9,6 +9,7 @@ import {
 } from "@/utils/api";
 import { fetchDitbinmasAbsensiLikes } from "@/utils/absensiLikes";
 import { getPeriodeDateForView } from "@/components/ViewDataSelector";
+import { compareUsersByPangkatAndNrp } from "@/utils/pangkat";
 
 interface Options {
   viewBy: string;
@@ -109,7 +110,8 @@ export default function useInstagramLikesData({
               scope,
             );
           if (controller.signal.aborted) return;
-          setChartData(users);
+          const sortedUsers = [...users].sort(compareUsersByPangkatAndNrp);
+          setChartData(sortedUsers);
           setRekapSummary(summary);
           setIgPosts(posts || []);
           setClientName(clientName || "");
@@ -280,14 +282,15 @@ export default function useInstagramLikesData({
           }
         }
 
-        const totalUser = filteredUsers.length;
+        const sortedUsers = [...filteredUsers].sort(compareUsersByPangkatAndNrp);
+        const totalUser = sortedUsers.length;
         const totalIGPost = Number((statsData as any).instagramPosts) || 0;
         const isZeroPost = (totalIGPost || 0) === 0;
         let totalSudahLike = 0;
         let totalKurangLike = 0;
         let totalBelumLike = 0;
         let totalTanpaUsername = 0;
-        filteredUsers.forEach((u: any) => {
+        sortedUsers.forEach((u: any) => {
           const username = String(u.username || "").trim();
           if (!username) {
             totalTanpaUsername += 1;
@@ -316,7 +319,7 @@ export default function useInstagramLikesData({
           totalTanpaUsername,
           totalIGPost,
         });
-        setChartData(filteredUsers);
+        setChartData(sortedUsers);
       } catch (err: any) {
         if (!(err instanceof DOMException && err.name === "AbortError")) {
           setError("Gagal mengambil data: " + (err.message || err));

--- a/cicero-dashboard/utils/pangkat.ts
+++ b/cicero-dashboard/utils/pangkat.ts
@@ -1,16 +1,4 @@
-export const PANGKAT_ORDER = [
-  "KOMISARIS BESAR POLISI",
-  "AKBP",
-  "KOMPOL",
-  "AKP",
-  "IPTU",
-  "IPDA",
-  "AIPTU",
-  "AIPDA",
-  "BRIPKA",
-  "BRIGADIR",
-  "BRIPTU",
-  "BRIPDA",
+const EXTRA_RANKS = [
   "BHARAKA",
   "BHARATU",
   "BHARADA",
@@ -33,20 +21,121 @@ export const PANGKAT_ORDER = [
   "JURU MUDA",
 ];
 
+export const PANGKAT_ORDER = [
+  "KOMISARIS BESAR POLISI",
+  "AKBP",
+  "KOMPOL",
+  "AKP",
+  "IPTU",
+  "IPDA",
+  "AIPTU",
+  "AIPDA",
+  "BRIPKA",
+  "BRIGPOL",
+  "BRIGADIR POLISI",
+  "BRIGADIR",
+  "BRIPTU",
+  "BRIPDA",
+  ...EXTRA_RANKS,
+  "LAINNYA",
+];
+
+const USER_PANGKAT_FIELDS = [
+  "title",
+  "pangkat",
+  "rank",
+  "pangkat_title",
+  "pangkatTitle",
+  "golongan",
+];
+
+const USER_JABATAN_FIELDS = [
+  "jabatan",
+  "jabatan_struktural",
+  "jabatanStruktural",
+  "jabatan_fungsional",
+  "jabatanFungsional",
+  "position",
+  "posisi",
+  "role",
+  "roleName",
+];
+
+function normalizeString(value?: unknown): string {
+  return String(value || "").trim().toUpperCase();
+}
+
 export function getPangkatRank(title?: string): number {
-  const t = String(title || "").toUpperCase();
-  const index = PANGKAT_ORDER.findIndex((p) => t.includes(p));
+  const normalized = normalizeString(title);
+  if (!normalized) {
+    return PANGKAT_ORDER.length;
+  }
+
+  const index = PANGKAT_ORDER.findIndex((pangkat) =>
+    normalized.includes(pangkat),
+  );
+
   return index === -1 ? PANGKAT_ORDER.length : index;
 }
 
+export function getUserPangkatRank(user: any): number {
+  const candidates = USER_PANGKAT_FIELDS.map((field) => user?.[field]);
+  const uniqueValues = Array.from(new Set(candidates.filter(Boolean)));
+
+  let bestRank = PANGKAT_ORDER.length;
+  for (const value of uniqueValues) {
+    const rank = getPangkatRank(String(value));
+    if (rank < bestRank) {
+      bestRank = rank;
+    }
+  }
+
+  return bestRank;
+}
+
+export function getUserJabatanPriority(user: any): number {
+  const values = USER_JABATAN_FIELDS.map((field) => user?.[field]);
+  for (const value of values) {
+    const jabatan = normalizeString(value);
+    if (!jabatan) continue;
+
+    if (jabatan.includes("WAKIL DIREKTUR") || jabatan.includes("WADIR")) {
+      return 1;
+    }
+    if (
+      jabatan.includes("DIREKTUR") ||
+      /\bDIR\b/.test(jabatan.replace(/[^A-Z\s]/g, " "))
+    ) {
+      return 0;
+    }
+  }
+
+  return 2;
+}
+
+function compareByName(a: any, b: any): number {
+  const nameA = String(a?.nama || a?.name || "");
+  const nameB = String(b?.nama || b?.name || "");
+  const diff = nameA.localeCompare(nameB, "id", { sensitivity: "base" });
+  if (diff !== 0) return diff;
+  return 0;
+}
+
 export function compareUsersByPangkatAndNrp(a: any, b: any): number {
-  const rankDiff = getPangkatRank(a.title) - getPangkatRank(b.title);
-  if (rankDiff !== 0) return rankDiff;
+  const jabatanDiff = getUserJabatanPriority(a) - getUserJabatanPriority(b);
+  if (jabatanDiff !== 0) return jabatanDiff;
+
+  const pangkatDiff = getUserPangkatRank(a) - getUserPangkatRank(b);
+  if (pangkatDiff !== 0) return pangkatDiff;
+
+  const nameDiff = compareByName(a, b);
+  if (nameDiff !== 0) return nameDiff;
+
   const aId = String(
-    a.user_id || a.userId || a.nrp || a.nip || a.nrp_nip || "",
+    a?.user_id || a?.userId || a?.nrp || a?.nip || a?.nrp_nip || "",
   );
   const bId = String(
-    b.user_id || b.userId || b.nrp || b.nip || b.nrp_nip || "",
+    b?.user_id || b?.userId || b?.nrp || b?.nip || b?.nrp_nip || "",
   );
   return aId.localeCompare(bId);
 }


### PR DESCRIPTION
## Summary
- sort TikTok comments rekap data by personnel rank before rendering the report
- update Instagram likes hook and table to prioritize rank (Dir/Wadir first) while keeping client tie-breakers
- expand pangkat utilities with the required rank order and helpers for jabatan priority comparisons

## Testing
- npm run lint *(fails: requires interactive configuration and was aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68e27c6dfad48327bed8d687ab820571