### PR TITLE
Update dashboard layout background gradient

### DIFF
--- a/cicero-dashboard/components/LayoutClient.tsx
+++ b/cicero-dashboard/components/LayoutClient.tsx
@@ -20,7 +20,7 @@ export default function LayoutClient({ children }: { children: React.ReactNode }
   return (
     <>
       <Header />
-      <div className="flex min-h-screen bg-gray-100 dark:bg-gray-950">
+      <div className="flex min-h-screen bg-gradient-to-b from-sky-50 via-blue-50 to-indigo-100">
         <aside aria-label="Sidebar navigation" className="md:sticky md:top-16">
           <SidebarWrapper />
         </aside>


### PR DESCRIPTION
## Summary
- replace the dashboard layout background with a bright gradient and remove the dark fallback so the gradient fills the viewport

## Testing
- none

------
https://chatgpt.com/codex/tasks/task_e_68e67c237f048327bd9a47a9296ba277