### PR TITLE
Refresh dashboard chrome for light theme defaults

### DIFF
--- a/cicero-dashboard/components/Header.tsx
+++ b/cicero-dashboard/components/Header.tsx
@@ -19,17 +19,17 @@ export default function Header() {
   if (pathname === "/" || pathname === "/login") return null;
 
   return (
-    <header className="sticky top-0 z-40 w-full border-b border-slate-800/60 bg-slate-950/90 backdrop-blur supports-[backdrop-filter]:bg-slate-950/70">
+    <header className="sticky top-0 z-40 w-full border-b border-sky-200/70 bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/70 dark:border-slate-800/60 dark:bg-slate-950/90 dark:supports-[backdrop-filter]:bg-slate-950/70">
       <div className="relative flex h-20 w-full items-center justify-between px-4 sm:px-6 lg:px-8">
         <div className="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
-          <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.32),_transparent_55%)]" />
-          <div className="absolute inset-0 bg-[linear-gradient(120deg,_rgba(129,140,248,0.18),_rgba(56,189,248,0.08),_rgba(59,130,246,0.24))] opacity-80" />
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.18),_transparent_55%)] dark:bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.32),_transparent_55%)]" />
+          <div className="absolute inset-0 bg-[linear-gradient(120deg,_rgba(125,211,252,0.18),_rgba(59,130,246,0.12),_rgba(99,102,241,0.22))] opacity-80 dark:bg-[linear-gradient(120deg,_rgba(129,140,248,0.18),_rgba(56,189,248,0.08),_rgba(59,130,246,0.24))]" />
         </div>
         <Link
           href="/dashboard"
-          className="group flex items-center gap-3 font-semibold text-sky-100"
+          className="group flex items-center gap-3 font-semibold text-sky-600 dark:text-sky-100"
         >
-          <span className="relative flex h-10 w-10 items-center justify-center overflow-hidden rounded-full border border-sky-200/70 bg-slate-100/90 shadow-[0_0_20px_rgba(56,189,248,0.4)] transition-shadow group-hover:shadow-[0_0_32px_rgba(125,211,252,0.6)]">
+          <span className="relative flex h-10 w-10 items-center justify-center overflow-hidden rounded-full border border-sky-300/80 bg-white/90 shadow-[0_0_20px_rgba(56,189,248,0.4)] transition-shadow group-hover:shadow-[0_0_32px_rgba(125,211,252,0.6)] dark:border-sky-200/70 dark:bg-slate-100/90">
             <Image
               src="/CICERO.png"
               alt="CICERO Logo"
