### PR TITLE
feat: refresh instagram rekap gradient palette

### DIFF
--- a/cicero-dashboard/app/likes/instagram/rekap/page.jsx
+++ b/cicero-dashboard/app/likes/instagram/rekap/page.jsx
@@ -200,25 +200,27 @@ export default function RekapLikesIGPage() {
   if (loading) return <Loader />;
   if (error)
     return (
-      <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-sky-50 via-white to-blue-100 p-6 text-slate-700">
-        <div className="rounded-3xl border border-red-300/60 bg-white/80 px-8 py-6 text-center text-red-600 shadow-[0_15px_35px_rgba(59,130,246,0.12)]">
+      <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-blue-50 via-white to-violet-50 p-6 text-slate-700">
+        <div className="rounded-3xl border border-red-300/60 bg-white/90 px-8 py-6 text-center text-red-600 shadow-[0_18px_40px_rgba(129,140,248,0.16)]">
           {error}
         </div>
       </div>
     );
   return (
-    <div className="relative min-h-screen overflow-hidden bg-gradient-to-br from-sky-50 via-white to-blue-100 text-slate-800">
-      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(125,211,252,0.25),_transparent_70%)]" />
-      <div className="pointer-events-none absolute bottom-0 left-1/2 h-96 w-96 -translate-x-1/2 rounded-full bg-[radial-gradient(circle,_rgba(96,165,250,0.2)_0%,_transparent_80%)]" />
+    <div className="relative min-h-screen overflow-hidden bg-gradient-to-br from-blue-50 via-white to-violet-50 text-slate-800">
+      <div className="pointer-events-none absolute inset-x-0 -top-10 h-72 bg-[radial-gradient(circle_at_top,_rgba(59,130,246,0.25),_transparent_65%)]" />
+      <div className="pointer-events-none absolute inset-x-0 bottom-0 h-80 bg-[radial-gradient(circle_at_bottom,_rgba(129,140,248,0.2),_transparent_70%)]" />
+      <div className="pointer-events-none absolute left-1/2 top-1/2 h-96 w-96 -translate-x-1/2 -translate-y-1/2 rounded-full bg-[radial-gradient(circle,_rgba(45,212,191,0.18)_0%,_transparent_75%)]" />
       <div className="relative mx-auto flex min-h-screen w-full max-w-6xl flex-col px-4 py-12 md:px-10">
         <div className="flex flex-col gap-10">
-          <div className="relative overflow-hidden rounded-3xl border border-sky-200/80 bg-white/70 p-6 shadow-[0_20px_50px_rgba(56,189,248,0.18)] backdrop-blur">
-            <div className="pointer-events-none absolute -top-16 left-0 h-40 w-40 rounded-full bg-sky-200/50 blur-3xl" />
-            <div className="pointer-events-none absolute -bottom-20 right-8 h-48 w-48 rounded-full bg-teal-200/50 blur-3xl" />
+          <div className="relative overflow-hidden rounded-3xl border border-blue-200/70 bg-white/90 p-6 shadow-[0_24px_60px_rgba(59,130,246,0.15)] backdrop-blur">
+            <div className="pointer-events-none absolute -top-16 left-0 h-40 w-40 rounded-full bg-blue-200/50 blur-3xl" />
+            <div className="pointer-events-none absolute -bottom-20 right-8 h-48 w-48 rounded-full bg-emerald-200/45 blur-3xl" />
+            <div className="pointer-events-none absolute inset-x-12 top-0 h-1 rounded-full bg-gradient-to-r from-sky-300/60 via-blue-400/50 to-violet-300/60" />
             <div className="relative flex flex-col gap-6">
               <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
                 <div>
-                  <h1 className="text-3xl font-semibold tracking-tight text-sky-900">
+                  <h1 className="text-3xl font-semibold tracking-tight text-blue-900">
                     Rekapitulasi Engagement Instagram
                   </h1>
                   <p className="mt-1 max-w-2xl text-sm text-slate-600">
@@ -227,13 +229,13 @@ export default function RekapLikesIGPage() {
                 </div>
                 <Link
                   href="/likes/instagram"
-                  className="inline-flex items-center gap-2 rounded-2xl border border-sky-300 bg-white px-4 py-2 text-sm font-semibold text-sky-700 shadow-[0_12px_30px_rgba(59,130,246,0.18)] transition hover:border-sky-400 hover:bg-sky-50 hover:text-sky-800"
+                  className="inline-flex items-center gap-2 rounded-2xl border border-blue-200/80 bg-white px-4 py-2 text-sm font-semibold text-blue-900 shadow-[0_12px_32px_rgba(129,140,248,0.18)] transition hover:border-violet-200 hover:bg-blue-50 hover:shadow-[0_16px_42px_rgba(129,140,248,0.24)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-200"
                 >
                   <ArrowLeft className="h-4 w-4" />
                   Kembali
                 </Link>
               </div>
-              <div className="rounded-2xl border border-sky-100 bg-white/80 p-4 shadow-inner backdrop-blur">
+              <div className="rounded-2xl border border-blue-100/80 bg-white/90 p-4 shadow-inner backdrop-blur">
                 <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
                   <ViewDataSelector
                     value={viewBy}
@@ -244,13 +246,13 @@ export default function RekapLikesIGPage() {
                   />
                   {isDitbinmasRole && (
                     <div className="flex w-full flex-col gap-2 md:w-64">
-                      <label className="text-sm font-semibold text-slate-700">
+                      <label className="text-sm font-semibold text-blue-900">
                         Lingkup Data
                       </label>
                       <select
                         value={ditbinmasScope}
                         onChange={handleDitbinmasScopeChange}
-                        className="w-full rounded-xl border border-sky-200 bg-white/80 px-3 py-2 text-sm text-slate-700 shadow-inner outline-none transition focus:border-sky-400 focus:ring-2 focus:ring-sky-200 hover:border-sky-300"
+                        className="w-full rounded-xl border border-blue-200/70 bg-white/90 px-3 py-2 text-sm text-slate-700 shadow-inner outline-none transition focus:border-blue-400 focus:ring-2 focus:ring-blue-200/60 hover:border-violet-200"
                       >
                         {ditbinmasScopeOptions.map((option) => (
                           <option key={option.value} value={option.value}>


### PR DESCRIPTION
## Summary
- refresh the instagram rekap page background with a blue-to-violet gradient and layered radial highlights
- modernize the primary card styling with softer white paneling, updated shadow, and an accent gradient strip
- align headings, controls, and the back button with the refreshed professional blue palette

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68e5ef5210c08327ab0c512190922858