### PR TITLE
Handle stale Next.js Server Action POSTs in dashboard middleware

### DIFF
--- a/cicero-dashboard/middleware.ts
+++ b/cicero-dashboard/middleware.ts
@@ -3,22 +3,41 @@ import type { NextRequest } from "next/server";
 
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
+  const isServerActionRequest = request.method === "POST" && request.headers.has("next-action");
+
+  if (isServerActionRequest) {
+    return NextResponse.json(
+      {
+        message:
+          "This action request is no longer valid for the active deployment. Please reload the page and try again.",
+      },
+      {
+        status: 409,
+        headers: {
+          "Cache-Control": "no-store, no-cache, must-revalidate",
+          "x-cicero-refresh-required": "1",
+        },
+      }
+    );
+  }
 
   if (pathname.startsWith("/reposter/login")) {
     return NextResponse.next();
   }
 
-  const sessionCookie = request.cookies.get("reposter_session");
-  if (!sessionCookie?.value) {
-    const loginUrl = request.nextUrl.clone();
-    loginUrl.pathname = "/reposter/login";
-    loginUrl.searchParams.set("next", pathname);
-    return NextResponse.redirect(loginUrl);
+  if (pathname.startsWith("/reposter")) {
+    const sessionCookie = request.cookies.get("reposter_session");
+    if (!sessionCookie?.value) {
+      const loginUrl = request.nextUrl.clone();
+      loginUrl.pathname = "/reposter/login";
+      loginUrl.searchParams.set("next", pathname);
+      return NextResponse.redirect(loginUrl);
+    }
   }
 
   return NextResponse.next();
 }
 
 export const config = {
-  matcher: ["/reposter/:path*"],
+  matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
 };


### PR DESCRIPTION
### Motivation
- Prevent noisy production errors like `Failed to find Server Action "x"` that occur when clients send stale Server Action POSTs after a deployment.
- Provide a deterministic signal to clients to reload while preserving the existing reposter authentication behavior.

### Description
- Add an early middleware guard that detects Server Action-like requests (`POST` with `next-action` header) and returns a JSON `409` response with `Cache-Control: no-store, no-cache, must-revalidate` and `x-cicero-refresh-required: 1`.
- Broaden the middleware `matcher` to run across app routes while excluding `_next/static`, `_next/image`, and `favicon.ico` so stale action POSTs are intercepted more broadly.
- Keep the reposter auth redirect logic in place by scoping the session cookie check to paths that start with `/reposter` and allowing `/reposter/login` through.
- Changed file: `cicero-dashboard/middleware.ts`.

### Testing
- Ran lint: `cd cicero-dashboard && npm run -s lint`, which completed successfully while reporting pre-existing warnings unrelated to this change.
- No other automated tests were added or changed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f839365adc8327884206c61ab2afe8)