### PR TITLE
style: refresh login page pastel theme

### DIFF
--- a/cicero-dashboard/app/login/page.jsx
+++ b/cicero-dashboard/app/login/page.jsx
@@ -39,13 +39,13 @@ export default function LoginPage() {
   const highlightItems = useMemo(
     () => [
       {
-        icon: <Sparkles className="h-4 w-4 text-cyan-300" />,
+        icon: <Sparkles className="h-4 w-4 text-sky-500" />,
         title: "Operasional Terpadu",
         description:
           "Cicero mengorkestrasi workflow harian, dari laporan lapangan hingga analisis data.",
       },
       {
-        icon: <ShieldCheck className="h-4 w-4 text-emerald-300" />,
+        icon: <ShieldCheck className="h-4 w-4 text-teal-500" />,
         title: "Keamanan Terkendali",
         description:
           "Proteksi berlapis memastikan data sensitif hanya diakses oleh akses yang disetujui.",
@@ -148,11 +148,11 @@ export default function LoginPage() {
   };
 
   return (
-    <main className="relative min-h-screen overflow-hidden bg-[radial-gradient(circle_at_top,_#0f172a,_#020617_55%)] text-slate-50">
-      <div className="pointer-events-none absolute inset-0 opacity-40">
-        <div className="absolute left-1/2 top-1/2 h-[620px] w-[620px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-cyan-500/20 blur-[160px]" />
-        <div className="absolute -left-32 top-[18%] h-64 w-64 rounded-full bg-violet-500/20 blur-[130px]" />
-        <div className="absolute -right-20 bottom-[10%] h-72 w-72 rounded-full bg-blue-500/20 blur-[140px]" />
+    <main className="relative min-h-screen overflow-hidden bg-[radial-gradient(circle_at_top,_#e9f3ff,_#cde9ff_58%)] text-slate-900">
+      <div className="pointer-events-none absolute inset-0 opacity-60">
+        <div className="absolute left-1/2 top-1/2 h-[620px] w-[620px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-sky-300/40 blur-[160px]" />
+        <div className="absolute -left-32 top-[18%] h-64 w-64 rounded-full bg-indigo-300/35 blur-[130px]" />
+        <div className="absolute -right-20 bottom-[10%] h-72 w-72 rounded-full bg-teal-300/35 blur-[140px]" />
       </div>
 
       <div className="absolute top-4 right-4 z-30">
@@ -161,10 +161,10 @@ export default function LoginPage() {
 
       <div className="relative z-10 flex min-h-screen items-center justify-center px-4 py-10 sm:px-6 lg:px-10">
         <div className="grid w-full max-w-6xl items-start gap-10 lg:grid-cols-[1.05fr_1fr]">
-          <section className="relative flex h-full flex-col justify-between gap-10 rounded-[32px] border border-white/10 bg-white/5 p-8 backdrop-blur-xl">
+          <section className="relative flex h-full flex-col justify-between gap-10 rounded-[32px] border border-sky-200/60 bg-white/40 p-8 text-slate-700 backdrop-blur-xl">
             <div className="space-y-7">
               <motion.span
-                className="inline-flex items-center rounded-full border border-white/15 bg-white/5 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-cyan-200"
+                className="inline-flex items-center rounded-full border border-sky-200/60 bg-white/60 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-sky-600"
                 initial={{ opacity: 0, y: -10 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ duration: 0.6 }}
@@ -172,15 +172,15 @@ export default function LoginPage() {
                 Portal Operasional Cicero
               </motion.span>
               <motion.h1
-                className="text-4xl font-bold leading-tight text-white md:text-5xl"
+                className="text-4xl font-bold leading-tight text-slate-900 md:text-5xl"
                 initial={{ opacity: 0, y: 12 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ duration: 0.7, delay: 0.1 }}
               >
-                Sentral komando untuk <span className="bg-gradient-to-r from-cyan-300 via-blue-400 to-violet-500 bg-clip-text text-transparent">respon cepat</span> dan koordinasi berbasis data.
+                Sentral komando untuk <span className="bg-gradient-to-r from-sky-500 via-cyan-400 to-indigo-500 bg-clip-text text-transparent">respon cepat</span> dan koordinasi berbasis data.
               </motion.h1>
               <motion.p
-                className="max-w-xl text-balance text-sm leading-relaxed text-slate-200/80 md:text-base"
+                className="max-w-xl text-balance text-sm leading-relaxed text-slate-700 md:text-base"
                 initial={{ opacity: 0, y: 12 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ duration: 0.7, delay: 0.2 }}
@@ -193,20 +193,20 @@ export default function LoginPage() {
               {highlightItems.map((item, index) => (
                 <motion.div
                   key={item.title}
-                  className="group relative flex h-full flex-col justify-between overflow-hidden rounded-2xl border border-white/10 bg-gradient-to-b from-white/10 via-white/5 to-transparent p-4 shadow-lg backdrop-blur-xl"
+                  className="group relative flex h-full flex-col justify-between overflow-hidden rounded-2xl border border-sky-200/60 bg-gradient-to-b from-white/70 via-white/50 to-transparent p-4 shadow-lg backdrop-blur-xl"
                   initial={{ opacity: 0, y: 16 }}
                   animate={{ opacity: 1, y: 0 }}
                   transition={{ duration: 0.6, delay: 0.15 * index }}
                 >
-                  <div className="mb-3 inline-flex items-center gap-2 rounded-full bg-slate-900/60 px-3 py-1 text-[0.7rem] font-semibold text-white/80">
+                  <div className="mb-3 inline-flex items-center gap-2 rounded-full bg-white/80 px-3 py-1 text-[0.7rem] font-semibold text-slate-700">
                     {item.icon}
                     {item.title}
                   </div>
-                  <p className="text-sm text-slate-200/80">
+                  <p className="text-sm text-slate-600">
                     {item.description}
                   </p>
                   <motion.div
-                    className="absolute -bottom-24 -right-20 h-32 w-32 rounded-full bg-cyan-400/30 blur-3xl transition-transform duration-500 group-hover:translate-y-12"
+                    className="absolute -bottom-24 -right-20 h-32 w-32 rounded-full bg-sky-300/30 blur-3xl transition-transform duration-500 group-hover:translate-y-12"
                     animate={{ scale: [1, 1.1, 1] }}
                     transition={{ duration: 6, repeat: Infinity }}
                   />
@@ -218,29 +218,31 @@ export default function LoginPage() {
 
           <div className="relative flex flex-col gap-6">
             <motion.div
-              className="absolute -right-6 -top-6 hidden h-32 w-32 rounded-full border border-cyan-400/40 lg:block"
+              className="absolute -right-6 -top-6 hidden h-32 w-32 rounded-full border border-sky-300/50 lg:block"
               animate={{ rotate: [0, 12, -8, 0] }}
               transition={{ duration: 12, repeat: Infinity, ease: "easeInOut" }}
             />
             <motion.div
-              className="relative z-20 rounded-[32px] border border-white/10 bg-slate-900/70 p-8 shadow-2xl backdrop-blur-2xl"
+              className="relative z-20 rounded-[32px] border border-sky-200/60 bg-white/40 p-8 text-slate-700 shadow-2xl backdrop-blur-2xl"
               initial={{ opacity: 0, y: 20, scale: 0.95 }}
               animate={{ opacity: 1, y: 0, scale: 1 }}
               transition={{ duration: 0.6, delay: 0.2 }}
             >
               <div className="mb-8 flex flex-col gap-6 sm:flex-row sm:items-center sm:justify-between">
                 <div className="space-y-1">
-                  <p className="text-xs uppercase tracking-[0.3em] text-cyan-200/80">Cicero Access</p>
-                  <h2 className="text-2xl font-semibold text-white">
+                  <p className="text-xs uppercase tracking-[0.3em] text-sky-600/90">Cicero Access</p>
+                  <h2 className="text-2xl font-semibold text-slate-900">
                     {isRegister ? "Aktivasi Akun" : "Masuk Dashboard"}
                   </h2>
                 </div>
-                <div className="flex self-start rounded-full border border-white/10 bg-white/5 p-1 text-xs font-medium sm:self-auto">
+                <div className="flex self-start rounded-full border border-sky-200/60 bg-white/60 p-1 text-xs font-medium sm:self-auto">
                   <button
                     type="button"
                     onClick={() => setIsRegister(false)}
                     className={`rounded-full px-3 py-1 transition ${
-                      !isRegister ? "bg-gradient-to-r from-cyan-400 to-blue-500 text-slate-950" : "text-white/70"
+                      !isRegister
+                        ? "bg-gradient-to-r from-sky-400 via-cyan-300 to-indigo-400 text-slate-900"
+                        : "text-slate-500"
                     }`}
                   >
                     Login
@@ -249,7 +251,9 @@ export default function LoginPage() {
                     type="button"
                     onClick={() => setIsRegister(true)}
                     className={`rounded-full px-3 py-1 transition ${
-                      isRegister ? "bg-gradient-to-r from-violet-500 to-blue-500 text-slate-950" : "text-white/70"
+                      isRegister
+                        ? "bg-gradient-to-r from-sky-400 via-cyan-300 to-indigo-400 text-slate-900"
+                        : "text-slate-500"
                     }`}
                   >
                     Register
@@ -257,7 +261,7 @@ export default function LoginPage() {
                 </div>
               </div>
 
-              <p className="mb-7 rounded-2xl border border-white/10 bg-white/5 p-4 text-xs text-slate-200/70">
+              <p className="mb-7 rounded-2xl border border-sky-200/60 bg-white/50 p-4 text-xs text-slate-600">
                 Autentikasi menggunakan kredensial User Cicero. Pastikan nomor WhatsApp aktif untuk menerima notifikasi verifikasi dan panduan operasional.
               </p>
 
@@ -274,7 +278,7 @@ export default function LoginPage() {
                     onChange={(e) => setUsername(e.target.value)}
                     onBlur={handleTrim(setUsername)}
                     required
-                    className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white placeholder:text-white/40 transition focus:border-cyan-400 focus:outline-none focus:ring-2 focus:ring-cyan-400/30"
+                    className="w-full rounded-xl border border-sky-200/60 bg-white/70 px-4 py-3 text-sm text-slate-800 placeholder:text-slate-400 transition focus:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-200"
                   />
                 </div>
                 <div className="relative">
@@ -290,12 +294,12 @@ export default function LoginPage() {
                     onBlur={handleTrim(setPassword)}
                     required
                     autoComplete={isRegister ? "new-password" : "current-password"}
-                    className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 pr-12 text-sm text-white placeholder:text-white/40 transition focus:border-cyan-400 focus:outline-none focus:ring-2 focus:ring-cyan-400/30"
+                    className="w-full rounded-xl border border-sky-200/60 bg-white/70 px-4 py-3 pr-12 text-sm text-slate-800 placeholder:text-slate-400 transition focus:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-200"
                   />
                   <button
                     type="button"
                     onClick={() => setShowPassword((prev) => !prev)}
-                    className="absolute inset-y-0 right-4 flex items-center text-white/60"
+                    className="absolute inset-y-0 right-4 flex items-center text-slate-500"
                     tabIndex={-1}
                   >
                     {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
@@ -317,12 +321,12 @@ export default function LoginPage() {
                         onBlur={handleTrim(setConfirmPassword)}
                         required
                         autoComplete="new-password"
-                        className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 pr-12 text-sm text-white placeholder:text-white/40 transition focus:border-violet-400 focus:outline-none focus:ring-2 focus:ring-violet-400/30"
+                        className="w-full rounded-xl border border-sky-200/60 bg-white/70 px-4 py-3 pr-12 text-sm text-slate-800 placeholder:text-slate-400 transition focus:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-200"
                       />
                       <button
                         type="button"
                         onClick={() => setShowConfirmPassword((prev) => !prev)}
-                        className="absolute inset-y-0 right-4 flex items-center text-white/60"
+                        className="absolute inset-y-0 right-4 flex items-center text-slate-500"
                         tabIndex={-1}
                       >
                         {showConfirmPassword ? <EyeOff size={18} /> : <Eye size={18} />}
@@ -342,7 +346,7 @@ export default function LoginPage() {
                         required
                         inputMode="tel"
                         autoComplete="tel"
-                        className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white placeholder:text-white/40 transition focus:border-violet-400 focus:outline-none focus:ring-2 focus:ring-violet-400/30"
+                        className="w-full rounded-xl border border-sky-200/60 bg-white/70 px-4 py-3 text-sm text-slate-800 placeholder:text-slate-400 transition focus:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-200"
                       />
                     </div>
                     <div className="grid gap-4 sm:grid-cols-2">
@@ -358,7 +362,7 @@ export default function LoginPage() {
                           value={role}
                           onChange={(e) => setRole(e.target.value)}
                           onBlur={handleTrim(setRole)}
-                          className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white placeholder:text-white/40 transition focus:border-violet-400 focus:outline-none focus:ring-2 focus:ring-violet-400/30"
+                          className="w-full rounded-xl border border-sky-200/60 bg-white/70 px-4 py-3 text-sm text-slate-800 placeholder:text-slate-400 transition focus:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-200"
                         />
                         <datalist id="role-options">
                           <option value="OPERATOR" />
@@ -379,7 +383,7 @@ export default function LoginPage() {
                           value={client_id}
                           onChange={(e) => setClientId(e.target.value)}
                           onBlur={handleTrim(setClientId)}
-                          className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white placeholder:text-white/40 transition focus:border-violet-400 focus:outline-none focus:ring-2 focus:ring-violet-400/30"
+                          className="w-full rounded-xl border border-sky-200/60 bg-white/70 px-4 py-3 text-sm text-slate-800 placeholder:text-slate-400 transition focus:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-200"
                         />
                         <datalist id="client-options">
                           <option value="DITBINMAS" />
@@ -431,12 +435,12 @@ export default function LoginPage() {
                 )}
 
                 {error && (
-                  <div className="rounded-xl border border-red-500/40 bg-red-500/10 px-4 py-3 text-center text-sm text-red-200">
+                  <div className="rounded-xl border border-red-400/40 bg-red-100 px-4 py-3 text-center text-sm text-red-600">
                     {error}
                   </div>
                 )}
                 {message && (
-                  <div className="rounded-xl border border-emerald-500/40 bg-emerald-500/10 px-4 py-3 text-center text-sm text-emerald-200">
+                  <div className="rounded-xl border border-emerald-400/50 bg-emerald-100 px-4 py-3 text-center text-sm text-emerald-600">
                     {message}
                   </div>
                 )}
@@ -444,8 +448,8 @@ export default function LoginPage() {
                 <button
                   type="submit"
                   disabled={loading}
-                  className={`w-full rounded-2xl border border-transparent bg-gradient-to-r from-cyan-400 via-blue-500 to-violet-500 px-6 py-3 text-sm font-semibold text-slate-950 shadow-lg transition focus:outline-none focus:ring-2 focus:ring-cyan-300 focus:ring-offset-2 focus:ring-offset-slate-900 ${
-                    loading ? "opacity-60" : "hover:shadow-xl hover:shadow-cyan-500/30"
+                  className={`w-full rounded-2xl border border-transparent bg-gradient-to-r from-sky-400 via-cyan-300 to-indigo-400 px-6 py-3 text-sm font-semibold text-slate-900 shadow-lg transition focus:outline-none focus:ring-2 focus:ring-sky-200 focus:ring-offset-2 focus:ring-offset-transparent ${
+                    loading ? "opacity-60" : "hover:shadow-xl hover:shadow-sky-200/60"
                   }`}
                 >
                   {loading
@@ -457,32 +461,32 @@ export default function LoginPage() {
                       : "Masuk sekarang"}
                 </button>
 
-                <p className="text-center text-[0.7rem] text-white/50">
+                <p className="text-center text-[0.7rem] text-slate-500">
                   Dengan masuk, Anda menyetujui protokol keamanan Cicero dan penggunaan data sesuai kebijakan internal.
                 </p>
               </form>
             </motion.div>
 
             <motion.div
-              className="relative z-10 flex items-start gap-4 rounded-[28px] border border-white/10 bg-white/5 p-6 backdrop-blur-xl"
+              className="relative z-10 flex items-start gap-4 rounded-[28px] border border-sky-200/60 bg-white/50 p-6 text-slate-700 backdrop-blur-xl"
               initial={{ opacity: 0, y: 16 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.6, delay: 0.45 }}
             >
-              <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-gradient-to-br from-cyan-400/20 via-blue-400/20 to-violet-400/20 text-cyan-200">
+              <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-gradient-to-br from-sky-200 via-cyan-200 to-indigo-200 text-sky-600">
                 <ArrowRight className="h-5 w-5" />
               </div>
               <div className="space-y-2">
-                <p className="text-sm font-semibold uppercase tracking-[0.2em] text-cyan-200/80">Onboarding Terarah</p>
-                <h3 className="text-lg font-semibold text-white">Validasi akses dalam 1x24 jam</h3>
-                <p className="text-sm leading-relaxed text-slate-200/80">
+                <p className="text-sm font-semibold uppercase tracking-[0.2em] text-sky-600/90">Onboarding Terarah</p>
+                <h3 className="text-lg font-semibold text-slate-800">Validasi akses dalam 1x24 jam</h3>
+                <p className="text-sm leading-relaxed text-slate-600">
                   Tim keamanan Cicero akan menghubungi Anda melalui WhatsApp untuk memverifikasi mandat dan memastikan akses dashboard hanya diberikan kepada personel yang tepat.
                 </p>
               </div>
             </motion.div>
 
             <motion.div
-              className="absolute inset-x-6 top-6 -z-10 h-[92%] rounded-[36px] bg-gradient-to-br from-white/10 via-white/5 to-transparent blur-2xl"
+              className="absolute inset-x-6 top-6 -z-10 h-[92%] rounded-[36px] bg-gradient-to-br from-white/60 via-white/30 to-transparent blur-2xl"
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               transition={{ duration: 1, delay: 0.3 }}


### PR DESCRIPTION
## Summary
- restyle the login screen with a bright pastel radial gradient backdrop and glassmorphism cards
- refresh highlight and onboarding cards with lighter borders, typography, and icon treatments
- update form inputs and primary actions to use cohesive pastel gradients and sky-toned focus states

## Testing
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_68e5aeed1f2c8327911e0b7f97d95994