### PR TITLE
Refresh Instagram likes dashboard with pastel theme

### DIFF
--- a/cicero-dashboard/app/likes/instagram/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/page.jsx
@@ -45,8 +45,8 @@ export default function InstagramEngagementInsightPage() {
   if (loading) return <Loader />;
   if (error)
     return (
-      <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 p-6 text-slate-100">
-        <div className="rounded-3xl border border-red-500/40 bg-slate-900/70 px-8 py-6 text-center text-red-200 shadow-[0_0_35px_rgba(248,113,113,0.25)]">
+      <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-sky-50 via-white to-indigo-50 p-6 text-slate-700">
+        <div className="rounded-3xl border border-rose-300/60 bg-white/80 px-8 py-6 text-center text-rose-600 shadow-[0_0_35px_rgba(248,113,113,0.18)] backdrop-blur">
           {error}
         </div>
       </div>
@@ -85,27 +85,27 @@ export default function InstagramEngagementInsightPage() {
   }
 
   return (
-    <div className="relative min-h-screen overflow-hidden bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 text-slate-100">
-      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.18),_transparent_60%)]" />
-      <div className="pointer-events-none absolute inset-y-0 right-0 w-1/2 bg-[radial-gradient(circle_at_center,_rgba(14,165,233,0.12),_transparent_70%)]" />
+    <div className="relative min-h-screen overflow-hidden bg-gradient-to-br from-sky-50 via-white to-indigo-50 text-slate-700">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(125,211,252,0.3),_transparent_65%)]" />
+      <div className="pointer-events-none absolute inset-y-0 right-0 w-1/2 bg-[radial-gradient(circle_at_center,_rgba(165,243,252,0.35),_transparent_70%)]" />
       <div className="relative flex min-h-screen items-start justify-center">
         <div className="w-full max-w-6xl px-4 py-12 md:px-10">
           <div className="flex flex-col gap-10">
-            <div className="relative overflow-hidden rounded-3xl border border-slate-800/80 bg-slate-900/60 p-6 shadow-[0_0_48px_rgba(56,189,248,0.12)] backdrop-blur">
-              <div className="pointer-events-none absolute -top-10 left-8 h-32 w-32 rounded-full bg-sky-500/20 blur-3xl" />
-              <div className="pointer-events-none absolute -bottom-14 right-10 h-36 w-36 rounded-full bg-indigo-500/20 blur-3xl" />
+            <div className="relative overflow-hidden rounded-3xl border border-sky-200/60 bg-white/70 p-6 shadow-[0_0_48px_rgba(96,165,250,0.25)] backdrop-blur">
+              <div className="pointer-events-none absolute -top-10 left-8 h-32 w-32 rounded-full bg-sky-200/50 blur-3xl" />
+              <div className="pointer-events-none absolute -bottom-14 right-10 h-36 w-36 rounded-full bg-indigo-200/50 blur-3xl" />
               <div className="relative flex flex-col gap-6">
                 <header className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
                   <div>
-                    <h1 className="text-3xl font-semibold tracking-tight text-sky-100">
+                    <h1 className="text-3xl font-semibold tracking-tight text-sky-700">
                       Instagram Engagement Insight
                     </h1>
-                    <p className="mt-1 max-w-2xl text-sm text-slate-300">
+                    <p className="mt-1 max-w-2xl text-sm text-slate-600">
                       Pantau performa likes dan komentar harian dengan visualisasi chart bar.
                     </p>
                   </div>
                 </header>
-                <div className="rounded-2xl border border-white/10 bg-white/5 p-4 shadow-inner backdrop-blur">
+                <div className="rounded-2xl border border-sky-100/60 bg-white/60 p-4 shadow-inner backdrop-blur">
                   <ViewDataSelector
                     value={viewBy}
                     onChange={setViewBy}
