### PR TITLE
Add timeout to dashboard auth requests to prevent UI hang

### DIFF
--- a/cicero-dashboard/app/login/page.jsx
+++ b/cicero-dashboard/app/login/page.jsx
@@ -41,6 +41,31 @@ export default function LoginPage() {
   const networkErrorMessage =
     "Server tidak merespons. Silakan hubungi admin Cicero.";
 
+  const AUTH_REQUEST_TIMEOUT_MS = 15000;
+
+  const fetchJsonWithTimeout = async (url, options) => {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), AUTH_REQUEST_TIMEOUT_MS);
+
+    try {
+      const res = await fetch(url, { ...options, signal: controller.signal });
+      let data = null;
+      try {
+        data = await res.json();
+      } catch {
+        data = null;
+      }
+      return { res, data };
+    } catch (err) {
+      if (err?.name === "AbortError") {
+        throw new Error(networkErrorMessage);
+      }
+      throw err;
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  };
+
   useEffect(() => {
     setError("");
     setMessage("");
@@ -86,13 +111,11 @@ export default function LoginPage() {
 
     try {
       const apiUrl = getApiBaseUrl();
-      const res = await fetch(`${apiUrl}/api/auth/dashboard-login`, {
+      const { data } = await fetchJsonWithTimeout(`${apiUrl}/api/auth/dashboard-login`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ username: trimmedUsername, password: password.trim() }),
       });
-
-      const data = await res.json();
 
       if (data.success && data.token) {
         const userId = data.user?.user_id || null;
@@ -151,7 +174,7 @@ export default function LoginPage() {
       const apiUrl = getApiBaseUrl();
       const trimmedRole = role.trim();
       const trimmedClientId = client_id.trim();
-      const res = await fetch(`${apiUrl}/api/auth/dashboard-register`, {
+      const { data } = await fetchJsonWithTimeout(`${apiUrl}/api/auth/dashboard-register`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -162,7 +185,6 @@ export default function LoginPage() {
           email: email.trim(),
         }),
       });
-      const data = await res.json();
       if (data.success) {
         const msg =
           data.status === false


### PR DESCRIPTION
### Motivation
- Dashboard login/register requests could hang without feedback because `fetch` had no timeout guard, causing the UI to appear unresponsive.

### Description
- Added a `fetchJsonWithTimeout` helper in `cicero-dashboard/app/login/page.jsx` that uses `AbortController` with a 15s timeout (`AUTH_REQUEST_TIMEOUT_MS`).
- Replaced direct `fetch` calls to `/api/auth/dashboard-login` and `/api/auth/dashboard-register` with the new `fetchJsonWithTimeout` helper.
- Implemented safe JSON parsing fallback so empty or non-JSON responses do not break the flow (`data = null` on parse failure).
- On timeout the helper throws the existing network message so the UI consistently surfaces `Server tidak merespons. Silakan hubungi admin Cicero.`

### Testing
- Ran targeted unit tests after the change: `cd cicero-dashboard && npm test -- --runInBand __tests__/api.test.ts` — PASS.
- Also ran the full dashboard test suite locally: `cd cicero-dashboard && npm test -- --runInBand` — PASS (27 test suites, 237 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f800b78de4832782fab2c996d57a71)