@@ -39,14 +39,14 @@ export default function Header() {
               priority
             />
           </span>
-          <span className="text-lg tracking-[0.35em] text-sky-100">CICERO</span>
+          <span className="text-lg tracking-[0.35em] text-sky-600 dark:text-sky-100">CICERO</span>
         </Link>
-        <div className="flex items-center gap-3 text-slate-200">
+        <div className="flex items-center gap-3 text-slate-600 dark:text-slate-200">
           <DarkModeToggle />
           <ClientProfileMenu />
           <button
             onClick={handleLogout}
-            className="text-xs font-semibold uppercase tracking-[0.3em] text-rose-300 transition-colors hover:text-rose-200"
+            className="text-xs font-semibold uppercase tracking-[0.3em] text-rose-500 transition-colors hover:text-rose-400 dark:text-rose-300 dark:hover:text-rose-200"
           >
             Logout
           </button>

--- a/cicero-dashboard/components/Sidebar.jsx
+++ b/cicero-dashboard/components/Sidebar.jsx
@@ -103,7 +103,7 @@ export default function Sidebar() {
   const navLinks = (isSheet = false, isCollapsed = false) => (
     <>
       <div className="mb-6 px-4 flex justify-center">
-        <div className="rounded-xl bg-white/90 px-3 py-2 shadow-[0_0_20px_rgba(56,189,248,0.35)] backdrop-blur">
+        <div className="rounded-xl bg-white/90 px-3 py-2 shadow-[0_12px_32px_rgba(56,189,248,0.18)] backdrop-blur dark:bg-slate-900/90 dark:shadow-[0_0_20px_rgba(56,189,248,0.35)]">
           <Image
             src="/CICERO.png"
             alt="CICERO Logo"
@@ -117,7 +117,7 @@ export default function Sidebar() {
         className={`flex-1 space-y-1 px-2 ${
           isSheet
             ? ""
-            : "[&>*]:shadow-[0_0_10px_rgba(56,189,248,0.15)]"
+            : "[&>*]:shadow-[0_10px_24px_rgba(56,189,248,0.12)]"
         }`}
       >
         {menu.map((item) => {
@@ -128,20 +128,20 @@ export default function Sidebar() {
               href={item.path}
               className={`group flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-all duration-200 ${
                 pathname.startsWith(item.path)
-                  ? "bg-gradient-to-r from-cyan-400/30 via-sky-500/30 to-indigo-500/30 text-sky-100 ring-1 ring-cyan-400/60"
+                  ? "bg-gradient-to-r from-sky-100 via-sky-200 to-indigo-100 text-sky-700 ring-1 ring-sky-200 dark:from-cyan-400/30 dark:via-sky-500/30 dark:to-indigo-500/30 dark:text-sky-100 dark:ring-cyan-400/60"
                   : isSheet
-                  ? "text-slate-100 hover:bg-white/10"
-                  : "text-slate-300 hover:bg-white/10 hover:text-slate-100"
+                  ? "text-slate-600 hover:bg-sky-50/80 hover:text-sky-700 dark:text-slate-100 dark:hover:bg-white/10"
+                  : "text-slate-600 hover:bg-sky-50 hover:text-sky-700 dark:text-slate-300 dark:hover:bg-white/10 dark:hover:text-slate-100"
               } ${isCollapsed ? "justify-center" : ""}`}
               {...(isSheet ? { onClick: () => setOpen(false) } : {})}
             >
               <ItemIcon
                 className={`${
                   isSheet
-                    ? "h-7 w-7 text-sky-300"
+                    ? "h-7 w-7 text-sky-500 dark:text-sky-300"
                     : pathname.startsWith(item.path)
-                    ? "h-5 w-5 text-cyan-300 drop-shadow-[0_0_4px_rgba(34,211,238,0.9)]"
-                    : "h-5 w-5 text-slate-400 group-hover:text-cyan-200"
+                    ? "h-5 w-5 text-sky-600 drop-shadow-[0_0_6px_rgba(56,189,248,0.55)] dark:text-cyan-300"
+                    : "h-5 w-5 text-slate-400 group-hover:text-sky-500 dark:text-slate-400 dark:group-hover:text-cyan-200"
                 }`}
               />
               {!isCollapsed && <span>{item.label}</span>}
@@ -158,7 +158,7 @@ export default function Sidebar() {
         <SheetTrigger asChild className="md:hidden">
           <button
             aria-label={open ? "Tutup Sidebar" : "Buka Sidebar"}
-            className="fixed z-50 top-4 left-4 flex h-12 w-12 items-center justify-center rounded-full border border-cyan-500/40 bg-slate-900/80 text-sky-200 shadow-[0_0_20px_rgba(56,189,248,0.45)] transition-all hover:bg-cyan-500/40 hover:text-white focus:outline-none"
+            className="fixed z-50 top-4 left-4 flex h-12 w-12 items-center justify-center rounded-full border border-sky-300/70 bg-white/90 text-sky-600 shadow-[0_12px_32px_rgba(56,189,248,0.25)] transition-all hover:bg-sky-100 hover:text-sky-800 focus:outline-none dark:border-cyan-500/40 dark:bg-slate-900/80 dark:text-sky-200 dark:hover:bg-cyan-500/40 dark:hover:text-white"
           >
             {open ? (
               <IconX size={28} strokeWidth={2.5} />
@@ -169,7 +169,7 @@ export default function Sidebar() {
         </SheetTrigger>
         <SheetContent
           side="left"
-          className="flex w-24 flex-col bg-slate-950/95 p-4 text-slate-100 backdrop-blur-xl md:hidden"
+          className="flex w-24 flex-col bg-white/90 p-4 text-slate-700 backdrop-blur-xl md:hidden dark:bg-slate-950/95 dark:text-slate-100"
         >
           <SheetTitle className="sr-only">Navigation Menu</SheetTitle>
           {navLinks(true, true)}
@@ -179,12 +179,12 @@ export default function Sidebar() {
       <div
         className={`hidden md:sticky md:top-16 md:flex ${
           collapsed ? "md:w-20" : "md:w-64"
-        } md:h-[calc(100vh-4rem)] md:flex-col md:overflow-y-auto border-r border-cyan-500/40 bg-gradient-to-b from-slate-950 via-slate-900 to-slate-950 text-slate-100 shadow-[0_0_35px_rgba(15,23,42,0.6)] transition-all`}
+        } md:h-[calc(100vh-4rem)] md:flex-col md:overflow-y-auto border-r border-sky-100 bg-white/90 text-slate-700 shadow-[0_20px_45px_rgba(56,189,248,0.18)] transition-all dark:border-cyan-500/40 dark:bg-gradient-to-b dark:from-slate-950 dark:via-slate-900 dark:to-slate-950 dark:text-slate-100 dark:shadow-[0_0_35px_rgba(15,23,42,0.6)]`}
       >
         <div className="flex justify-end p-2">
           <button
             onClick={() => setCollapsed(!collapsed)}
-            className="rounded-full bg-white/5 p-1 text-slate-400 transition hover:bg-cyan-500/30 hover:text-white"
+            className="rounded-full bg-sky-100/80 p-1 text-slate-500 transition hover:bg-sky-200 hover:text-sky-700 dark:bg-white/5 dark:text-slate-400 dark:hover:bg-cyan-500/30 dark:hover:text-white"
             aria-label="Toggle Sidebar"
           >
             {collapsed ? (


### PR DESCRIPTION
## Summary
- brighten the dashboard header with light backgrounds, gradients, and typography while preserving dark variants
- restyle the sidebar for a luminous light mode treatment and confine dark styling to `dark:` utilities

## Testing
- Manual check `/dashboard` light/dark in browser_container

------
https://chatgpt.com/codex/tasks/task_e_68e677b071c88327b19ebac2fc30a33c