### PR TITLE
Fix user creation type guards in useUserDirectoryActions

### DIFF
--- a/cicero-dashboard/hooks/useUserDirectoryActions.ts
+++ b/cicero-dashboard/hooks/useUserDirectoryActions.ts
@@ -65,6 +65,9 @@ export function useUserDirectoryActions(params: {
       const { error: validationError, nrpNip: sanitizedNrpNip, satfungValue } =
         validateNewUser(submitForm);
       if (validationError) throw new Error(validationError);
+      if (!sanitizedNrpNip) throw new Error("NRP/NIP wajib diisi");
+      if (!satfungValue) throw new Error("Satfung wajib diisi");
+      if (!clientId) throw new Error("Client ID tidak ditemukan");
       await createUser(token || "", {
         client_id: clientId,
         nama: submitForm.nama,


### PR DESCRIPTION
### Motivation
- Prevent a Next.js TypeScript build failure caused by passing potentially `undefined` values (`nrpNip`, `satfungValue`, `clientId`) into `createUser` and enforce that required fields exist at runtime.

### Description
- Added explicit runtime guards in `handleSubmit` inside `cicero-dashboard/hooks/useUserDirectoryActions.ts` to throw errors when `sanitizedNrpNip`, `satfungValue`, or `clientId` are missing before calling `createUser`.
- This narrows the inferred types from `string | undefined` to `string` for the `createUser` payload and makes validation behavior explicit.

### Testing
- Ran `npm run build` in `cicero-dashboard` and confirmed the production build and type checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f83a955ea08327ae0be5f61b655f78)