### PR TITLE
Fix engagement highlight formatting

### DIFF
--- a/cicero-dashboard/app/dashboard/page.tsx
+++ b/cicero-dashboard/app/dashboard/page.tsx
@@ -509,7 +509,7 @@ export default function DashboardPage() {
       {
         key: "engagement",
         title: "Engagement",
-        value: `${analytics.totals.engagements}`,
+        value: analytics.totals.engagements,
         subtitle: "Likes + Komentar",
         icon: "⚡",
       },


### PR DESCRIPTION
## Summary
- ensure the engagement highlight value remains numeric so DashboardStats can format it consistently

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e66d23cf588327a62b82dd9f6b265a