### PR TITLE
Refresh TikTok recap visuals with pastel interface

### DIFF
--- a/cicero-dashboard/app/comments/tiktok/rekap/page.jsx
+++ b/cicero-dashboard/app/comments/tiktok/rekap/page.jsx
@@ -437,15 +437,15 @@ export default function RekapKomentarTiktokPage() {
   if (loading) return <Loader />;
   if (error)
     return (
-      <div className="flex min-h-screen items-center justify-center bg-slate-950 p-6 text-slate-100">
-        <div className="relative w-full max-w-lg overflow-hidden rounded-3xl border border-rose-500/40 bg-slate-900/80 p-8 text-center shadow-[0_0_40px_rgba(244,63,94,0.25)]">
-          <div className="absolute inset-x-12 -top-8 h-24 rounded-full bg-gradient-to-b from-rose-500/30 to-transparent blur-2xl" />
+      <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-sky-50 via-indigo-50 to-violet-50 p-6 text-slate-800">
+        <div className="relative w-full max-w-lg overflow-hidden rounded-3xl border border-rose-100 bg-rose-50 p-8 text-center text-rose-600 shadow-xl">
+          <div className="pointer-events-none absolute inset-x-10 -top-16 h-32 rounded-full bg-rose-200/40 blur-3xl" />
           <div className="relative space-y-3">
-            <p className="text-xs font-semibold uppercase tracking-[0.4em] text-rose-200/80">
+            <p className="text-xs font-semibold uppercase tracking-[0.4em] text-rose-400">
               System Alert
             </p>
-            <p className="text-lg font-semibold text-rose-100">{error}</p>
-            <p className="text-sm text-slate-300">
+            <p className="text-lg font-semibold">{error}</p>
+            <p className="text-sm text-rose-500">
               Coba muat ulang halaman atau periksa kembali koneksi data Anda.
             </p>
           </div>
@@ -454,24 +454,24 @@ export default function RekapKomentarTiktokPage() {
     );
 
   return (
-    <div className="relative min-h-screen overflow-hidden bg-slate-950 text-slate-100">
+    <div className="relative min-h-screen overflow-hidden bg-gradient-to-br from-sky-50 via-indigo-50 to-violet-50 text-slate-800">
       <div className="pointer-events-none absolute inset-0">
-        <div className="absolute -left-32 top-[-100px] h-[360px] w-[360px] rounded-full bg-fuchsia-500/20 blur-[150px]" />
-        <div className="absolute right-[-120px] top-1/4 h-[400px] w-[400px] rounded-full bg-cyan-500/20 blur-[160px]" />
-        <div className="absolute inset-x-0 bottom-[-200px] h-[320px] bg-gradient-to-t from-slate-900 via-slate-950/60 to-transparent" />
+        <div className="absolute -left-40 top-[-120px] h-[320px] w-[320px] rounded-full bg-sky-200/40 blur-3xl" />
+        <div className="absolute right-[-80px] top-1/4 h-[360px] w-[360px] rounded-full bg-indigo-200/40 blur-3xl" />
+        <div className="absolute inset-x-0 bottom-[-160px] h-[260px] bg-gradient-to-t from-violet-100/60 via-transparent to-transparent" />
       </div>
       <div className="relative z-10 mx-auto flex w-full max-w-6xl flex-col gap-8 px-4 pb-16 pt-10 sm:px-6 lg:px-10">
         <div className="flex flex-col gap-4">
           <div className="flex flex-col gap-3">
-            <span className="inline-flex w-fit items-center gap-2 rounded-full border border-fuchsia-400/40 bg-fuchsia-500/10 px-4 py-1 text-[11px] font-semibold uppercase tracking-[0.4em] text-fuchsia-200">
+            <span className="inline-flex w-fit items-center gap-2 rounded-full border border-indigo-200 bg-white/80 px-4 py-1 text-[11px] font-semibold uppercase tracking-[0.4em] text-indigo-500 shadow-sm">
               Rekap Komentar
             </span>
             <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
               <div className="space-y-2">
-                <h1 className="text-3xl font-semibold leading-tight text-slate-50 md:text-4xl">
+                <h1 className="text-3xl font-semibold leading-tight text-slate-900 md:text-4xl">
                   Rekapitulasi Komentar TikTok
                 </h1>
-                <p className="max-w-3xl text-sm text-slate-300 md:text-base">
+                <p className="max-w-3xl text-sm text-slate-600 md:text-base">
                   Pantau laporan engagement Tiktok harian / rentang tanggal tertentu.
                   Panel rekap memberikan ringkasan kepatuhan serta detail pengguna
                   sehingga Anda bisa menindaklanjuti satker dan personil yang belum / kurang aktif.
@@ -479,7 +479,7 @@ export default function RekapKomentarTiktokPage() {
               </div>
               <Link
                 href="/comments/tiktok"
-                className="group inline-flex items-center gap-2 rounded-2xl border border-slate-700/70 bg-slate-900/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-slate-200 transition hover:border-fuchsia-400/60 hover:bg-fuchsia-500/10"
+                className="group inline-flex items-center gap-2 rounded-2xl border border-indigo-200 bg-white px-4 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-indigo-600 shadow-sm transition hover:border-indigo-300 hover:bg-indigo-50"
               >
                 <ArrowLeft className="h-4 w-4 transition-transform group-hover:-translate-x-1" />
                 Kembali
@@ -493,17 +493,17 @@ export default function RekapKomentarTiktokPage() {
             options={viewOptions}
             date={selectorDateValue}
             onDateChange={handleDateChange}
-            className="justify-start gap-3 rounded-3xl border border-slate-800/70 bg-slate-900/70 px-4 py-4 backdrop-blur"
-            labelClassName="text-xs font-semibold uppercase tracking-[0.35em] text-slate-400/90"
-            controlClassName="border-slate-700/60 bg-slate-900/70 text-slate-100 focus:border-fuchsia-400 focus:outline-none focus:ring-2 focus:ring-fuchsia-500/30"
+            className="justify-start gap-3 rounded-3xl border border-indigo-100 bg-white/90 px-4 py-4 shadow-sm"
+            labelClassName="text-xs font-semibold uppercase tracking-[0.35em] text-slate-600"
+            controlClassName="border-indigo-200 bg-white text-slate-800 focus:border-sky-200 focus:outline-none focus:ring-2 focus:ring-sky-200/60"
           />
           {isDitbinmasUser ? (
-            <div className="flex flex-col gap-2 rounded-3xl border border-slate-800/70 bg-slate-900/70 px-4 py-4 backdrop-blur sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex flex-col gap-2 rounded-3xl border border-indigo-100 bg-white/90 px-4 py-4 shadow-sm sm:flex-row sm:items-center sm:justify-between">
               <div className="space-y-1">
-                <p className="text-xs font-semibold uppercase tracking-[0.35em] text-slate-400/90">
+                <p className="text-xs font-semibold uppercase tracking-[0.35em] text-slate-600">
                   Scope Data Ditbinmas
                 </p>
-                <p className="text-xs text-slate-400">
+                <p className="text-xs text-slate-500">
                   Pilih apakah ingin menampilkan data hanya untuk client Anda atau seluruh Ditbinmas.
                 </p>
               </div>
@@ -514,7 +514,7 @@ export default function RekapKomentarTiktokPage() {
                     event.target.value === "all" ? "all" : "client",
                   )
                 }
-                className="w-full rounded-2xl border border-slate-700/60 bg-slate-900/70 px-3 py-2 text-sm font-medium text-slate-100 transition focus:border-fuchsia-400 focus:outline-none focus:ring-2 focus:ring-fuchsia-500/30 sm:w-auto"
+                className="w-full rounded-2xl border border-indigo-200 bg-white px-3 py-2 text-sm font-medium text-slate-800 transition focus:border-sky-200 focus:outline-none focus:ring-2 focus:ring-sky-200/60 sm:w-auto"
               >
                 <option value="client">Client Saya</option>
                 <option value="all">Seluruh Ditbinmas</option>

--- a/cicero-dashboard/components/RekapKomentarTiktok.jsx
+++ b/cicero-dashboard/components/RekapKomentarTiktok.jsx
@@ -125,9 +125,9 @@ export default function RekapKomentarTiktok({
         description:
           "Silakan cek kembali periode laporan atau pastikan sumber data sudah terhubung.",
         containerClass:
-          "border border-fuchsia-500/30 bg-slate-950/60 text-slate-200 backdrop-blur",
+          "border border-indigo-100 bg-white text-slate-600 shadow-sm",
         badgeClass:
-          "bg-fuchsia-500/10 border border-fuchsia-400/40 text-fuchsia-200",
+          "bg-indigo-50 border border-indigo-200 text-indigo-600",
       }
     : showSearchEmptyState
     ? {
@@ -138,9 +138,9 @@ export default function RekapKomentarTiktok({
             : "Tidak ada data yang cocok dengan filter saat ini.",
         description: "Coba ubah kata kunci atau atur ulang filter pencarian.",
         containerClass:
-          "border border-cyan-500/30 bg-slate-950/60 text-slate-200 backdrop-blur",
+          "border border-sky-100 bg-white text-slate-600 shadow-sm",
         badgeClass:
-          "bg-cyan-500/10 border border-cyan-400/40 text-cyan-200",
+          "bg-sky-50 border border-sky-200 text-sky-600",
       }
     : null;
   useEffect(() => setPage(1), [search, setPage]);
@@ -436,7 +436,7 @@ export default function RekapKomentarTiktok({
   }
 
   return (
-    <div className="relative mt-10 flex flex-col gap-10 pb-24">
+    <div className="relative mt-10 flex flex-col gap-10 pb-24 text-slate-700">
       <div className="grid gap-4 md:grid-cols-3 xl:grid-cols-6">
         <SummaryCard
           title="TikTok Post Aktif"
@@ -480,7 +480,7 @@ export default function RekapKomentarTiktok({
         />
       </div>
       {tidakAdaPost && (
-        <p className="text-xs text-slate-400 text-center md:text-right">
+        <p className="text-xs text-slate-500 text-center md:text-right">
           Tidak ada posting aktif. Tidak diperlukan aksi komentar.
         </p>
       )}
@@ -502,7 +502,7 @@ export default function RekapKomentarTiktok({
                 : "Cari nama, username, atau divisi"
             }
             aria-describedby={searchHelpId}
-            className="w-full rounded-2xl border border-slate-800/70 bg-slate-900/70 px-3 py-2 text-sm text-slate-100 placeholder-slate-500 shadow focus:border-fuchsia-400 focus:outline-none focus:ring-2 focus:ring-fuchsia-500/30 sm:w-72"
+            className="w-full rounded-2xl border border-indigo-200 bg-white px-3 py-2 text-sm text-slate-800 placeholder:text-slate-400 shadow-sm transition focus:border-sky-200 focus:outline-none focus:ring-2 focus:ring-sky-200/60 sm:w-72"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
           />
@@ -510,25 +510,25 @@ export default function RekapKomentarTiktok({
       </div>
 
       {tidakAdaPost && (
-        <div className="rounded-3xl border border-slate-800/70 bg-slate-900/70 px-4 py-3 text-sm text-slate-300">
+        <div className="rounded-3xl border border-indigo-100 bg-white px-4 py-3 text-sm text-slate-600 shadow-sm">
           Tidak ada posting TikTok yang perlu dikomentari hari ini. Tim kamu bisa
           beristirahat sejenak.
         </div>
       )}
 
-      <div className="relative overflow-x-auto rounded-3xl border border-slate-800/70 bg-slate-900/60 shadow-[0_0_32px_rgba(15,118,110,0.2)]">
-        <table className="w-full text-left text-sm text-slate-200">
-          <thead className="sticky top-0 z-10 bg-slate-950/80 backdrop-blur">
+      <div className="relative overflow-x-auto rounded-3xl border border-indigo-100 bg-white/90 shadow-xl">
+        <table className="w-full text-left text-sm text-slate-700">
+          <thead className="sticky top-0 z-10 bg-indigo-50/80 backdrop-blur">
             <tr>
-              <th className="py-3 px-3 text-xs font-semibold uppercase tracking-widest text-slate-400">No</th>
-              <th className="py-3 px-3 text-xs font-semibold uppercase tracking-widest text-slate-400">Satker</th>
-              <th className="py-3 px-3 text-xs font-semibold uppercase tracking-widest text-slate-400">Nama</th>
-              <th className="py-3 px-3 text-xs font-semibold uppercase tracking-widest text-slate-400">Username TikTok</th>
-              <th className="py-3 px-3 text-xs font-semibold uppercase tracking-widest text-slate-400">Divisi/Satfung</th>
-              <th className="py-3 px-3 text-center text-xs font-semibold uppercase tracking-widest text-slate-400">
+              <th className="py-3 px-3 text-xs font-semibold uppercase tracking-widest text-slate-500">No</th>
+              <th className="py-3 px-3 text-xs font-semibold uppercase tracking-widest text-slate-500">Satker</th>
+              <th className="py-3 px-3 text-xs font-semibold uppercase tracking-widest text-slate-500">Nama</th>
+              <th className="py-3 px-3 text-xs font-semibold uppercase tracking-widest text-slate-500">Username TikTok</th>
+              <th className="py-3 px-3 text-xs font-semibold uppercase tracking-widest text-slate-500">Divisi/Satfung</th>
+              <th className="py-3 px-3 text-center text-xs font-semibold uppercase tracking-widest text-slate-500">
                 Status
               </th>
-              <th className="py-3 px-3 text-center text-xs font-semibold uppercase tracking-widest text-slate-400">
+              <th className="py-3 px-3 text-center text-xs font-semibold uppercase tracking-widest text-slate-500">
                 Jumlah Komentar
               </th>
             </tr>
@@ -556,34 +556,34 @@ export default function RekapKomentarTiktok({
                 const sudahKomentar =
                   tidakAdaPost ? false : Number(u.jumlah_komentar) > 0;
                 const baseRowClass =
-                  "border-b border-slate-800/60 transition duration-150 hover:bg-slate-800/60";
+                  "border-b border-slate-100 transition duration-150 hover:bg-sky-50/60";
                 const rowClass = tidakAdaPost
-                  ? `bg-slate-900/60 ${baseRowClass}`
+                  ? `bg-white ${baseRowClass}`
                   : sudahKomentar
-                  ? `bg-emerald-500/10 ${baseRowClass}`
-                  : `bg-rose-500/10 ${baseRowClass}`;
+                  ? `bg-emerald-50 ${baseRowClass}`
+                  : `bg-rose-50 ${baseRowClass}`;
                 const statusClass = tidakAdaPost
-                  ? "inline-flex items-center gap-1 rounded-full border border-slate-600/70 bg-slate-800/80 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-300"
+                  ? "inline-flex items-center gap-1 rounded-full border border-slate-200 bg-slate-100 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-600"
                   : sudahKomentar
-                  ? "inline-flex items-center gap-1 rounded-full border border-emerald-500/50 bg-emerald-500/15 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-emerald-200"
-                  : "inline-flex items-center gap-1 rounded-full border border-rose-500/50 bg-rose-500/15 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-rose-200";
+                  ? "inline-flex items-center gap-1 rounded-full border border-emerald-200 bg-emerald-100 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-emerald-700"
+                  : "inline-flex items-center gap-1 rounded-full border border-rose-200 bg-rose-100 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-rose-600";
                 return (
                   <tr
                     key={u.user_id}
                     className={rowClass}
                   >
-                    <td className="py-3 px-3 text-slate-400">{(page - 1) * PAGE_SIZE + i + 1}</td>
+                    <td className="py-3 px-3 text-slate-500">{(page - 1) * PAGE_SIZE + i + 1}</td>
                     <td className="py-3 px-3">
                       {u.nama_client || u.client_name || u.client || u.client_id || "-"}
                     </td>
                     <td className="py-3 px-3">
                       {u.title ? `${u.title} ${u.nama}` : u.nama}
                     </td>
-                    <td className="py-3 px-3 font-mono text-fuchsia-300">
+                    <td className="py-3 px-3 font-mono text-indigo-600">
                       {u.username}
                     </td>
                     <td className="py-3 px-3">
-                      <span className="inline-flex items-center gap-2 rounded-full border border-sky-500/40 bg-sky-500/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-sky-200">
+                      <span className="inline-flex items-center gap-2 rounded-full border border-sky-200 bg-sky-50 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.2em] text-sky-600">
                         {bersihkanSatfung(u.divisi || "-")}
                       </span>
                     </td>
@@ -607,7 +607,7 @@ export default function RekapKomentarTiktok({
                         )}
                       </span>
                     </td>
-                    <td className="py-3 px-3 text-center text-lg font-semibold text-slate-50">
+                    <td className="py-3 px-3 text-center text-lg font-semibold text-slate-900">
                       {tidakAdaPost ? "-" : u.jumlah_komentar}
                     </td>
                   </tr>
@@ -616,7 +616,7 @@ export default function RekapKomentarTiktok({
           </tbody>
         </table>
       </div>
-      <p className="mt-2 text-sm text-slate-400">
+      <p className="mt-2 text-sm text-slate-500">
         Tabel ini merangkum status komentar TikTok setiap user dan total jumlah
         komentar yang diberikan.
       </p>
@@ -624,17 +624,17 @@ export default function RekapKomentarTiktok({
       {totalPages > 1 && (
         <div className="mt-6 flex items-center justify-between">
           <button
-            className="rounded-full border border-slate-700/60 bg-slate-900/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-200 transition hover:border-cyan-400/60 hover:bg-cyan-500/10 disabled:opacity-40 disabled:hover:bg-slate-900/70"
+            className="rounded-full border border-indigo-200 bg-white px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-indigo-600 transition hover:border-indigo-300 hover:bg-indigo-50 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-white"
             disabled={page === 1}
             onClick={() => setPage(p => Math.max(1, p - 1))}
           >
             Prev
           </button>
-          <span className="text-sm text-slate-300">
+          <span className="text-sm text-slate-600">
             Halaman <b>{page}</b> dari <b>{totalPages}</b>
           </span>
           <button
-            className="rounded-full border border-slate-700/60 bg-slate-900/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-slate-200 transition hover:border-cyan-400/60 hover:bg-cyan-500/10 disabled:opacity-40 disabled:hover:bg-slate-900/70"
+            className="rounded-full border border-indigo-200 bg-white px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-indigo-600 transition hover:border-indigo-300 hover:bg-indigo-50 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-white"
             disabled={page === totalPages}
             onClick={() => setPage(p => Math.min(totalPages, p + 1))}
           >
@@ -644,17 +644,17 @@ export default function RekapKomentarTiktok({
       )}
 
       <div className="sticky bottom-6 z-20 flex w-full justify-end px-4">
-        <div className="flex w-full max-w-xl flex-col gap-2 rounded-3xl border border-slate-700/60 bg-slate-900/80 p-4 shadow-[0_0_32px_rgba(217,70,239,0.25)] backdrop-blur-sm sm:flex-row sm:items-center">
+        <div className="flex w-full max-w-xl flex-col gap-2 rounded-3xl border border-sky-100 bg-white/95 p-4 shadow-xl backdrop-blur sm:flex-row sm:items-center">
           <button
             onClick={handleDownloadRekap}
-            className="w-full rounded-2xl border border-emerald-400/40 bg-emerald-500/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-emerald-200 transition hover:border-emerald-300/60 hover:bg-emerald-400/20 sm:w-auto"
+            className="w-full rounded-2xl bg-gradient-to-r from-sky-400 to-indigo-400 px-4 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-white shadow-sm transition hover:from-sky-500 hover:to-indigo-500 focus:outline-none focus:ring-2 focus:ring-sky-200/60 sm:w-auto"
           >
             Salin Teks Rekap
           </button>
           {showCopyButton && (
             <button
               onClick={handleCopyRekap}
-              className="w-full rounded-2xl border border-fuchsia-400/40 bg-fuchsia-500/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-fuchsia-200 transition hover:border-fuchsia-300/60 hover:bg-fuchsia-500/20 sm:w-auto"
+              className="w-full rounded-2xl bg-gradient-to-r from-violet-400 to-fuchsia-400 px-4 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-white shadow-sm transition hover:from-violet-500 hover:to-fuchsia-500 focus:outline-none focus:ring-2 focus:ring-fuchsia-200/60 sm:w-auto"
             >
               Salin Rekap
             </button>
@@ -668,40 +668,46 @@ export default function RekapKomentarTiktok({
 function SummaryCard({ title, value, icon, percentage, tone = "slate" }) {
   const palettes = {
     fuchsia: {
-      icon: "text-fuchsia-300",
-      border: "border-fuchsia-500/40",
-      glow: "from-fuchsia-500/25 via-fuchsia-500/10 to-transparent",
-      bar: "from-fuchsia-400 to-pink-500",
+      icon: "text-rose-500",
+      iconWrap: "border-rose-200 bg-rose-50",
+      glow: "from-rose-100 via-rose-50 to-transparent",
+      bar: "from-rose-400 to-pink-400",
+      cardBorder: "border-rose-100",
     },
     emerald: {
-      icon: "text-emerald-300",
-      border: "border-emerald-500/40",
-      glow: "from-emerald-500/25 via-emerald-500/10 to-transparent",
+      icon: "text-emerald-500",
+      iconWrap: "border-emerald-200 bg-emerald-50",
+      glow: "from-emerald-100 via-emerald-50 to-transparent",
       bar: "from-emerald-400 to-lime-400",
+      cardBorder: "border-emerald-100",
     },
     amber: {
-      icon: "text-amber-200",
-      border: "border-amber-400/40",
-      glow: "from-amber-400/20 via-amber-500/10 to-transparent",
+      icon: "text-amber-500",
+      iconWrap: "border-amber-200 bg-amber-50",
+      glow: "from-amber-100 via-amber-50 to-transparent",
       bar: "from-amber-300 to-orange-400",
+      cardBorder: "border-amber-100",
     },
     rose: {
-      icon: "text-rose-300",
-      border: "border-rose-500/40",
-      glow: "from-rose-500/20 via-rose-500/10 to-transparent",
+      icon: "text-rose-500",
+      iconWrap: "border-rose-200 bg-rose-50",
+      glow: "from-rose-100 via-rose-50 to-transparent",
       bar: "from-rose-400 to-amber-400",
+      cardBorder: "border-rose-100",
     },
     violet: {
-      icon: "text-violet-300",
-      border: "border-violet-500/40",
-      glow: "from-violet-500/20 via-violet-500/10 to-transparent",
+      icon: "text-violet-500",
+      iconWrap: "border-violet-200 bg-violet-50",
+      glow: "from-violet-100 via-violet-50 to-transparent",
       bar: "from-violet-400 to-purple-500",
+      cardBorder: "border-violet-100",
     },
     slate: {
-      icon: "text-slate-300",
-      border: "border-slate-500/40",
-      glow: "from-slate-500/20 via-slate-500/10 to-transparent",
+      icon: "text-slate-500",
+      iconWrap: "border-slate-200 bg-slate-50",
+      glow: "from-slate-100 via-slate-50 to-transparent",
       bar: "from-slate-300 to-slate-400",
+      cardBorder: "border-slate-200",
     },
   };
   const palette = palettes[tone] || palettes.slate;
@@ -720,32 +726,37 @@ function SummaryCard({ title, value, icon, percentage, tone = "slate" }) {
     : null;
 
   return (
-    <div className="relative overflow-hidden rounded-3xl border border-slate-800/70 bg-slate-900/70 p-5 text-center shadow-[0_0_32px_rgba(30,64,175,0.25)]">
+    <div
+      className={cn(
+        "relative overflow-hidden rounded-3xl border bg-white p-5 text-center shadow-sm",
+        palette.cardBorder,
+      )}
+    >
       <div
         className={cn(
-          "pointer-events-none absolute inset-px rounded-[1.35rem] bg-gradient-to-br opacity-70 blur-2xl",
+          "pointer-events-none absolute inset-0 rounded-[1.35rem] bg-gradient-to-br opacity-60 blur-2xl",
           palette.glow,
         )}
       />
       <div className="relative flex flex-col items-center gap-2">
         <div
           className={cn(
-            "flex h-12 w-12 items-center justify-center rounded-2xl border bg-slate-950/70",
-            palette.border,
+            "flex h-12 w-12 items-center justify-center rounded-2xl border",
+            palette.iconWrap,
           )}
         >
           {iconElement}
         </div>
-        <div className="text-3xl font-semibold text-slate-50">{value}</div>
-        <div className="text-[11px] font-semibold uppercase tracking-[0.35em] text-slate-400">
+        <div className="text-3xl font-semibold text-slate-900">{value}</div>
+        <div className="text-[11px] font-semibold uppercase tracking-[0.35em] text-slate-500">
           {title}
         </div>
         {formattedPercentage && (
           <div className="mt-2 flex w-full max-w-[180px] flex-col items-center gap-2">
-            <span className="text-[11px] font-medium text-slate-300">
+            <span className="text-[11px] font-medium text-slate-500">
               {formattedPercentage}
             </span>
-            <div className="h-1.5 w-full rounded-full bg-slate-800/80">
+            <div className="h-1.5 w-full rounded-full bg-slate-100">
               <div
                 className={cn("h-full rounded-full bg-gradient-to-r", palette.bar)}
                 style={{ width: `${clampedPercentage}%` }}

--- a/cicero-dashboard/components/ViewDataSelector.jsx
+++ b/cicero-dashboard/components/ViewDataSelector.jsx
@@ -71,20 +71,20 @@ export default function ViewDataSelector({
   const rangeStartId = `${id}-start`;
   const rangeEndId = `${id}-end`;
   const baseContainerClass = cn(
-    "flex w-full flex-wrap items-center justify-between gap-3 rounded-2xl border border-blue-100/70 bg-white/90 px-4 py-3 shadow-sm sm:justify-start",
+    "flex w-full flex-wrap items-center justify-between gap-3 rounded-2xl border border-indigo-100 bg-white px-4 py-3 shadow-sm sm:justify-start",
     disabled && "opacity-60",
     className,
   );
   const baseLabelClass = cn(
-    "w-full text-sm font-semibold tracking-tight text-blue-900 sm:w-auto",
+    "w-full text-sm font-semibold tracking-tight text-slate-800 sm:w-auto",
     labelClassName,
   );
   const baseControlClass = cn(
-    "w-full rounded-xl border border-blue-200 bg-blue-50/70 px-3 py-2 text-sm text-blue-900 placeholder:text-blue-300 shadow-inner transition focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-300 sm:w-auto",
+    "w-full rounded-xl border border-indigo-200 bg-white px-3 py-2 text-sm text-slate-800 placeholder:text-slate-400 shadow-inner transition focus:border-sky-200 focus:outline-none focus:ring-2 focus:ring-sky-200/60 sm:w-auto",
     controlClassName,
   );
   const segmentedButtonBaseClass =
-    "rounded-full border border-blue-200 bg-white/60 px-4 py-2 text-sm font-medium text-blue-700 shadow-inner transition hover:bg-blue-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-300";
+    "rounded-full border border-indigo-200 bg-white px-4 py-2 text-sm font-medium text-slate-600 shadow-inner transition hover:bg-sky-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-200/60";
 
   return (
     <div className={baseContainerClass} aria-disabled={disabled}>
@@ -104,7 +104,7 @@ export default function ViewDataSelector({
                 className={cn(
                   segmentedButtonBaseClass,
                   isActive &&
-                    "border-blue-300 bg-blue-100/80 text-blue-900 shadow-sm",
+                    "border-sky-200 bg-sky-50 text-slate-800 shadow-sm",
                   disabled && "cursor-not-allowed opacity-70",
                 )}
               >
@@ -128,7 +128,7 @@ export default function ViewDataSelector({
             ))}
           </select>
           <svg
-            className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-blue-500"
+            className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400"
             aria-hidden="true"
             fill="none"
             stroke="currentColor"


### PR DESCRIPTION
## Summary
- restyle the TikTok comment recap page with a bright pastel gradient backdrop and lighter controls
- align ViewDataSelector and Ditbinmas scope panel inputs with the new indigo/summer-sky control palette
- refresh RekapKomentarTiktok components, cards, badges, and CTAs to deliver a cohesive optimistic visual language and pastel error state

## Testing
- npm run lint *(fails: command requires interactive ESLint configuration and was aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68e65b3bac588327978e5eb6b7be4f9d