### PR TITLE
Remove direct DOM manipulation from dashboard page

### DIFF
--- a/cicero-dashboard/app/dashboard/page.tsx
+++ b/cicero-dashboard/app/dashboard/page.tsx
@@ -176,13 +176,6 @@ export default function DashboardPage() {
     fetchData();
   }, [token]);
 
-  useEffect(() => {
-    const comment = document.querySelector<HTMLElement>("#comm1");
-    if (comment) {
-      comment.style.border = "1px solid red";
-    }
-  }, []);
-
   const analytics = useMemo(() => {
     const instagramFollowers = pickNumericValue(igProfile, [
       "followers",


### PR DESCRIPTION
## Summary
- remove the dashboard useEffect that directly manipulates the DOM border styling
- rely on Tailwind-driven styling by eliminating manual querySelector usage

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e66835d27483279fe3edf80ff0058a