@@ -130,7 +130,7 @@ export default function InstagramEngagementInsightPage() {
                     value={rekapSummary.totalIGPost}
                     color="blue"
                     icon={
-                      <Camera className="h-7 w-7 text-sky-300 drop-shadow-[0_0_12px_rgba(56,189,248,0.55)]" />
+                      <Camera className="h-7 w-7 text-sky-500 drop-shadow-[0_0_12px_rgba(56,189,248,0.45)]" />
                     }
                   />
                   <SummaryItem
@@ -138,7 +138,7 @@ export default function InstagramEngagementInsightPage() {
                     value={rekapSummary.totalUser}
                     color="gray"
                     icon={
-                      <User className="h-7 w-7 text-slate-200 drop-shadow-[0_0_12px_rgba(148,163,184,0.45)]" />
+                      <User className="h-7 w-7 text-slate-500 drop-shadow-[0_0_12px_rgba(148,163,184,0.35)]" />
                     }
                   />
                   <SummaryItem
@@ -146,7 +146,7 @@ export default function InstagramEngagementInsightPage() {
                     value={rekapSummary.totalSudahLike}
                     color="green"
                     icon={
-                      <ThumbsUp className="h-7 w-7 text-emerald-300 drop-shadow-[0_0_12px_rgba(16,185,129,0.55)]" />
+                      <ThumbsUp className="h-7 w-7 text-teal-500 drop-shadow-[0_0_12px_rgba(45,212,191,0.4)]" />
                     }
                     percentage={getPercentage(rekapSummary.totalSudahLike)}
                   />
@@ -155,7 +155,7 @@ export default function InstagramEngagementInsightPage() {
                     value={rekapSummary.totalKurangLike}
                     color="orange"
                     icon={
-                      <ThumbsDown className="h-7 w-7 text-amber-300 drop-shadow-[0_0_12px_rgba(251,191,36,0.55)]" />
+                      <ThumbsDown className="h-7 w-7 text-sky-500 drop-shadow-[0_0_12px_rgba(56,189,248,0.4)]" />
                     }
                     percentage={getPercentage(rekapSummary.totalKurangLike)}
                   />
@@ -164,7 +164,7 @@ export default function InstagramEngagementInsightPage() {
                     value={rekapSummary.totalBelumLike}
                     color="red"
                     icon={
-                      <ThumbsDown className="h-7 w-7 text-rose-300 drop-shadow-[0_0_12px_rgba(244,63,94,0.55)]" />
+                      <ThumbsDown className="h-7 w-7 text-indigo-400 drop-shadow-[0_0_12px_rgba(129,140,248,0.4)]" />
                     }
                     percentage={getPercentage(rekapSummary.totalBelumLike)}
                   />
@@ -173,7 +173,7 @@ export default function InstagramEngagementInsightPage() {
                     value={rekapSummary.totalTanpaUsername}
                     color="gray"
                     icon={
-                      <UserX className="h-7 w-7 text-slate-200 drop-shadow-[0_0_12px_rgba(148,163,184,0.45)]" />
+                      <UserX className="h-7 w-7 text-slate-500 drop-shadow-[0_0_12px_rgba(148,163,184,0.35)]" />
                     }
                     percentage={getPercentage(
                       rekapSummary.totalTanpaUsername,
@@ -246,16 +246,16 @@ export default function InstagramEngagementInsightPage() {
             <div className="flex justify-end gap-3">
               <button
                 onClick={handleCopyRekap}
-                className="group inline-flex items-center gap-2 rounded-2xl border border-emerald-400/40 bg-emerald-500/20 px-6 py-3 text-lg font-semibold text-emerald-200 shadow-[0_0_25px_rgba(16,185,129,0.35)] transition-colors hover:border-emerald-300/60 hover:bg-emerald-400/30"
+                className="group inline-flex items-center gap-2 rounded-2xl border border-teal-300/60 bg-teal-200/50 px-6 py-3 text-lg font-semibold text-teal-700 shadow-[0_0_25px_rgba(45,212,191,0.35)] transition-colors hover:border-teal-400/70 hover:bg-teal-200/70"
               >
-                <Copy className="h-5 w-5" />
+                <Copy className="h-5 w-5 text-teal-600" />
                 Salin Rekap
               </button>
               <Link
                 href="/likes/instagram/rekap"
-                className="inline-flex items-center gap-2 rounded-2xl border border-sky-400/40 bg-sky-500/20 px-6 py-3 text-lg font-semibold text-sky-200 shadow-[0_0_25px_rgba(56,189,248,0.35)] transition-colors hover:border-sky-300/60 hover:bg-sky-400/30"
+                className="inline-flex items-center gap-2 rounded-2xl border border-sky-300/60 bg-sky-200/50 px-6 py-3 text-lg font-semibold text-sky-700 shadow-[0_0_25px_rgba(96,165,250,0.35)] transition-colors hover:border-sky-400/70 hover:bg-sky-200/70"
               >
-                <ArrowRight className="h-5 w-5" />
+                <ArrowRight className="h-5 w-5 text-sky-600" />
                 Lihat Rekap Detail
               </Link>
             </div>

--- a/cicero-dashboard/components/ChartDataTable.jsx
+++ b/cicero-dashboard/components/ChartDataTable.jsx
@@ -36,26 +36,26 @@ export default function ChartDataTable({
 
   return (
     <details
-      className="group mt-4 rounded-2xl border border-white/10 bg-slate-950/30 p-4 text-slate-200 shadow-inner backdrop-blur"
+      className="group mt-4 rounded-2xl border border-sky-100/60 bg-white/70 p-4 text-slate-700 shadow-inner backdrop-blur"
       open={initialOpen}
     >
-      <summary className="inline-flex cursor-pointer items-center gap-2 rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-sm font-semibold text-slate-100 transition hover:bg-white/10 focus:outline-none focus-visible:ring focus-visible:ring-sky-500/60 focus-visible:ring-offset-0">
+      <summary className="inline-flex cursor-pointer items-center gap-2 rounded-xl border border-sky-100/70 bg-sky-50/70 px-3 py-2 text-sm font-semibold text-sky-700 transition hover:bg-sky-100/80 focus:outline-none focus-visible:ring focus-visible:ring-sky-400/60 focus-visible:ring-offset-0">
         <span
           aria-hidden="true"
-          className="text-xs text-cyan-300 transition-transform duration-200 group-open:rotate-90"
+          className="text-xs text-sky-500 transition-transform duration-200 group-open:rotate-90"
         >
           ▶
         </span>
         {summaryLabel}
       </summary>
       <div className="mt-3 overflow-x-auto">
-        <table className="min-w-full border-collapse text-sm text-slate-100">
+        <table className="min-w-full border-collapse text-sm text-slate-700">
           {title ? (
-            <caption className="mb-2 text-left text-base font-semibold text-sky-200">
+            <caption className="mb-2 text-left text-base font-semibold text-sky-600">
               {title}
             </caption>
           ) : null}
-          <thead className="bg-slate-900/80 text-xs font-semibold uppercase tracking-[0.2em] text-slate-200">
+          <thead className="bg-sky-100/70 text-xs font-semibold uppercase tracking-[0.2em] text-slate-600">
             <tr>
               {normalizedColumns.map((column) => (
                 <th
@@ -68,11 +68,11 @@ export default function ChartDataTable({
               ))}
             </tr>
           </thead>
-          <tbody className="divide-y divide-white/10 bg-slate-950/50">
+          <tbody className="divide-y divide-sky-100 bg-white/60">
             {rows.map((row, rowIndex) => (
               <tr
                 key={row.id ?? row.key ?? rowIndex}
-                className={rowIndex % 2 === 0 ? "bg-slate-950/40" : "bg-slate-900/40"}
+                className={rowIndex % 2 === 0 ? "bg-sky-50/70" : "bg-white/80"}
               >
                 {normalizedColumns.map((column, columnIndex) => {
                   const cellValue = row[column.key];
@@ -85,7 +85,7 @@ export default function ChartDataTable({
                       <th
                         key={column.key}
                         scope="row"
-                        className={`${baseClass} font-semibold text-sky-100`}
+                        className={`${baseClass} font-semibold text-sky-700`}
                       >
                         {content}
                       </th>
@@ -93,7 +93,7 @@ export default function ChartDataTable({
                   }
 
                   return (
-                    <td key={column.key} className={`${baseClass} whitespace-nowrap text-slate-200`}>
+                    <td key={column.key} className={`${baseClass} whitespace-nowrap text-slate-600`}>
                       {content}
                     </td>
                   );

--- a/cicero-dashboard/components/ChartDivisiAbsensi.jsx
+++ b/cicero-dashboard/components/ChartDivisiAbsensi.jsx
@@ -289,8 +289,10 @@ export default function ChartDivisiAbsensi({
   });
 
   return (
-    <div className="w-full bg-white rounded-xl shadow p-0 md:p-0 mt-8">
-      <div className="w-full px-2 pb-4">
+    <div className="relative mt-8 w-full overflow-hidden rounded-3xl border border-sky-100/60 bg-white/70 p-6 shadow-[0_25px_55px_-30px_rgba(56,189,248,0.45)] backdrop-blur">
+      <div className="pointer-events-none absolute -right-16 top-8 h-40 w-40 rounded-full bg-sky-200/50 blur-3xl" />
+      <div className="pointer-events-none absolute inset-x-12 top-0 h-16 bg-gradient-to-b from-white/60 to-transparent blur-2xl" />
+      <div className="relative w-full px-2 pb-4">
         <ResponsiveContainer width="100%" height={chartHeight}>
           <BarChart
             data={dataChart}
@@ -303,9 +305,15 @@ export default function ChartDivisiAbsensi({
             }}
             barCategoryGap={isHorizontal ? "30%" : "16%"}
           >
-            <CartesianGrid strokeDasharray="3 3" />
+            <CartesianGrid strokeDasharray="3 3" stroke="rgba(148,163,184,0.35)" />
             {isHorizontal ? (
-              <XAxis type="number" fontSize={12} />
+              <XAxis
+                type="number"
+                fontSize={12}
+                tick={{ fill: "#1e293b" }}
+                axisLine={{ stroke: "rgba(148,163,184,0.4)" }}
+                tickLine={{ stroke: "rgba(148,163,184,0.4)" }}
+              />
             ) : (
               <XAxis
                 dataKey={labelKey}
@@ -315,6 +323,8 @@ export default function ChartDivisiAbsensi({
                 interval={0}
                 height={70}
                 tick={{ fontSize: 15, fontWeight: 700, fill: "#1e293b" }}
+                axisLine={{ stroke: "rgba(148,163,184,0.4)" }}
+                tickLine={{ stroke: "rgba(148,163,184,0.4)" }}
               />
             )}
             {isHorizontal ? (
@@ -340,7 +350,13 @@ export default function ChartDivisiAbsensi({
                 )}
               />
             ) : (
-              <YAxis type="number" fontSize={12} />
+              <YAxis
+                type="number"
+                fontSize={12}
+                tick={{ fill: "#1e293b" }}
+                axisLine={{ stroke: "rgba(148,163,184,0.4)" }}
+                tickLine={{ stroke: "rgba(148,163,184,0.4)" }}
+              />
             )}
             <Tooltip
               formatter={(value, name) =>
@@ -362,8 +378,16 @@ export default function ChartDivisiAbsensi({
               labelFormatter={(label) =>
                 `${labelKey === "client_name" ? "Client" : "Divisi"}: ${label}`
               }
+              wrapperStyle={{ outline: "none" }}
+              contentStyle={{
+                backgroundColor: "rgba(255,255,255,0.95)",
+                borderRadius: 16,
+                borderColor: "rgba(56,189,248,0.35)",
+                boxShadow: "0 20px 45px rgba(56,189,248,0.25)",
+                color: "#0f172a",
+              }}
             />
-            <Legend />
+            <Legend wrapperStyle={{ color: "#1d4ed8", paddingTop: 8 }} />
             {showTotalUser && (
               <Bar
                 dataKey="total_user"
@@ -380,7 +404,7 @@ export default function ChartDivisiAbsensi({
             )}
             <Bar
               dataKey="user_sudah"
-              fill="#22c55e"
+              fill="#14b8a6"
               name={labelSudah}
               barSize={isHorizontal ? 20 * thicknessMultiplier : undefined}
             >
@@ -392,7 +416,7 @@ export default function ChartDivisiAbsensi({
             </Bar>
             <Bar
               dataKey="user_kurang"
-              fill="#f97316"
+              fill="#38bdf8"
               name={labelKurang}
               barSize={isHorizontal ? 20 * thicknessMultiplier : undefined}
             >
@@ -404,7 +428,7 @@ export default function ChartDivisiAbsensi({
             </Bar>
             <Bar
               dataKey="user_belum"
-              fill="#ef4444"
+              fill="#94a3b8"
               name={labelBelum}
               barSize={isHorizontal ? 20 * thicknessMultiplier : undefined}
             >
@@ -416,7 +440,7 @@ export default function ChartDivisiAbsensi({
             </Bar>
             <Bar
               dataKey="total_value"
-              fill="#2563eb"
+              fill="#6366f1"
               name={labelTotal}
               barSize={isHorizontal ? 20 * thicknessMultiplier : undefined}
             >

--- a/cicero-dashboard/components/ChartHorizontal.jsx
+++ b/cicero-dashboard/components/ChartHorizontal.jsx
@@ -127,11 +127,11 @@ export default function ChartHorizontal({
   });
 
   return (
-    <div className="relative mt-8 w-full overflow-hidden rounded-3xl border border-slate-800/60 bg-slate-900/60 p-6 shadow-[0_0_32px_rgba(56,189,248,0.08)] backdrop-blur">
-      <div className="pointer-events-none absolute -right-16 top-8 h-40 w-40 rounded-full bg-sky-500/15 blur-3xl" />
-      <div className="pointer-events-none absolute inset-x-12 top-0 h-16 bg-gradient-to-b from-white/10 to-transparent blur-2xl" />
+    <div className="relative mt-8 w-full overflow-hidden rounded-3xl border border-sky-100/60 bg-white/70 p-6 shadow-[0_25px_55px_-30px_rgba(56,189,248,0.45)] backdrop-blur">
+      <div className="pointer-events-none absolute -right-16 top-8 h-40 w-40 rounded-full bg-sky-200/50 blur-3xl" />
+      <div className="pointer-events-none absolute inset-x-12 top-0 h-16 bg-gradient-to-b from-white/60 to-transparent blur-2xl" />
       <div className="relative flex flex-col gap-6">
-        <h3 className="text-center text-sm font-semibold uppercase tracking-[0.4em] text-cyan-200/80">
+        <h3 className="text-center text-sm font-semibold uppercase tracking-[0.4em] text-sky-600">
           {title}
         </h3>
         <div className="w-full">
@@ -142,12 +142,12 @@ export default function ChartHorizontal({
               margin={{ top: 8, right: 24, left: 0, bottom: 8 }}
               barCategoryGap="16%"
             >
-            <CartesianGrid strokeDasharray="3 3" stroke="rgba(148,163,184,0.25)" />
+            <CartesianGrid strokeDasharray="3 3" stroke="rgba(148,163,184,0.35)" />
             <XAxis
               type="number"
-              tick={{ fill: "#cbd5f5", fontSize: 12 }}
-              axisLine={{ stroke: "rgba(148,163,184,0.3)" }}
-              tickLine={{ stroke: "rgba(148,163,184,0.3)" }}
+              tick={{ fill: "#1e293b", fontSize: 12 }}
+              axisLine={{ stroke: "rgba(148,163,184,0.4)" }}
+              tickLine={{ stroke: "rgba(148,163,184,0.4)" }}
             />
             <YAxis
               dataKey="divisi"
@@ -161,7 +161,7 @@ export default function ChartHorizontal({
                     x={x - 160} // mundur sedikit agar makin lepas dari bar
                     y={y + 10}
                     fontSize={12}
-                    fill="#cbd5f5"
+                    fill="#1f2937"
                     style={{ fontWeight: 500 }}
                     textAnchor="start"
                   >
@@ -190,16 +190,16 @@ export default function ChartHorizontal({
               labelFormatter={(label) => `Divisi: ${label}`}
               wrapperStyle={{ outline: "none" }}
               contentStyle={{
-                backgroundColor: "rgba(15,23,42,0.92)",
+                backgroundColor: "rgba(255,255,255,0.95)",
                 borderRadius: 16,
-                borderColor: "rgba(148,163,184,0.4)",
-                boxShadow: "0 20px 45px rgba(15,118,110,0.2)",
-                color: "#e2e8f0",
+                borderColor: "rgba(56,189,248,0.35)",
+                boxShadow: "0 20px 45px rgba(56,189,248,0.25)",
+                color: "#0f172a",
               }}
             />
             <Legend
               wrapperStyle={{
-                color: "#cbd5f5",
+                color: "#1d4ed8",
                 paddingTop: 8,
               }}
             />
@@ -217,21 +217,21 @@ export default function ChartHorizontal({
                 />
               </Bar>
             )}
-            <Bar dataKey="user_sudah" fill="#22c55e" name={labelSudah} barSize={10}>
+            <Bar dataKey="user_sudah" fill="#14b8a6" name={labelSudah} barSize={10}>
               <LabelList dataKey="user_sudah" position="right" fontSize={10} />
             </Bar>
             <Bar
               dataKey="user_kurang"
-              fill="#f97316"
+              fill="#38bdf8"
               name={labelKurang}
               barSize={10}
             >
               <LabelList dataKey="user_kurang" position="right" fontSize={10} />
             </Bar>
-            <Bar dataKey="total_value" fill="#2563eb" name={labelTotal} barSize={10}>
+            <Bar dataKey="total_value" fill="#6366f1" name={labelTotal} barSize={10}>
               <LabelList dataKey="total_value" position="right" fontSize={10} />
             </Bar>
-            <Bar dataKey="user_belum" fill="#ef4444" name={labelBelum} barSize={10}>
+            <Bar dataKey="user_belum" fill="#94a3b8" name={labelBelum} barSize={10}>
               <LabelList dataKey="user_belum" position="right" fontSize={10} />
             </Bar>
           </BarChart>

--- a/cicero-dashboard/components/Narrative.jsx
+++ b/cicero-dashboard/components/Narrative.jsx
@@ -1,7 +1,7 @@
 "use client";
 export default function Narrative({ children }) {
   return (
-    <p className="mt-2 text-sm italic leading-snug text-slate-300">
+    <p className="mt-2 text-sm italic leading-snug text-slate-600">
       {children}
     </p>
   );

--- a/cicero-dashboard/components/ViewDataSelector.jsx
+++ b/cicero-dashboard/components/ViewDataSelector.jsx
@@ -76,11 +76,11 @@ export default function ViewDataSelector({
     className,
   );
   const baseLabelClass = cn(
-    "text-sm font-semibold w-full sm:w-auto",
+    "text-sm font-semibold text-sky-700 w-full sm:w-auto",
     labelClassName,
   );
   const baseControlClass = cn(
-    "w-full rounded border px-2 py-1 text-sm transition sm:w-auto",
+    "w-full rounded border border-sky-200 bg-white/80 px-2 py-1 text-sm text-slate-700 transition focus:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-200 sm:w-auto",
     controlClassName,
   );
 

--- a/cicero-dashboard/components/likes/instagram/ChartBox.jsx
+++ b/cicero-dashboard/components/likes/instagram/ChartBox.jsx
@@ -5,8 +5,8 @@ import { cn } from "@/lib/utils";
 
 const defaultDecorations = (
   <>
-    <div className="pointer-events-none absolute -right-12 top-6 h-32 w-32 rounded-full bg-cyan-500/10 blur-3xl" />
-    <div className="pointer-events-none absolute inset-x-10 top-0 h-16 bg-gradient-to-b from-white/10 to-transparent blur-2xl" />
+    <div className="pointer-events-none absolute -right-12 top-6 h-32 w-32 rounded-full bg-cyan-200/50 blur-3xl" />
+    <div className="pointer-events-none absolute inset-x-10 top-0 h-16 bg-gradient-to-b from-white/60 to-transparent blur-2xl" />
   </>
 );
 
@@ -29,14 +29,14 @@ export default function ChartBox({
   emptyStateClassName,
   useDefaultContainerStyle = true,
   decorations = defaultDecorations,
-  titleClassName = "text-cyan-200/80",
+  titleClassName = "text-sky-600",
 }) {
   return (
     <div
       className={cn(
         "relative overflow-hidden rounded-3xl",
         useDefaultContainerStyle &&
-          "p-6 border border-slate-800/60 bg-slate-900/60 shadow-[0_0_32px_rgba(56,189,248,0.08)] backdrop-blur",
+          "p-6 border border-sky-100/60 bg-white/70 shadow-[0_25px_55px_-30px_rgba(56,189,248,0.45)] backdrop-blur",
         containerClassName,
       )}
     >
@@ -68,7 +68,7 @@ export default function ChartBox({
       ) : (
         <div
           className={cn(
-            "relative text-center text-sm text-slate-400",
+            "relative text-center text-sm text-slate-500",
             emptyStateClassName,
           )}
         >

--- a/cicero-dashboard/components/likes/instagram/SummaryItem.jsx
+++ b/cicero-dashboard/components/likes/instagram/SummaryItem.jsx
@@ -6,57 +6,57 @@ import { cn } from "@/lib/utils";
 
 const defaultPalettes = {
   blue: {
-    icon: "text-sky-300",
-    border: "border-sky-500/40",
-    glow: "from-sky-500/25 via-sky-500/10 to-transparent",
-    bar: "from-sky-400 to-cyan-400",
+    icon: "text-sky-600",
+    border: "border-sky-300/60",
+    glow: "from-sky-200/60 via-sky-100/30 to-transparent",
+    bar: "from-sky-400 to-cyan-300",
   },
   green: {
-    icon: "text-emerald-300",
-    border: "border-emerald-500/40",
-    glow: "from-emerald-500/25 via-emerald-500/10 to-transparent",
-    bar: "from-emerald-400 to-lime-400",
+    icon: "text-teal-600",
+    border: "border-teal-300/60",
+    glow: "from-teal-200/60 via-teal-100/30 to-transparent",
+    bar: "from-teal-400 to-emerald-300",
   },
   red: {
-    icon: "text-rose-300",
-    border: "border-rose-500/40",
-    glow: "from-rose-500/25 via-rose-500/10 to-transparent",
-    bar: "from-rose-400 to-orange-400",
+    icon: "text-rose-500",
+    border: "border-rose-300/60",
+    glow: "from-rose-200/60 via-rose-100/30 to-transparent",
+    bar: "from-rose-400 to-pink-300",
   },
   gray: {
-    icon: "text-slate-300",
-    border: "border-slate-500/40",
-    glow: "from-slate-500/20 via-slate-500/10 to-transparent",
+    icon: "text-slate-500",
+    border: "border-slate-200/60",
+    glow: "from-slate-200/60 via-slate-100/30 to-transparent",
     bar: "from-slate-300 to-slate-400",
   },
   orange: {
-    icon: "text-amber-200",
-    border: "border-amber-400/40",
-    glow: "from-amber-400/25 via-amber-500/10 to-transparent",
-    bar: "from-amber-300 to-orange-400",
+    icon: "text-amber-500",
+    border: "border-amber-300/60",
+    glow: "from-amber-200/60 via-amber-100/30 to-transparent",
+    bar: "from-amber-300 to-orange-300",
   },
   amber: {
-    icon: "text-amber-200",
-    border: "border-amber-400/40",
-    glow: "from-amber-400/20 via-amber-500/10 to-transparent",
-    bar: "from-amber-300 to-orange-400",
+    icon: "text-amber-500",
+    border: "border-amber-300/60",
+    glow: "from-amber-200/60 via-amber-100/30 to-transparent",
+    bar: "from-amber-300 to-orange-300",
   },
   fuchsia: {
-    icon: "text-fuchsia-300",
-    border: "border-fuchsia-500/40",
-    glow: "from-fuchsia-500/20 via-fuchsia-500/10 to-transparent",
-    bar: "from-fuchsia-400 to-pink-500",
+    icon: "text-fuchsia-500",
+    border: "border-fuchsia-300/60",
+    glow: "from-fuchsia-200/60 via-fuchsia-100/30 to-transparent",
+    bar: "from-fuchsia-400 to-pink-300",
   },
   violet: {
-    icon: "text-violet-300",
-    border: "border-violet-500/40",
-    glow: "from-violet-500/20 via-violet-500/10 to-transparent",
-    bar: "from-violet-400 to-purple-500",
+    icon: "text-violet-500",
+    border: "border-violet-300/60",
+    glow: "from-violet-200/60 via-violet-100/30 to-transparent",
+    bar: "from-violet-400 to-purple-300",
   },
   slate: {
-    icon: "text-slate-300",
-    border: "border-slate-500/40",
-    glow: "from-slate-500/20 via-slate-500/10 to-transparent",
+    icon: "text-slate-500",
+    border: "border-slate-200/60",
+    glow: "from-slate-200/60 via-slate-100/30 to-transparent",
     bar: "from-slate-300 to-slate-400",
   },
 };
@@ -91,7 +91,7 @@ export default function SummaryItem({
       className={cn(
         "relative overflow-hidden rounded-3xl p-5 transition duration-300",
         useDefaultContainerStyle &&
-          "border border-slate-800/70 bg-slate-900/70 shadow-[0_0_24px_rgba(56,189,248,0.25)] hover:-translate-y-1 hover:shadow-[0_0_36px_rgba(56,189,248,0.3)]",
+          "border border-sky-100/60 bg-white/70 shadow-[0_20px_45px_-20px_rgba(56,189,248,0.35)] backdrop-blur hover:-translate-y-1 hover:shadow-[0_25px_55px_-25px_rgba(56,189,248,0.45)]",
         containerClassName,
       )}
     >
@@ -104,29 +104,29 @@ export default function SummaryItem({
       <div className="relative flex flex-col gap-3">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
-            <span className="flex h-11 w-11 items-center justify-center rounded-2xl bg-slate-950/80">
+            <span className="flex h-11 w-11 items-center justify-center rounded-2xl bg-sky-100/80">
               {iconElement}
             </span>
-            <div className="text-[11px] font-semibold uppercase tracking-[0.35em] text-slate-400">
+            <div className="text-[11px] font-semibold uppercase tracking-[0.35em] text-slate-500">
               {label}
             </div>
           </div>
           <span
             className={cn(
-              "h-10 w-10 rounded-full border bg-slate-950/70",
+              "h-10 w-10 rounded-full border bg-sky-100/60",
               palette.border,
             )}
           />
         </div>
-        <div className="text-3xl font-semibold text-slate-50 md:text-4xl">
+        <div className="text-3xl font-semibold text-slate-800 md:text-4xl">
           {value}
         </div>
         {formattedPercentage && (
           <div className="mt-1 flex flex-col gap-2">
-            <span className="text-[11px] font-medium text-slate-300">
+            <span className="text-[11px] font-medium text-slate-600">
               {formattedPercentage}
             </span>
-            <div className="h-1.5 w-full rounded-full bg-slate-800/80">
+            <div className="h-1.5 w-full rounded-full bg-slate-200">
               <div
                 className={cn(
                   "h-full rounded-full bg-gradient-to-r",


### PR DESCRIPTION
## Summary
- restyle the Instagram likes insight page with pastel gradients and softer typography
- refresh summary cards, charts, and data tables with light semi-transparent surfaces and blue/teal accents
- align chart palettes, tooltips, and selectors for a cohesive social media-inspired theme

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68e5e4b146788327a2abcf43bfaef609