### PR TITLE
Align pangkat-driven ordering across rekap views

### DIFF
--- a/cicero-dashboard/app/comments/tiktok/rekap/page.jsx
+++ b/cicero-dashboard/app/comments/tiktok/rekap/page.jsx
@@ -16,7 +16,7 @@ import ViewDataSelector, {
   VIEW_OPTIONS,
 } from "@/components/ViewDataSelector";
 import { ArrowLeft } from "lucide-react";
-import { compareUsersByPangkatAndNrp } from "@/utils/pangkat";
+import { compareUsersByPangkatOnly } from "@/utils/pangkat";
 
 function getLocalDateString(date = new Date()) {
   const year = date.getFullYear();
@@ -373,7 +373,7 @@ export default function RekapKomentarTiktokPage() {
         });
 
         const sortedUsers = [...enrichedUsers].sort(
-          compareUsersByPangkatAndNrp,
+          compareUsersByPangkatOnly,
         );
 
         // Sumber utama TikTok Post Hari Ini dari statsRes

--- a/cicero-dashboard/components/RekapKomentarTiktok.jsx
+++ b/cicero-dashboard/components/RekapKomentarTiktok.jsx
@@ -4,11 +4,7 @@ import usePersistentState from "@/hooks/usePersistentState";
 import { AlertTriangle, Music, User, Check, X, Minus, UserX } from "lucide-react";
 import { showToast } from "@/utils/showToast";
 import { cn } from "@/lib/utils";
-import {
-  compareUsersByPangkatAndNrp,
-  getUserJabatanPriority,
-  getUserPangkatRank,
-} from "@/utils/pangkat";
+import { compareUsersByPangkatOnly } from "@/utils/pangkat";
 
 function bersihkanSatfung(divisi = "") {
   return divisi
@@ -111,29 +107,10 @@ export default function RekapKomentarTiktok({
     );
   }, [users, search]);
 
-  const sorted = useMemo(() => {
-    return [...filtered].sort((a, b) => {
-      const jabatanDiff =
-        getUserJabatanPriority(a) - getUserJabatanPriority(b);
-      if (jabatanDiff !== 0) {
-        return jabatanDiff;
-      }
-
-      const pangkatDiff = getUserPangkatRank(a) - getUserPangkatRank(b);
-      if (pangkatDiff !== 0) {
-        return pangkatDiff;
-      }
-
-      const aCom = Number(a.jumlah_komentar);
-      const bCom = Number(b.jumlah_komentar);
-
-      if (aCom > 0 && bCom === 0) return -1;
-      if (aCom === 0 && bCom > 0) return 1;
-      if (aCom !== bCom) return bCom - aCom;
-
-      return compareUsersByPangkatAndNrp(a, b);
-    });
-  }, [filtered]);
+  const sorted = useMemo(
+    () => [...filtered].sort(compareUsersByPangkatOnly),
+    [filtered],
+  );
 
   const [page, setPage] = usePersistentState("rekapKomentarTiktok_page", 1);
   const totalPages = Math.ceil(sorted.length / PAGE_SIZE);

--- a/cicero-dashboard/components/RekapLikesIG.jsx
+++ b/cicero-dashboard/components/RekapLikesIG.jsx
@@ -8,7 +8,7 @@ import {
 } from "react";
 import usePersistentState from "@/hooks/usePersistentState";
 import { Camera, Users, Check, X, AlertTriangle, UserX } from "lucide-react";
-import { compareUsersByPangkatAndNrp } from "@/utils/pangkat";
+import { compareUsersByPangkatOnly } from "@/utils/pangkat";
 import { showToast } from "@/utils/showToast";
 
 const PAGE_SIZE = 25;
@@ -87,9 +87,9 @@ const RekapLikesIG = forwardRef(function RekapLikesIG(
     };
 
     const compareUsers = (a, b) => {
-      const rankDiff = compareUsersByPangkatAndNrp(a, b);
-      if (rankDiff !== 0) {
-        return rankDiff;
+      const pangkatDiff = compareUsersByPangkatOnly(a, b);
+      if (pangkatDiff !== 0) {
+        return pangkatDiff;
       }
 
       const clientDiff = compareByClientIdOnly(a, b);
@@ -303,7 +303,7 @@ const RekapLikesIG = forwardRef(function RekapLikesIG(
     });
 
     const sortByRank = (arr) =>
-      [...arr].sort(compareUsersByPangkatAndNrp);
+      [...arr].sort(compareUsersByPangkatOnly);
 
     const sortedClients = Object.keys(clients).sort((a, b) => {
       if (a === "Direktorat Binmas") return -1;

--- a/cicero-dashboard/hooks/useInstagramLikesData.ts
+++ b/cicero-dashboard/hooks/useInstagramLikesData.ts
@@ -9,7 +9,7 @@ import {
 } from "@/utils/api";
 import { fetchDitbinmasAbsensiLikes } from "@/utils/absensiLikes";
 import { getPeriodeDateForView } from "@/components/ViewDataSelector";
-import { compareUsersByPangkatAndNrp } from "@/utils/pangkat";
+import { compareUsersByPangkatOnly } from "@/utils/pangkat";
 
 interface Options {
   viewBy: string;
@@ -110,7 +110,7 @@ export default function useInstagramLikesData({
               scope,
             );
           if (controller.signal.aborted) return;
-          const sortedUsers = [...users].sort(compareUsersByPangkatAndNrp);
+          const sortedUsers = [...users].sort(compareUsersByPangkatOnly);
           setChartData(sortedUsers);
           setRekapSummary(summary);
           setIgPosts(posts || []);
@@ -282,7 +282,7 @@ export default function useInstagramLikesData({
           }
         }
 
-        const sortedUsers = [...filteredUsers].sort(compareUsersByPangkatAndNrp);
+        const sortedUsers = [...filteredUsers].sort(compareUsersByPangkatOnly);
         const totalUser = sortedUsers.length;
         const totalIGPost = Number((statsData as any).instagramPosts) || 0;
         const isZeroPost = (totalIGPost || 0) === 0;


### PR DESCRIPTION
## Summary
- add a pangkat-only comparator with deterministic NRP/NIP fallback in the shared pangkat utilities
- switch TikTok and Instagram rekap components and data loaders to rely on the pangkat-only order
- ensure upstream pages/hooks no longer override the pangkat-driven ordering

## Testing
- Manual verification via node scripts that exercise the new comparator and component sorting helpers

------
https://chatgpt.com/codex/tasks/task_e_68e2828cd30483279d8309a2b5229090