### PR TITLE
Sync claim contact payload with backend aliases

### DIFF
--- a/cicero-dashboard/__tests__/api.test.ts
+++ b/cicero-dashboard/__tests__/api.test.ts
@@ -365,5 +365,6 @@ test("claim update sends whatsapp with 62 prefix for local numbers", async () =>
   const [, options] = (global.fetch as jest.Mock).mock.calls[0];
   expect(JSON.parse(options.body)).toMatchObject({
     whatsapp: "628123",
+    no_wa: "628123",
   });
 });

--- a/cicero-dashboard/app/claim/edit/page.jsx
+++ b/cicero-dashboard/app/claim/edit/page.jsx
@@ -140,9 +140,9 @@ export default function EditUserPage() {
 
     if (!normalizedWhatsapp) {
       nextFieldErrors.whatsapp = "No WhatsApp wajib diisi.";
-    } else if (normalizedWhatsappDigits.length < 10) {
+    } else if (normalizedWhatsappDigits.length < 8) {
       nextFieldErrors.whatsapp =
-        "No WhatsApp terlalu pendek (minimal 10 digit).";
+        "No WhatsApp terlalu pendek (minimal 8 digit).";
     } else if (!/^\d+$/.test(normalizedWhatsappDigits)) {
       nextFieldErrors.whatsapp =
         "No WhatsApp hanya boleh berisi angka. Tanda + hanya boleh di awal.";
@@ -207,6 +207,7 @@ export default function EditUserPage() {
         // Aturan bisnis: field desa hanya diproses untuk personel role Ditbinmas.
         desa: isDitbinmasRole ? desa.trim() : "",
         whatsapp: normalizedWhatsapp,
+        no_wa: normalizedWhatsapp,
         email: normalizedEmail,
         insta: instaUsername,
         tiktok: tiktokUsername,
@@ -387,8 +388,8 @@ export default function EditUserPage() {
                     whatsapp:
                       !sanitizedValue
                         ? ""
-                        : sanitizedDigits.length < 10
-                          ? "No WhatsApp terlalu pendek (minimal 10 digit)."
+                        : sanitizedDigits.length < 8
+                          ? "No WhatsApp terlalu pendek (minimal 8 digit)."
                           : /^\d+$/.test(sanitizedDigits)
                             ? ""
                             : "No WhatsApp hanya boleh berisi angka. Tanda + hanya boleh di awal.",

--- a/cicero-dashboard/utils/api.ts
+++ b/cicero-dashboard/utils/api.ts
@@ -3640,17 +3640,25 @@ export async function updateUserViaClaim(
     jabatan?: string;
     desa?: string;
     whatsapp?: string;
+    no_wa?: string;
     email?: string;
     insta?: string;
     tiktok?: string;
   },
 ): Promise<any> {
   const url = buildApiUrl("/api/claim/update");
+  const payload: Record<string, unknown> = { ...data };
+  if (typeof payload.whatsapp === "string" && !payload.no_wa) {
+    payload.no_wa = payload.whatsapp;
+  }
+  if (typeof payload.no_wa === "string" && !payload.whatsapp) {
+    payload.whatsapp = payload.no_wa;
+  }
   const res = await fetch(url, {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
     credentials: "include",
-    body: JSON.stringify(data),
+    body: JSON.stringify(payload),
   });
   if (!res.ok) {
     const defaultMessage = "Failed to update user";

--- a/docs/claim-contact-update.md
+++ b/docs/claim-contact-update.md
@@ -43,6 +43,7 @@ Ditambahkan card informasi sebelum input kontak dengan teks persis:
 Saat submit (`handleSubmit`), payload `updateUserViaClaim` kini menyertakan:
 
 - `whatsapp`
+- `no_wa` (alias kompatibilitas backend lama)
 - `email`
 
 Nilai dikirim dalam bentuk hasil `trim()` agar konsisten dengan field profil lainnya.
@@ -52,9 +53,15 @@ Nilai dikirim dalam bentuk hasil `trim()` agar konsisten dengan field profil lai
 Di `cicero-dashboard/utils/api.ts`, parameter fungsi `updateUserViaClaim` diperbarui dengan properti opsional:
 
 - `whatsapp?: string`
+- `no_wa?: string`
 - `email?: string`
 
-Body request tetap meneruskan seluruh objek `data` ke endpoint `/api/claim/update`.
+Body request meneruskan payload ke endpoint `/api/claim/update` dengan fallback dua arah:
+
+- jika hanya ada `whatsapp`, frontend otomatis menambahkan `no_wa`
+- jika hanya ada `no_wa`, frontend otomatis menambahkan `whatsapp`
+
+Validasi nomor di halaman claim edit juga diselaraskan menjadi minimal **8 digit** agar konsisten dengan kontrak backend.
 
 ## Dampak
 


### PR DESCRIPTION
### Motivation
- Backend `PUT /api/claim/update` accepts `whatsapp` and validates phone/email but some older clients expect `no_wa` alias, so payloads must remain backward-compatible.
- Frontend WhatsApp validation and normalization needed to match backend rules (min 8 digits, non-digit stripped) to avoid spurious client-side rejections.
- Ensure the dashboard sends a payload shape compatible with both new and legacy backends without breaking existing integrations.

### Description
- Frontend API helper `updateUserViaClaim` now accepts an optional `no_wa` and performs two-way fallback so if only `whatsapp` is provided `no_wa` is added and vice-versa, then sends the unified `payload` to `/api/claim/update`.
- Claim edit page validation in `cicero-dashboard/app/claim/edit/page.jsx` lowered WhatsApp minimum digit requirement from 10 to 8 to match backend and now includes `no_wa` in the submit payload alongside `whatsapp`.
- Updated the unit test in `cicero-dashboard/__tests__/api.test.ts` to assert that both `whatsapp` and `no_wa` are present in the outgoing payload for local numbers.
- Documentation `docs/claim-contact-update.md` updated to reflect the `no_wa` alias behavior and the synchronized 8-digit validation rule.
- Backend inspection confirmed `updateUserData` uses `whatsapp` from request (validates digits length >= 8 and normalizes by stripping non-digits) and email is validated with an email regex; backend does not rewrite leading `0` to `62` (normalization is digit-only via `normalizeWhatsappNumber`).

### Testing
- Ran frontend unit tests: `cd cicero-dashboard && npm test -- --runTestsByPath __tests__/api.test.ts`, test suite passed (`1 test suite, 20 tests, all passed`).
- Attempted to run tests from repository root (`npm test -- --runTestsByPath cicero-dashboard/__tests__/api.test.ts`) failed because root `package.json` is not present; this does not affect the verified `cicero-dashboard` test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c924f183cc8327b190929209104723)