### PR TITLE
Refresh dashboard visuals with pastel palette

### DIFF
--- a/cicero-dashboard/app/dashboard/page.tsx
+++ b/cicero-dashboard/app/dashboard/page.tsx
@@ -529,28 +529,28 @@ export default function DashboardPage() {
         key: "posts",
         label: "Total Konten",
         value: analytics.totals.posts,
-        accent: "text-emerald-300",
+        accent: "text-emerald-600 dark:text-emerald-300",
         helper: "Konten dianalisis hari ini",
       },
       {
         key: "videos",
         label: "Total Video",
         value: analytics.totals.videoPosts,
-        accent: "text-cyan-300",
+        accent: "text-sky-600 dark:text-cyan-300",
         helper: "Video lintas platform",
       },
       {
         key: "carousel-image",
         label: "Total Carousel / Image",
         value: analytics.totals.carouselImagePosts,
-        accent: "text-fuchsia-300",
+        accent: "text-fuchsia-600 dark:text-fuchsia-300",
         helper: "Konten gambar & carousel",
       },
       {
         key: "engagement",
         label: "Total Engagement",
         value: formatCompactNumber(analytics.totals.engagements),
-        accent: "text-amber-300",
+        accent: "text-amber-600 dark:text-amber-300",
         helper: "Akumulasi likes & komentar",
       },
     ],
