### PR TITLE
Fix TypeScript clientId typing error in user creation hook

### DIFF
--- a/cicero-dashboard/hooks/useUserDirectoryActions.ts
+++ b/cicero-dashboard/hooks/useUserDirectoryActions.ts
@@ -68,8 +68,9 @@ export function useUserDirectoryActions(params: {
       if (!sanitizedNrpNip) throw new Error("NRP/NIP wajib diisi");
       if (!satfungValue) throw new Error("Satfung wajib diisi");
       if (!clientId) throw new Error("Client ID tidak ditemukan");
+      const resolvedClientId = clientId;
       await createUser(token || "", {
-        client_id: clientId,
+        client_id: resolvedClientId,
         nama: submitForm.nama,
         title: submitForm.pangkat,
         user_id: sanitizedNrpNip,


### PR DESCRIPTION
### Motivation
- The Next.js production build failed type checking because `clientId` could be `string | undefined` when passed to `createUser`, causing a TypeScript error in `cicero-dashboard/hooks/useUserDirectoryActions.ts`.

### Description
- After the existing runtime guard (`if (!clientId) throw ...`) introduce a local `const resolvedClientId = clientId;` and use `resolvedClientId` for the `client_id` field in the `createUser` payload to satisfy the compiler without changing runtime behavior.

### Testing
- Ran `npm run build` in `cicero-dashboard` and the build completed successfully, including type checking.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f83ddc6974832787f152d0b22fe5d1)