### PR TITLE
Update theme toggle storage and defaults

### DIFF
--- a/cicero-dashboard/app/globals.css
+++ b/cicero-dashboard/app/globals.css
@@ -19,13 +19,6 @@ html {
   --font-mono: var(--font-geist-mono);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
-}
-
 .dark {
   --background: #0a0a0a;
   --foreground: #ededed;
@@ -75,13 +68,11 @@ select::placeholder {
   opacity: 0.9;
 }
 
-@media (prefers-color-scheme: dark) {
-  input::placeholder,
-  textarea::placeholder,
-  select::placeholder {
-    color: #cbd5f5; /* Brighter tone for dark surfaces */
-    opacity: 0.95;
-  }
+.dark input::placeholder,
+.dark textarea::placeholder,
+.dark select::placeholder {
+  color: #cbd5f5; /* Brighter tone for dark surfaces */
+  opacity: 0.95;
 }
 
 input,

--- a/cicero-dashboard/components/DarkModeToggle.tsx
+++ b/cicero-dashboard/components/DarkModeToggle.tsx
@@ -2,23 +2,44 @@
 import { useEffect, useState } from "react";
 import { Moon, Sun } from "lucide-react";
 
+const STORAGE_KEY = "theme:v2";
+const LEGACY_KEY = "theme";
+
 export default function DarkModeToggle() {
   const [enabled, setEnabled] = useState(false);
 
   useEffect(() => {
-    const stored = localStorage.getItem("theme");
-    if (stored === "dark") setEnabled(true);
+    const root = document.documentElement;
+    root.classList.remove("dark");
+
+    const legacyValue = localStorage.getItem(LEGACY_KEY);
+    if (legacyValue) {
+      localStorage.removeItem(LEGACY_KEY);
+    }
+
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored === "dark") {
+      setEnabled(true);
+    } else {
+      root.classList.remove("dark");
+      if (stored !== "light") {
+        localStorage.setItem(STORAGE_KEY, "light");
+      }
+    }
   }, []);
 
   useEffect(() => {
     const root = document.documentElement;
+
     if (enabled) {
       root.classList.add("dark");
-      localStorage.setItem("theme", "dark");
+      localStorage.setItem(STORAGE_KEY, "dark");
     } else {
       root.classList.remove("dark");
-      localStorage.setItem("theme", "light");
+      localStorage.setItem(STORAGE_KEY, "light");
     }
+
+    localStorage.removeItem(LEGACY_KEY);
   }, [enabled]);
 
   return (


### PR DESCRIPTION
## Summary
- migrate the dark mode toggle to the new `theme:v2` storage key with a light default and legacy cleanup
- rely on the `.dark` class for dark styling while keeping the base CSS variables aligned with the light theme
- scope placeholder styling updates to the dark mode class so toggled dark mode still has readable inputs

## Testing
- Not run (interactive ESLint initialization prompt)


------
https://chatgpt.com/codex/tasks/task_e_68e67f76db708327bfec5117d37e0715