@@ -558,59 +558,59 @@ export default function DashboardPage() {
   );
 
   return (
-    <div className="relative min-h-screen overflow-hidden bg-slate-950 text-slate-100">
+    <div className="relative min-h-screen overflow-hidden bg-gradient-to-br from-sky-50 via-cyan-50 to-indigo-100 text-slate-900 dark:from-slate-950 dark:via-slate-900 dark:to-indigo-950 dark:text-slate-100">
       <div className="pointer-events-none absolute inset-0 overflow-hidden">
-        <div className="absolute -top-24 -right-32 h-96 w-96 rounded-full bg-cyan-500/30 blur-3xl" />
-        <div className="absolute bottom-0 left-0 h-[28rem] w-[28rem] rounded-full bg-purple-500/20 blur-[200px]" />
-        <div className="absolute right-1/3 top-1/2 h-64 w-64 -translate-y-1/2 rounded-full bg-blue-500/10 blur-3xl" />
+        <div className="absolute -top-24 -right-32 h-96 w-96 rounded-full bg-sky-200/60 blur-3xl dark:bg-cyan-500/30" />
+        <div className="absolute bottom-0 left-0 h-[28rem] w-[28rem] rounded-full bg-indigo-200/40 blur-[200px] dark:bg-purple-500/20" />
+        <div className="absolute right-1/3 top-1/2 h-64 w-64 -translate-y-1/2 rounded-full bg-cyan-200/50 blur-3xl dark:bg-blue-500/10" />
       </div>
       <div className="relative z-10 mx-auto flex w-full max-w-7xl flex-col gap-10 px-6 py-12">
         <section className="space-y-8">
           <div className="space-y-6">
-            <span className="inline-flex items-center gap-2 rounded-full border border-slate-700/60 bg-slate-900/70 px-4 py-1 text-xs uppercase tracking-[0.3em] text-slate-300">
-              <span className="h-2 w-2 rounded-full bg-emerald-400 shadow-[0_0_0.6rem_rgba(52,211,153,0.7)]" />
+            <span className="inline-flex items-center gap-2 rounded-full border border-sky-200/70 bg-white/80 px-4 py-1 text-xs uppercase tracking-[0.3em] text-sky-700 shadow-[0_12px_30px_rgba(14,165,233,0.12)] dark:border-slate-700/60 dark:bg-slate-900/70 dark:text-slate-300">
+              <span className="h-2 w-2 rounded-full bg-emerald-400 shadow-[0_0_0.6rem_rgba(52,211,153,0.45)] dark:shadow-[0_0_0.6rem_rgba(52,211,153,0.7)]" />
               Command Center
             </span>
-            <h1 className="text-3xl font-semibold leading-tight text-slate-50 md:text-4xl">
+            <h1 className="text-3xl font-semibold leading-tight text-slate-900 md:text-4xl dark:text-slate-50">
               Ikhtisar Data Keterlibatan Audiens Instagram & TikTok secara Real-time
             </h1>
-            <p className="max-w-2xl text-base text-slate-300 md:text-lg">
+            <p className="max-w-2xl text-base text-sky-700 md:text-lg dark:text-slate-300">
               Pantau detik demi detik perkembangan audiens, reaksi komunitas, dan percakapan yang terjadi di Instagram serta TikTok melalui satu kanvas visual yang imersif.
             </p>
-            <div className="grid gap-3 text-sm text-slate-300 sm:grid-cols-2">
-              <div className="flex items-center gap-2 rounded-full border border-slate-700/60 bg-slate-900/60 px-3 py-1.5">
-                <span className="text-emerald-300">◎</span>
+            <div className="grid gap-3 text-sm text-sky-700 sm:grid-cols-2 dark:text-slate-300">
+              <div className="flex items-center gap-2 rounded-full border border-sky-200/70 bg-white/80 px-3 py-1.5 shadow-[0_10px_25px_rgba(56,189,248,0.12)] dark:border-slate-700/60 dark:bg-slate-900/60">
+                <span className="text-emerald-500 dark:text-emerald-300">◎</span>
                 <span>Data terintegrasi lintas platform</span>
               </div>
-              <div className="flex items-center gap-2 rounded-full border border-slate-700/60 bg-slate-900/60 px-3 py-1.5">
-                <span className="text-cyan-300">◎</span>
+              <div className="flex items-center gap-2 rounded-full border border-sky-200/70 bg-white/80 px-3 py-1.5 shadow-[0_10px_25px_rgba(129,140,248,0.12)] dark:border-slate-700/60 dark:bg-slate-900/60">
+                <span className="text-sky-600 dark:text-cyan-300">◎</span>
                 <span>Visual responsif & mudah dipahami</span>
               </div>
             </div>
           </div>
           <div className="grid gap-6 lg:grid-cols-2 lg:items-stretch">
-            <div className="relative flex h-full flex-col overflow-hidden rounded-3xl border border-slate-700/60 bg-gradient-to-br from-slate-900/60 via-slate-900/40 to-slate-900/10 p-6 shadow-[0_0_2rem_rgba(56,189,248,0.25)]">
-              <div className="absolute inset-x-10 top-4 h-24 rounded-full bg-gradient-to-b from-cyan-400/30 via-transparent to-transparent blur-2xl" />
+            <div className="relative flex h-full flex-col overflow-hidden rounded-3xl border border-sky-200/70 bg-gradient-to-br from-white/80 via-sky-50/80 to-cyan-50/60 p-6 shadow-[0_35px_60px_-15px_rgba(14,165,233,0.2)] dark:border-slate-700/60 dark:from-slate-900/60 dark:via-slate-900/40 dark:to-slate-900/10">
+              <div className="absolute inset-x-10 top-4 h-24 rounded-full bg-gradient-to-b from-sky-300/40 via-transparent to-transparent blur-2xl dark:from-cyan-400/30" />
               <div className="relative flex flex-1 flex-col gap-6">
-                <h2 className="text-lg font-semibold text-slate-100">Snapshot Hari Ini</h2>
-                <p className="text-sm text-slate-300">
+                <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Snapshot Hari Ini</h2>
+                <p className="text-sm text-sky-700 dark:text-slate-300">
                   {analytics.totals.posts > 0
                     ? `Analisis ${analytics.totals.posts} konten terbaru dengan akumulasi likes dan komentar sebanyak ${formatCompactNumber(
                         analytics.totals.engagements
                       )}`
                     : "Menunggu konten terbaru untuk dianalisis."}
                 </p>
-                <div className="grid gap-4 text-sm text-slate-200 sm:grid-cols-2 xl:grid-cols-2">
+                <div className="grid gap-4 text-sm text-slate-700 sm:grid-cols-2 xl:grid-cols-2 dark:text-slate-200">
                   {snapshotMetrics.map((metric) => (
                     <div
                       key={metric.key}
-                      className="group flex flex-col gap-2 rounded-2xl border border-slate-800/60 bg-slate-900/60 p-4 shadow-[0_0_1.5rem_rgba(56,189,248,0.12)] transition duration-200 hover:-translate-y-1 hover:border-cyan-400/40 hover:shadow-[0_0_2.5rem_rgba(56,189,248,0.25)]"
+                      className="group flex flex-col gap-2 rounded-2xl border border-sky-200/70 bg-white/75 p-4 shadow-[0_18px_40px_rgba(14,165,233,0.14)] transition duration-200 hover:-translate-y-1 hover:border-sky-300/70 hover:shadow-[0_22px_45px_rgba(56,189,248,0.2)] dark:border-slate-800/60 dark:bg-slate-900/60 dark:shadow-[0_0_1.5rem_rgba(56,189,248,0.12)] dark:hover:border-cyan-400/40 dark:hover:shadow-[0_0_2.5rem_rgba(56,189,248,0.25)]"
                     >
-                      <span className="text-xs font-medium uppercase tracking-[0.2em] text-slate-400">
+                      <span className="text-xs font-medium uppercase tracking-[0.2em] text-sky-600 dark:text-slate-400">
                         {metric.label}
                       </span>
                       <p className={cn("text-2xl font-semibold", metric.accent)}>{metric.value}</p>
-                      <span className="text-xs text-slate-400">{metric.helper}</span>
+                      <span className="text-xs text-sky-600 dark:text-slate-400">{metric.helper}</span>
                     </div>
                   ))}
                 </div>
@@ -624,7 +624,7 @@ export default function DashboardPage() {
                 tiktokProfile={tiktokProfile}
                 tiktokPosts={tiktokPosts}
                 className="grid-cols-1 sm:grid-cols-2 h-full"
-                cardClassName="border-slate-800/70 bg-slate-900/70"
+                cardClassName="border-sky-200/70 bg-white/75 dark:border-slate-800/70 dark:bg-slate-900/70"
               />
             </div>
           </div>
@@ -632,8 +632,8 @@ export default function DashboardPage() {
 
         <section className="space-y-6">
           <div className="space-y-2">
-            <h2 className="text-2xl font-semibold text-slate-50">Rincian Kinerja Platform</h2>
-            <p className="text-sm text-slate-300">
+            <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-50">Rincian Kinerja Platform</h2>
+            <p className="text-sm text-sky-700 dark:text-slate-300">
               Bandingkan performa inti tiap kanal untuk melihat kontribusi terhadap interaksi keseluruhan.
             </p>
           </div>
@@ -644,19 +644,19 @@ export default function DashboardPage() {
                   key: "likes",
                   label: "Likes",
                   value: formatCompactNumber(platform.likes),
-                  accent: "text-cyan-300",
+                  accent: "text-sky-600 dark:text-cyan-300",
                 },
                 {
                   key: "comments",
                   label: "Komentar",
                   value: formatCompactNumber(platform.comments),
-                  accent: "text-emerald-300",
+                  accent: "text-emerald-600 dark:text-emerald-300",
                 },
                 {
                   key: "engagement",
                   label: "Engagement",
                   value: `${platform.engagementRate.toFixed(2)}%`,
-                  accent: "text-fuchsia-300",
+                  accent: "text-fuchsia-600 dark:text-fuchsia-300",
                 },
               ];
 
@@ -684,45 +684,47 @@ export default function DashboardPage() {
               return (
                 <div
                   key={platform.key}
-                  className="group relative flex h-full flex-col overflow-hidden rounded-3xl border border-slate-800/70 bg-slate-900/50 p-6 shadow-[0_0_30px_rgba(79,70,229,0.25)] transition duration-200 hover:-translate-y-1 hover:border-cyan-400/40 hover:shadow-[0_0_45px_rgba(34,211,238,0.22)]"
+                  className="group relative flex h-full flex-col overflow-hidden rounded-3xl border border-sky-200/70 bg-white/75 p-6 shadow-[0_28px_60px_rgba(99,102,241,0.18)] transition duration-200 hover:-translate-y-1 hover:border-sky-300/70 hover:shadow-[0_32px_70px_rgba(129,140,248,0.25)] dark:border-slate-800/70 dark:bg-slate-900/50 dark:shadow-[0_0_30px_rgba(79,70,229,0.25)] dark:hover:border-cyan-400/40 dark:hover:shadow-[0_0_45px_rgba(34,211,238,0.22)]"
                 >
-                  <div className="absolute -top-12 right-4 h-32 w-32 rounded-full bg-gradient-to-br from-cyan-400/40 via-transparent to-transparent blur-2xl transition group-hover:from-cyan-400/60" />
+                  <div className="absolute -top-12 right-4 h-32 w-32 rounded-full bg-gradient-to-br from-sky-300/50 via-transparent to-transparent blur-2xl transition group-hover:from-sky-300/70 dark:from-cyan-400/40 dark:group-hover:from-cyan-400/60" />
                   <div className="relative flex h-full flex-col gap-6">
                     <div className="flex items-start justify-between gap-4">
                       <div>
-                        <p className="text-xs font-medium uppercase tracking-[0.25em] text-slate-400">Platform</p>
-                        <h3 className="text-xl font-semibold text-slate-50">{platform.label}</h3>
+                        <p className="text-xs font-medium uppercase tracking-[0.25em] text-sky-600 dark:text-slate-400">Platform</p>
+                        <h3 className="text-xl font-semibold text-slate-900 dark:text-slate-50">{platform.label}</h3>
                       </div>
-                      <div className="flex flex-col items-end rounded-2xl border border-slate-800/60 bg-slate-900/60 px-3 py-2 text-xs text-slate-300">
-                        <span className="font-medium text-slate-200">Followers</span>
-                        <span>{formatCompactNumber(platform.followers)}</span>
-                        <span className="mt-1 text-slate-400">Posts: {platform.posts}</span>
+                      <div className="flex flex-col items-end rounded-2xl border border-sky-200/70 bg-white/80 px-3 py-2 text-xs text-sky-700 shadow-[0_12px_30px_rgba(14,165,233,0.12)] dark:border-slate-800/60 dark:bg-slate-900/60 dark:text-slate-300">
+                        <span className="font-medium text-slate-900 dark:text-slate-200">Followers</span>
+                        <span className="text-lg font-semibold text-sky-600 dark:text-cyan-300">
+                          {formatCompactNumber(platform.followers)}
+                        </span>
+                        <span className="mt-1 text-sky-600 dark:text-slate-400">Posts: {platform.posts}</span>
                       </div>
                     </div>
-                    <div className="grid grid-cols-1 gap-3 text-sm text-slate-200 sm:grid-cols-3">
+                    <div className="grid grid-cols-1 gap-3 text-sm text-slate-700 sm:grid-cols-3 dark:text-slate-200">
                       {primaryMetrics.map((metric) => (
                         <div
                           key={metric.key}
-                          className="flex flex-col gap-2 rounded-2xl border border-slate-800/60 bg-slate-900/60 p-4"
+                          className="flex flex-col gap-2 rounded-2xl border border-sky-200/70 bg-white/80 p-4 shadow-[0_15px_35px_rgba(14,165,233,0.12)] dark:border-slate-800/60 dark:bg-slate-900/60"
                         >
-                          <span className="text-xs font-medium uppercase tracking-wide text-slate-400">
+                          <span className="text-xs font-medium uppercase tracking-wide text-sky-600 dark:text-slate-400">
                             {metric.label}
                           </span>
                           <span className={cn("text-lg font-semibold", metric.accent)}>{metric.value}</span>
                         </div>
                       ))}
                     </div>
-                    <div className="mt-auto space-y-3 text-xs text-slate-300">
+                    <div className="mt-auto space-y-3 text-xs text-sky-700 dark:text-slate-300">
                       {shareMetrics.map((share) => (
                         <div
                           key={share.key}
-                          className="rounded-2xl border border-slate-800/60 bg-slate-900/60 p-3"
+                          className="rounded-2xl border border-sky-200/70 bg-white/80 p-3 shadow-[0_12px_28px_rgba(56,189,248,0.16)] dark:border-slate-800/60 dark:bg-slate-900/60"
                         >
-                          <div className="mb-2 flex justify-between text-[0.7rem] font-medium uppercase tracking-wider text-slate-400">
+                          <div className="mb-2 flex justify-between text-[0.7rem] font-medium uppercase tracking-wider text-sky-600 dark:text-slate-400">
                             <span>{share.label}</span>
                             <span>{share.value.toFixed(1)}%</span>
                           </div>
-                          <div className="h-2 rounded-full bg-slate-800">
+                          <div className="h-2 rounded-full bg-sky-100 dark:bg-slate-800">
                             <div
                               className={cn(
                                 "h-full rounded-full bg-gradient-to-r",
@@ -743,8 +745,8 @@ export default function DashboardPage() {
 
         <section className="space-y-6">
           <div className="space-y-2">
-            <h2 className="text-2xl font-semibold text-slate-50">Detak Interaksi & Percakapan</h2>
-            <p className="text-sm text-slate-300">
+            <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-50">Detak Interaksi & Percakapan</h2>
+            <p className="text-sm text-sky-700 dark:text-slate-300">
               Pilih platform untuk menggali profil audiens, posting unggulan, dan percakapan yang
               sedang berlangsung.
             </p>
@@ -767,15 +769,15 @@ export default function DashboardPage() {
 
         <section className="space-y-4">
           <div className="flex flex-col gap-2">
-            <h2 className="text-2xl font-semibold text-slate-50">Konten Paling Resonansi</h2>
-            <p className="text-sm text-slate-300">
+            <h2 className="text-2xl font-semibold text-slate-900 dark:text-slate-50">Konten Paling Resonansi</h2>
+            <p className="text-sm text-sky-700 dark:text-slate-300">
               Sorotan posting dengan likes, komentar, dan views tertinggi untuk memetakan pola konten
               yang paling disukai audiens.
             </p>
           </div>
           <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
             {analytics.topPosts.length === 0 && (
-              <div className="col-span-full rounded-3xl border border-slate-800/70 bg-slate-900/50 p-8 text-center text-sm text-slate-300">
+              <div className="col-span-full rounded-3xl border border-sky-200/70 bg-white/75 p-8 text-center text-sm text-sky-700 shadow-[0_25px_60px_rgba(59,130,246,0.18)] dark:border-slate-800/70 dark:bg-slate-900/50 dark:text-slate-300">
                 Data konten belum tersedia. Unggah konten baru untuk melihat analitik terbaru.
               </div>
             )}
@@ -785,9 +787,9 @@ export default function DashboardPage() {
                 href={post.url || undefined}
                 target={post.url ? "_blank" : undefined}
                 rel={post.url ? "noopener noreferrer" : undefined}
-                className="group relative overflow-hidden rounded-3xl border border-slate-800/60 bg-slate-900/50 p-4 transition hover:border-cyan-400/60 hover:shadow-[0_0_30px_rgba(34,211,238,0.3)]"
+                className="group relative overflow-hidden rounded-3xl border border-sky-200/70 bg-white/80 p-4 transition hover:-translate-y-1 hover:border-sky-300/70 hover:shadow-[0_28px_60px_rgba(56,189,248,0.22)] dark:border-slate-800/60 dark:bg-slate-900/50 dark:hover:border-cyan-400/60 dark:hover:shadow-[0_0_30px_rgba(34,211,238,0.3)]"
               >
-                <div className="absolute -top-16 right-0 h-32 w-32 rounded-full bg-cyan-500/20 blur-3xl transition group-hover:bg-cyan-400/30" />
+                <div className="absolute -top-16 right-0 h-32 w-32 rounded-full bg-sky-300/40 blur-3xl transition group-hover:bg-sky-300/60 dark:bg-cyan-500/20 dark:group-hover:bg-cyan-400/30" />
                 <div className="relative space-y-4">
                   {post.thumbnail ? (
                     <img
@@ -797,16 +799,16 @@ export default function DashboardPage() {
                       loading="lazy"
                     />
                   ) : (
-                    <div className="flex h-40 w-full items-center justify-center rounded-2xl border border-slate-800 bg-slate-900/60 text-slate-500">
+                    <div className="flex h-40 w-full items-center justify-center rounded-2xl border border-sky-200/70 bg-white/70 text-sky-600 dark:border-slate-800 dark:bg-slate-900/60 dark:text-slate-500">
                       Tidak ada thumbnail
                     </div>
                   )}
                   <div className="space-y-2">
-                    <span className="inline-flex items-center gap-2 rounded-full border border-slate-700/60 bg-slate-900/80 px-3 py-1 text-xs uppercase tracking-[0.2em] text-slate-300">
+                    <span className="inline-flex items-center gap-2 rounded-full border border-sky-200/70 bg-white/80 px-3 py-1 text-xs uppercase tracking-[0.2em] text-sky-700 shadow-[0_12px_28px_rgba(79,70,229,0.18)] dark:border-slate-700/60 dark:bg-slate-900/80 dark:text-slate-300">
                       {post.platform}
                     </span>
                     <p
-                      className="text-sm text-slate-200"
+                      className="text-sm text-slate-800 dark:text-slate-200"
                       style={{
                         display: "-webkit-box",
                         WebkitLineClamp: 3,
@@ -817,22 +819,22 @@ export default function DashboardPage() {
                       {post.caption}
                     </p>
                   </div>
-                  <div className="grid grid-cols-3 gap-3 text-center text-xs text-slate-300">
-                    <div className="rounded-2xl border border-slate-800/70 bg-slate-900/70 px-3 py-2">
-                      <p className="text-[0.65rem] uppercase tracking-wide text-slate-400">Likes</p>
-                      <p className="text-base font-semibold text-cyan-300">
+                  <div className="grid grid-cols-3 gap-3 text-center text-xs text-slate-700 dark:text-slate-300">
+                    <div className="rounded-2xl border border-sky-200/70 bg-white/80 px-3 py-2 shadow-[0_12px_30px_rgba(56,189,248,0.15)] dark:border-slate-800/70 dark:bg-slate-900/70">
+                      <p className="text-[0.65rem] uppercase tracking-wide text-sky-600 dark:text-slate-400">Likes</p>
+                      <p className="text-base font-semibold text-sky-600 dark:text-cyan-300">
                         {formatCompactNumber(post.likes)}
                       </p>
                     </div>
-                    <div className="rounded-2xl border border-slate-800/70 bg-slate-900/70 px-3 py-2">
-                      <p className="text-[0.65rem] uppercase tracking-wide text-slate-400">Komentar</p>
-                      <p className="text-base font-semibold text-emerald-300">
+                    <div className="rounded-2xl border border-sky-200/70 bg-white/80 px-3 py-2 shadow-[0_12px_30px_rgba(16,185,129,0.15)] dark:border-slate-800/70 dark:bg-slate-900/70">
+                      <p className="text-[0.65rem] uppercase tracking-wide text-sky-600 dark:text-slate-400">Komentar</p>
+                      <p className="text-base font-semibold text-emerald-600 dark:text-emerald-300">
                         {formatCompactNumber(post.comments)}
                       </p>
                     </div>
-                    <div className="rounded-2xl border border-slate-800/70 bg-slate-900/70 px-3 py-2">
-                      <p className="text-[0.65rem] uppercase tracking-wide text-slate-400">Views</p>
-                      <p className="text-base font-semibold text-fuchsia-300">
+                    <div className="rounded-2xl border border-sky-200/70 bg-white/80 px-3 py-2 shadow-[0_12px_30px_rgba(217,70,239,0.15)] dark:border-slate-800/70 dark:bg-slate-900/70">
+                      <p className="text-[0.65rem] uppercase tracking-wide text-sky-600 dark:text-slate-400">Views</p>
+                      <p className="text-base font-semibold text-fuchsia-600 dark:text-fuchsia-300">
                         {formatCompactNumber(post.views)}
                       </p>
                     </div>

--- a/cicero-dashboard/components/DashboardStats.jsx
+++ b/cicero-dashboard/components/DashboardStats.jsx
@@ -80,24 +80,24 @@ export default function DashboardStats({
         <div
           key={item.key || item.title}
           className={cn(
-            "group relative overflow-hidden rounded-3xl border border-slate-800/70 bg-slate-900/60 p-5 shadow-[0_0_32px_rgba(14,165,233,0.15)] transition duration-300 hover:border-cyan-400/60 hover:shadow-[0_0_40px_rgba(34,211,238,0.35)]",
+            "group relative overflow-hidden rounded-3xl border border-sky-200/70 bg-white/80 p-5 shadow-[0_26px_55px_rgba(56,189,248,0.2)] transition duration-300 hover:-translate-y-1 hover:border-sky-300/70 hover:shadow-[0_30px_65px_rgba(56,189,248,0.28)] dark:border-slate-800/70 dark:bg-slate-900/60 dark:shadow-[0_0_32px_rgba(14,165,233,0.15)] dark:hover:border-cyan-400/60 dark:hover:shadow-[0_0_40px_rgba(34,211,238,0.35)]",
             cardClassName,
           )}
         >
-          <div className="absolute -right-10 top-0 h-32 w-32 rounded-full bg-cyan-500/10 blur-3xl transition duration-300 group-hover:bg-cyan-400/20" />
-          <div className="absolute inset-x-6 top-8 h-16 rounded-full bg-gradient-to-b from-slate-100/10 to-transparent blur-2xl" />
+          <div className="absolute -right-10 top-0 h-32 w-32 rounded-full bg-sky-300/40 blur-3xl transition duration-300 group-hover:bg-sky-300/60 dark:bg-cyan-500/10 dark:group-hover:bg-cyan-400/20" />
+          <div className="absolute inset-x-6 top-8 h-16 rounded-full bg-gradient-to-b from-sky-200/40 to-transparent blur-2xl dark:from-slate-100/10" />
           <div className="relative space-y-3">
-            <div className="flex items-center gap-3">
+            <div className="flex items-center gap-3 text-slate-700 dark:text-slate-300">
               <span className="text-xl">{item.icon ?? "◎"}</span>
-              <span className="text-xs uppercase tracking-[0.3em] text-slate-400">
+              <span className="text-xs uppercase tracking-[0.3em] text-sky-600 dark:text-slate-400">
                 {item.title}
               </span>
             </div>
-            <p className="text-3xl font-semibold text-slate-50">
+            <p className="text-3xl font-semibold text-slate-900 dark:text-slate-50">
               {formatValue(item.value)}
             </p>
             {item.subtitle && (
-              <p className="text-xs text-slate-300">{item.subtitle}</p>
+              <p className="text-xs text-slate-600 dark:text-slate-300">{item.subtitle}</p>
             )}
           </div>
         </div>

--- a/cicero-dashboard/components/SocialCardsClient.tsx
+++ b/cicero-dashboard/components/SocialCardsClient.tsx
@@ -132,14 +132,14 @@ export default function SocialCardsClient({
   ];
 
   return (
-    <div className="relative overflow-hidden rounded-3xl border border-slate-800/70 bg-slate-900/60 p-6 shadow-[0_0_36px_rgba(14,165,233,0.15)]">
-      <div className="absolute -left-16 top-20 h-48 w-48 rounded-full bg-violet-500/20 blur-3xl" />
-      <div className="absolute -right-12 bottom-0 h-44 w-44 rounded-full bg-cyan-500/20 blur-3xl" />
+    <div className="relative overflow-hidden rounded-3xl border border-sky-200/70 bg-white/80 p-6 shadow-[0_28px_60px_rgba(59,130,246,0.18)] dark:border-slate-800/70 dark:bg-slate-900/60 dark:shadow-[0_0_36px_rgba(14,165,233,0.15)]">
+      <div className="absolute -left-16 top-20 h-48 w-48 rounded-full bg-sky-300/40 blur-3xl dark:bg-violet-500/20" />
+      <div className="absolute -right-12 bottom-0 h-44 w-44 rounded-full bg-cyan-200/40 blur-3xl dark:bg-cyan-500/20" />
       <div className="relative space-y-6">
         <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
           <div>
-            <h3 className="text-xl font-semibold text-slate-50">Radar Interaksi</h3>
-            <p className="text-sm text-slate-300">
+            <h3 className="text-xl font-semibold text-slate-900 dark:text-slate-50">Radar Interaksi</h3>
+            <p className="text-sm text-sky-700 dark:text-slate-300">
               Bandingkan performa audiens, likes, dan komentar antar platform.
             </p>
           </div>
@@ -149,14 +149,14 @@ export default function SocialCardsClient({
                 key={b.key}
                 className={`relative overflow-hidden rounded-full border px-4 py-1.5 text-sm transition ${
                   platform === b.key
-                    ? "border-cyan-400/60 bg-cyan-500/20 text-cyan-200 shadow-[0_0_20px_rgba(34,211,238,0.45)]"
-                    : "border-slate-700 bg-slate-900/60 text-slate-400 hover:text-slate-200"
+                    ? "border-sky-300/70 bg-sky-200/60 text-sky-900 shadow-[0_18px_40px_rgba(56,189,248,0.25)] dark:border-cyan-400/60 dark:bg-cyan-500/20 dark:text-cyan-200"
+                    : "border-sky-200/70 bg-white/70 text-sky-700 hover:text-sky-900 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-400 dark:hover:text-slate-200"
                 }`}
                 onClick={() => setPlatform(b.key)}
               >
                 <span className="relative z-10">{b.label}</span>
                 {platform === b.key && (
-                  <span className="absolute inset-0 rounded-full bg-gradient-to-r from-cyan-500/20 to-slate-900/0" />
+                  <span className="absolute inset-0 rounded-full bg-gradient-to-r from-sky-300/40 to-transparent dark:from-cyan-500/20" />
                 )}
               </button>
             ))}
@@ -167,56 +167,56 @@ export default function SocialCardsClient({
           {metrics.map(({ key, metric }) => (
             <div
               key={key}
-              className="relative flex h-full flex-col overflow-hidden rounded-2xl border border-slate-800/70 bg-slate-900/70 p-5"
+              className="relative flex h-full flex-col overflow-hidden rounded-2xl border border-sky-200/70 bg-white/75 p-5 shadow-[0_18px_38px_rgba(79,70,229,0.18)] dark:border-slate-800/70 dark:bg-slate-900/70"
             >
-              <div className="absolute -top-12 right-0 h-28 w-28 rounded-full bg-cyan-500/10 blur-3xl" />
+              <div className="absolute -top-12 right-0 h-28 w-28 rounded-full bg-sky-300/40 blur-3xl dark:bg-cyan-500/10" />
               <div className="relative flex flex-1 flex-col gap-4">
-                <div className="flex items-center justify-between">
-                  <span className="text-xs uppercase tracking-[0.3em] text-slate-400">
+                <div className="flex items-center justify-between text-slate-700 dark:text-slate-300">
+                  <span className="text-xs uppercase tracking-[0.3em] text-sky-600 dark:text-slate-400">
                     {key}
                   </span>
-                  <span className="text-xs text-slate-400">
+                  <span className="text-xs text-sky-600 dark:text-slate-400">
                     {metric?.posts ?? 0} posts
                   </span>
                 </div>
-                <div className="grid grid-cols-3 gap-3 text-sm">
+                <div className="grid grid-cols-3 gap-3 text-sm text-slate-700 dark:text-slate-200">
                   <div>
-                    <p className="text-[0.65rem] uppercase tracking-wide text-slate-400">Likes</p>
-                    <p className="text-lg font-semibold text-cyan-300">
+                    <p className="text-[0.65rem] uppercase tracking-wide text-sky-600 dark:text-slate-400">Likes</p>
+                    <p className="text-lg font-semibold text-sky-600 dark:text-cyan-300">
                       {formatNumber(metric?.likes)}
                     </p>
                   </div>
                   <div>
-                    <p className="text-[0.65rem] uppercase tracking-wide text-slate-400">Komentar</p>
-                    <p className="text-lg font-semibold text-emerald-300">
+                    <p className="text-[0.65rem] uppercase tracking-wide text-sky-600 dark:text-slate-400">Komentar</p>
+                    <p className="text-lg font-semibold text-emerald-600 dark:text-emerald-300">
                       {formatNumber(metric?.comments)}
                     </p>
                   </div>
                   <div>
-                    <p className="text-[0.65rem] uppercase tracking-wide text-slate-400">Followers</p>
-                    <p className="text-lg font-semibold text-fuchsia-300">
+                    <p className="text-[0.65rem] uppercase tracking-wide text-sky-600 dark:text-slate-400">Followers</p>
+                    <p className="text-lg font-semibold text-fuchsia-600 dark:text-fuchsia-300">
                       {formatNumber(metric?.followers)}
                     </p>
                   </div>
                 </div>
-                <div className="flex items-center justify-between text-xs text-slate-300">
+                <div className="flex items-center justify-between text-xs text-slate-700 dark:text-slate-300">
                   <span>Engagement</span>
                   <span>{metric ? metric.engagementRate.toFixed(2) : "0.00"}%</span>
                 </div>
                 {metric?.shares && (
-                  <div className="flex flex-wrap gap-2 text-[0.65rem] text-slate-400">
-                    <span className="rounded-full bg-slate-800/60 px-2 py-1">
+                  <div className="flex flex-wrap gap-2 text-[0.65rem] text-sky-600 dark:text-slate-400">
+                    <span className="rounded-full bg-sky-100 px-2 py-1 dark:bg-slate-800/60">
                       Followers {metric.shares.followers.toFixed(1)}%
                     </span>
-                    <span className="rounded-full bg-slate-800/60 px-2 py-1">
+                    <span className="rounded-full bg-sky-100 px-2 py-1 dark:bg-slate-800/60">
                       Likes {metric.shares.likes.toFixed(1)}%
                     </span>
-                    <span className="rounded-full bg-slate-800/60 px-2 py-1">
+                    <span className="rounded-full bg-sky-100 px-2 py-1 dark:bg-slate-800/60">
                       Komentar {metric.shares.comments.toFixed(1)}%
                     </span>
                   </div>
                 )}
-                <div className="mt-auto h-1.5 overflow-hidden rounded-full bg-slate-800">
+                <div className="mt-auto h-1.5 overflow-hidden rounded-full bg-sky-100 dark:bg-slate-800">
                   <div
                     className="h-full rounded-full bg-gradient-to-r from-sky-500 via-cyan-400 to-emerald-300"
                     style={{

--- a/cicero-dashboard/components/SocialPostsCard.tsx
+++ b/cicero-dashboard/components/SocialPostsCard.tsx
@@ -17,21 +17,21 @@ export default function SocialPostsCard({
 
   return (
     <div
-      className={`relative flex h-full flex-col overflow-hidden rounded-3xl border border-slate-800/70 bg-slate-900/60 p-6 shadow-[0_0_32px_rgba(59,130,246,0.15)]${
+      className={`relative flex h-full flex-col overflow-hidden rounded-3xl border border-sky-200/70 bg-white/80 p-6 shadow-[0_26px_55px_rgba(59,130,246,0.18)] dark:border-slate-800/70 dark:bg-slate-900/60 dark:shadow-[0_0_32px_rgba(59,130,246,0.15)]${
         className ? ` ${className}` : ""
       }`}
     >
-      <div className="absolute inset-0 bg-gradient-to-br from-slate-800/40 via-transparent to-slate-900/40" />
-      <div className="absolute -right-20 top-12 h-40 w-40 rounded-full bg-cyan-500/20 blur-3xl" />
+      <div className="absolute inset-0 bg-gradient-to-br from-sky-200/40 via-transparent to-cyan-100/40 dark:from-slate-800/40 dark:to-slate-900/40" />
+      <div className="absolute -right-20 top-12 h-40 w-40 rounded-full bg-sky-300/40 blur-3xl dark:bg-cyan-500/20" />
       <div className="relative flex flex-1 flex-col gap-4">
         <div className="flex items-center justify-between">
-          <h2 className="text-lg font-semibold text-slate-50">{platformLabel} Posts</h2>
-          <span className="text-xs uppercase tracking-[0.3em] text-slate-400">
+          <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-50">{platformLabel} Posts</h2>
+          <span className="text-xs uppercase tracking-[0.3em] text-sky-600 dark:text-slate-400">
             Highlights
           </span>
         </div>
         {posts && posts.length > 0 ? (
-          <div className="rounded-2xl border border-slate-800/60 bg-slate-900/80 p-4">
+          <div className="rounded-2xl border border-sky-200/70 bg-white/75 p-4 shadow-[0_20px_45px_rgba(129,140,248,0.2)] dark:border-slate-800/60 dark:bg-slate-900/80">
             {platform === "instagram" ? (
               <InstagramPostsGrid posts={posts.slice(0, 3)} />
             ) : (
@@ -39,7 +39,7 @@ export default function SocialPostsCard({
             )}
           </div>
         ) : (
-          <div className="rounded-2xl border border-dashed border-slate-700/60 bg-slate-900/60 p-6 text-center text-sm text-slate-300">
+          <div className="rounded-2xl border border-dashed border-sky-200/70 bg-white/70 p-6 text-center text-sm text-sky-700 shadow-[0_20px_45px_rgba(14,165,233,0.16)] dark:border-slate-700/60 dark:bg-slate-900/60 dark:text-slate-300">
             Belum ada posting untuk ditampilkan.
           </div>
         )}

--- a/cicero-dashboard/components/SocialProfileCard.tsx
+++ b/cicero-dashboard/components/SocialProfileCard.tsx
@@ -74,13 +74,13 @@ export default function SocialProfileCard({
 
   if (!profile) {
     const emptyStateClassName =
-      "relative overflow-hidden rounded-3xl border border-slate-800/70 bg-slate-900/60 p-6 text-center text-sm text-slate-300";
+      "relative overflow-hidden rounded-3xl border border-sky-200/70 bg-white/80 p-6 text-center text-sm text-sky-700 shadow-[0_24px_50px_rgba(129,140,248,0.18)] dark:border-slate-800/70 dark:bg-slate-900/60 dark:text-slate-300";
 
     return (
       <div className={`${emptyStateClassName}${className ? ` ${className}` : ""}`}>
-        <div className="absolute inset-0 bg-gradient-to-br from-slate-800/40 to-transparent" />
+        <div className="absolute inset-0 bg-gradient-to-br from-sky-200/40 to-transparent dark:from-slate-800/40" />
         <div className="relative space-y-2">
-          <span className="inline-flex items-center gap-2 rounded-full border border-slate-700/60 bg-slate-900/70 px-3 py-1 text-xs uppercase tracking-[0.3em] text-slate-300">
+          <span className="inline-flex items-center gap-2 rounded-full border border-sky-200/70 bg-white/80 px-3 py-1 text-xs uppercase tracking-[0.3em] text-sky-700 shadow-[0_12px_28px_rgba(79,70,229,0.18)] dark:border-slate-700/60 dark:bg-slate-900/70 dark:text-slate-300">
             {platformLabel} Profile
           </span>
           <p>Data profil belum tersedia.</p>
@@ -112,12 +112,12 @@ export default function SocialProfileCard({
   ];
 
   const baseClassName =
-    "relative flex h-full flex-col overflow-hidden rounded-3xl border border-slate-800/70 bg-slate-900/60 p-6 shadow-[0_0_32px_rgba(79,70,229,0.2)]";
+    "relative flex h-full flex-col overflow-hidden rounded-3xl border border-sky-200/70 bg-white/80 p-6 shadow-[0_28px_60px_rgba(99,102,241,0.18)] dark:border-slate-800/70 dark:bg-slate-900/60 dark:shadow-[0_0_32px_rgba(79,70,229,0.2)]";
 
   return (
     <div className={`${baseClassName}${className ? ` ${className}` : ""}`}>
       <div className={`absolute inset-0 bg-gradient-to-br ${platformGradient} opacity-40`} />
-      <div className="absolute -right-16 top-10 h-32 w-32 rounded-full bg-white/5 blur-3xl" />
+      <div className="absolute -right-16 top-10 h-32 w-32 rounded-full bg-white/40 blur-3xl dark:bg-white/5" />
       <div className="relative flex flex-1 flex-col gap-5">
         <div className="flex flex-wrap items-center gap-4">
           <div className="relative">
@@ -126,31 +126,31 @@ export default function SocialProfileCard({
                 src={avatarSrc}
                 alt="avatar"
                 loading="lazy"
-                className="h-16 w-16 rounded-full border border-white/20 object-cover shadow-[0_0_20px_rgba(255,255,255,0.15)]"
+                className="h-16 w-16 rounded-full border border-white/40 object-cover shadow-[0_18px_36px_rgba(148,163,184,0.25)] dark:border-white/20 dark:shadow-[0_0_20px_rgba(255,255,255,0.15)]"
                 onError={(e) => {
                   e.currentTarget.style.display = "none";
                 }}
               />
             ) : (
-              <div className="flex h-16 w-16 items-center justify-center rounded-full border border-slate-700 bg-slate-900 text-lg text-slate-400">
+              <div className="flex h-16 w-16 items-center justify-center rounded-full border border-sky-200 bg-white text-lg text-sky-600 shadow-[0_10px_28px_rgba(59,130,246,0.2)] dark:border-slate-700 dark:bg-slate-900 dark:text-slate-400">
                 {platformLabel[0] ?? "?"}
               </div>
             )}
-            <span className="absolute -bottom-1 -right-1 inline-flex items-center rounded-full bg-slate-900/90 px-2 py-0.5 text-[0.6rem] uppercase tracking-[0.3em] text-slate-300">
+            <span className="absolute -bottom-1 -right-1 inline-flex items-center rounded-full bg-white/80 px-2 py-0.5 text-[0.6rem] uppercase tracking-[0.3em] text-sky-700 shadow-[0_8px_20px_rgba(14,165,233,0.2)] dark:bg-slate-900/90 dark:text-slate-300">
               {platformLabel}
             </span>
           </div>
           <div className="flex flex-col">
-            {name && <span className="text-lg font-semibold text-slate-50">{name}</span>}
+            {name && <span className="text-lg font-semibold text-slate-900 dark:text-slate-50">{name}</span>}
             <a
               href={profileLink ?? undefined}
               target={profileLink ? "_blank" : undefined}
               rel={profileLink ? "noopener noreferrer" : undefined}
-              className="text-sm text-cyan-300 hover:text-cyan-200"
+              className="text-sm text-sky-600 transition hover:text-sky-800 dark:text-cyan-300 dark:hover:text-cyan-200"
             >
               @{displayUsername || profile.username}
             </a>
-            <div className="flex items-center gap-2 text-xs text-slate-300">
+            <div className="flex items-center gap-2 text-xs text-slate-700 dark:text-slate-300">
               <span
                 className="relative"
                 onMouseEnter={() => setShowTooltip(true)}
@@ -158,12 +158,12 @@ export default function SocialProfileCard({
               >
                 {formatNumber(followers)} followers
                 {showTooltip && (
-                  <span className="absolute left-0 top-full mt-1 w-max rounded-md bg-slate-900/95 px-3 py-1 text-[0.65rem] text-slate-200 shadow-lg">
+                  <span className="absolute left-0 top-full mt-1 w-max rounded-md bg-slate-900/90 px-3 py-1 text-[0.65rem] text-slate-100 shadow-lg">
                     Total pengikut akun
                   </span>
                 )}
               </span>
-              <span className="text-slate-500">•</span>
+              <span className="text-sky-400 dark:text-slate-500">•</span>
               <span>{formatNumber(following)} following</span>
             </div>
           </div>
@@ -172,15 +172,15 @@ export default function SocialProfileCard({
           {badges.map((badge) => (
             <span
               key={badge.label}
-              className="inline-flex items-center gap-2 rounded-full border border-slate-700/60 bg-slate-900/70 px-3 py-1 text-xs text-slate-200"
+              className="inline-flex items-center gap-2 rounded-full border border-sky-200/70 bg-white/80 px-3 py-1 text-xs text-slate-800 shadow-[0_12px_30px_rgba(56,189,248,0.18)] dark:border-slate-700/60 dark:bg-slate-900/70 dark:text-slate-200"
             >
-              <span className="text-slate-400">{badge.label}</span>
-              <span className="font-semibold text-slate-100">{badge.value}</span>
+              <span className="text-sky-600 dark:text-slate-400">{badge.label}</span>
+              <span className="font-semibold text-slate-900 dark:text-slate-100">{badge.value}</span>
             </span>
           ))}
         </div>
         {bio && (
-          <div className="text-sm text-slate-200 whitespace-pre-line">
+          <div className="text-sm text-slate-700 whitespace-pre-line dark:text-slate-200">
             {bio}
           </div>
         )}


### PR DESCRIPTION
## Summary
- restyle the dashboard shell with a pastel gradient backdrop and lighter typography while keeping dark-mode support
- soften platform, snapshot, and top-post cards with airy borders, shadows, and updated accent colors across all social components
- tune shared metric accents to maintain readable contrast on both light and dark surfaces

## Testing
- npm run lint *(fails: command prompts for initial ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68e5d0cde7b88327a82f95762555b4f1