### PR TITLE
feat(claim): add pending-content UI and API client with tests

### DIFF
--- a/cicero-dashboard/__tests__/PendingContentCard.test.tsx
+++ b/cicero-dashboard/__tests__/PendingContentCard.test.tsx
@@ -1,0 +1,84 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import PendingContentCard from "@/components/claim/PendingContentCard";
+import type { ClaimPendingContentResponse } from "@/utils/api";
+
+const platform = (overrides = {}) => ({
+  username_available: true,
+  usernames: ["cicero"],
+  total_content: 0,
+  completed_content: 0,
+  pending_content: 0,
+  items: [],
+  completed_ids: [],
+  ...overrides,
+});
+
+const responseData = (overrides = {}): ClaimPendingContentResponse["data"] => ({
+  user_id: "123",
+  timezone: "Asia/Jakarta",
+  filters: { periode: "harian", tanggal: null, start_date: null, end_date: null },
+  instagram: platform(),
+  tiktok: platform(),
+  ...overrides,
+});
+
+describe("PendingContentCard", () => {
+  it("menampilkan state response kosong per platform", () => {
+    render(<PendingContentCard data={responseData()} loading={false} error="" onRefresh={jest.fn()} />);
+    expect(screen.getByText("Tidak ada konten tertunda untuk Instagram.")).toBeTruthy();
+    expect(screen.getByText("Tidak ada konten tertunda untuk TikTok.")).toBeTruthy();
+  });
+
+  it("merangkum dan mengelompokkan konten multi-platform berdasarkan aksi", () => {
+    render(
+      <PendingContentCard
+        loading={false}
+        error=""
+        onRefresh={jest.fn()}
+        data={responseData({
+          instagram: platform({ pending_content: 1, items: [{ shortcode: "IG1", url: "https://www.instagram.com/p/IG1", caption: "Konten Instagram", content_time: "2026-08-07T01:00:00.000Z" }] }),
+          tiktok: platform({ pending_content: 1, items: [{ video_id: "TT1", url: "https://www.tiktok.com/@cicero/video/1", caption: "Konten TikTok", content_time: "2026-08-07T02:00:00.000Z" }] }),
+        })}
+      />,
+    );
+    expect(screen.getByLabelText("Instagram - Like")).toBeTruthy();
+    expect(screen.getByLabelText("TikTok - Comment")).toBeTruthy();
+    expect(screen.getAllByText("1")).toHaveLength(2);
+    expect(screen.getByText("Konten Instagram")).toBeTruthy();
+    expect(screen.getByText("Konten TikTok")).toBeTruthy();
+  });
+
+  it("tidak menampilkan tombol konten ketika URL null", () => {
+    render(<PendingContentCard loading={false} error="" onRefresh={jest.fn()} data={responseData({ tiktok: platform({ pending_content: 1, items: [{ video_id: "TT1", url: null, caption: "Tanpa URL", content_time: null }] }) })} />);
+    expect(screen.queryByRole("link", { name: /Buka Konten/ })).toBeNull();
+    expect(screen.getByText("Tanggal tidak tersedia")).toBeTruthy();
+  });
+
+  it("menampilkan state username platform belum tersedia", () => {
+    render(<PendingContentCard loading={false} error="" onRefresh={jest.fn()} data={responseData({ instagram: platform({ username_available: false, usernames: [] }) })} />);
+    expect(screen.getByText(/Username Instagram belum terdaftar/)).toBeTruthy();
+  });
+
+  it("menampilkan error API dan refresh manual", () => {
+    const onRefresh = jest.fn();
+    render(<PendingContentCard data={null} loading={false} error="Sesi berakhir" onRefresh={onRefresh} />);
+    expect(screen.getByRole("alert").textContent).toContain("Gagal memuat konten tertunda: Sesi berakhir");
+    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("hanya membuka URL HTTPS pada host platform yang tepercaya", () => {
+    const maliciousItems = [
+      { shortcode: "A", url: "javascript:alert(1)", caption: "JS", content_time: null },
+      { shortcode: "B", url: "https://evil.example/phishing", caption: "Host lain", content_time: null },
+      { shortcode: "C", url: "https://www.instagram.com/p/C", caption: "Aman", content_time: null },
+    ];
+    render(<PendingContentCard loading={false} error="" onRefresh={jest.fn()} data={responseData({ instagram: platform({ pending_content: 3, items: maliciousItems }) })} />);
+    const links = screen.getAllByRole("link", { name: /Buka Konten/ });
+    expect(links).toHaveLength(1);
+    expect(links[0].getAttribute("href")).toBe("https://www.instagram.com/p/C");
+    expect(links[0].getAttribute("target")).toBe("_blank");
+    expect(links[0].getAttribute("rel")).toBe("noopener noreferrer");
+  });
+});

--- a/cicero-dashboard/__tests__/claimPendingContentApi.test.ts
+++ b/cicero-dashboard/__tests__/claimPendingContentApi.test.ts
@@ -1,0 +1,26 @@
+describe("getClaimPendingContent", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    process.env.NEXT_PUBLIC_API_URL = "https://api.cicero.test";
+    global.fetch = jest.fn();
+  });
+
+  it("memakai endpoint GET dengan cookie", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: true, json: async () => ({ success: true, data: {} }) });
+    const { getClaimPendingContent } = await import("@/utils/api");
+    await getClaimPendingContent();
+    expect(global.fetch).toHaveBeenCalledWith("https://api.cicero.test/api/claim/pending-content", { method: "GET", credentials: "include" });
+  });
+
+  it("meneruskan pesan API 401", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: false, status: 401, json: async () => ({ message: "Token user tidak valid" }) });
+    const { getClaimPendingContent } = await import("@/utils/api");
+    await expect(getClaimPendingContent()).rejects.toThrow("Token user tidak valid");
+  });
+
+  it("memberi pesan fallback pada error API tanpa body JSON", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: false, status: 500, json: async () => { throw new Error("invalid json"); } });
+    const { getClaimPendingContent } = await import("@/utils/api");
+    await expect(getClaimPendingContent()).rejects.toThrow("Gagal memuat konten yang belum tercatat");
+  });
+});

--- a/cicero-dashboard/app/claim/edit/page.jsx
+++ b/cicero-dashboard/app/claim/edit/page.jsx
@@ -5,7 +5,9 @@ import { useRouter } from "next/navigation";
 import { CheckCircle2, Edit3, Info, TriangleAlert } from "lucide-react";
 
 import ClaimLayout from "@/components/claim/ClaimLayout";
+import PendingContentCard from "@/components/claim/PendingContentCard";
 import {
+  getClaimPendingContent,
   getClaimUserData,
   normalizeWhatsapp,
   updateUserViaClaim,
@@ -35,6 +37,11 @@ export default function EditUserPage() {
     useState("");
   const [secondaryTiktokUsername, setSecondaryTiktokUsername] = useState("");
   const [loading, setLoading] = useState(false);
+  const [profileLoading, setProfileLoading] = useState(true);
+  const [profileError, setProfileError] = useState("");
+  const [pendingContent, setPendingContent] = useState(null);
+  const [contentLoading, setContentLoading] = useState(true);
+  const [contentError, setContentError] = useState("");
   const [error, setError] = useState("");
   const [message, setMessage] = useState("");
   const [fieldErrors, setFieldErrors] = useState({
@@ -58,10 +65,13 @@ export default function EditUserPage() {
       setNrp(n);
       setPassword(w);
       loadUser(n, w);
+      loadPendingContent();
     }
   }, [router]);
 
   async function loadUser(n, w) {
+    setProfileLoading(true);
+    setProfileError("");
     try {
       const res = await getClaimUserData(n, w);
       const user = res.data || res.user || res;
@@ -104,7 +114,22 @@ export default function EditUserPage() {
       const message = err?.message?.trim()
         ? err.message
         : "Gagal mengambil data user";
-      setError(message);
+      setProfileError(message);
+    } finally {
+      setProfileLoading(false);
+    }
+  }
+
+  async function loadPendingContent() {
+    setContentLoading(true);
+    setContentError("");
+    try {
+      const response = await getClaimPendingContent();
+      setPendingContent(response.data);
+    } catch (err) {
+      setContentError(err?.message?.trim() || "Terjadi kesalahan pada server");
+    } finally {
+      setContentLoading(false);
     }
   }
 
@@ -253,6 +278,13 @@ export default function EditUserPage() {
       cardAccent="spirit"
     >
       <div className="space-y-8">
+        <PendingContentCard
+          data={pendingContent}
+          loading={contentLoading}
+          error={contentError}
+          onRefresh={loadPendingContent}
+        />
+
         <section className="rounded-3xl border border-spirit-200/80 bg-gradient-to-br from-white/80 via-spirit-50/70 to-trust-50/70 px-6 py-5 text-sm text-neutral-slate shadow-inner">
           <div className="flex items-start gap-3">
             <Info className="mt-0.5 h-5 w-5 text-spirit-500" />
@@ -277,6 +309,15 @@ export default function EditUserPage() {
         </section>
 
         <form onSubmit={handleSubmit} className="space-y-5">
+          {profileLoading && (
+            <p role="status" className="text-sm text-neutral-slate">Memuat profil...</p>
+          )}
+          {profileError && (
+            <div className="flex items-start gap-3 rounded-2xl border border-red-200/70 bg-red-50/80 px-4 py-3 text-sm text-red-600 shadow-sm">
+              <TriangleAlert className="mt-0.5 h-4 w-4 flex-shrink-0" />
+              <span>Gagal memuat profil: {profileError}</span>
+            </div>
+          )}
           {error && (
             <div className="flex items-start gap-3 rounded-2xl border border-red-200/70 bg-red-50/80 px-4 py-3 text-sm text-red-600 shadow-sm">
               <TriangleAlert className="mt-0.5 h-4 w-4 flex-shrink-0" />

--- a/cicero-dashboard/components/claim/PendingContentCard.tsx
+++ b/cicero-dashboard/components/claim/PendingContentCard.tsx
@@ -1,0 +1,161 @@
+import { ExternalLink, Instagram, RefreshCw, TriangleAlert } from "lucide-react";
+
+import type {
+  ClaimPendingContentResponse,
+  ClaimPendingContentItem,
+  ClaimPendingPlatformContent,
+} from "@/utils/api";
+
+type Props = {
+  data: ClaimPendingContentResponse["data"] | null;
+  loading: boolean;
+  error: string;
+  onRefresh: () => void;
+};
+
+const platformDetails = {
+  instagram: { label: "Instagram", action: "Like", icon: Instagram },
+  tiktok: { label: "TikTok", action: "Comment", icon: ExternalLink },
+} as const;
+
+function safeContentUrl(value: string | null, platform: keyof typeof platformDetails) {
+  if (!value) return null;
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol !== "https:") return null;
+    const hostname = parsed.hostname.toLowerCase();
+    const allowedHosts =
+      platform === "instagram"
+        ? ["instagram.com", "www.instagram.com"]
+        : ["tiktok.com", "www.tiktok.com", "m.tiktok.com"];
+    return allowedHosts.includes(hostname) ? parsed.toString() : null;
+  } catch {
+    return null;
+  }
+}
+
+function formatContentDate(value: string | null) {
+  if (!value) return "Tanggal tidak tersedia";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "Tanggal tidak tersedia";
+  return new Intl.DateTimeFormat("id-ID", {
+    dateStyle: "medium",
+    timeZone: "Asia/Jakarta",
+  }).format(date);
+}
+
+function ContentItem({
+  item,
+  platform,
+}: {
+  item: ClaimPendingContentItem;
+  platform: keyof typeof platformDetails;
+}) {
+  const url = safeContentUrl(item.url, platform);
+  return (
+    <li className="rounded-2xl border border-neutral-200 bg-white p-4 shadow-sm">
+      <p className="line-clamp-2 text-sm font-medium text-neutral-navy">
+        {item.caption?.trim() || "Caption tidak tersedia"}
+      </p>
+      <div className="mt-3 flex flex-wrap items-center justify-between gap-3 text-xs text-neutral-slate">
+        <div className="space-y-1">
+          <p>{formatContentDate(item.content_time)}</p>
+          <p className="font-semibold text-amber-600">Belum tercatat</p>
+        </div>
+        {url && (
+          <a
+            href={url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 rounded-xl border border-spirit-200 px-3 py-2 font-semibold text-spirit-600 transition hover:bg-spirit-50"
+          >
+            Buka Konten <ExternalLink className="h-3.5 w-3.5" />
+          </a>
+        )}
+      </div>
+    </li>
+  );
+}
+
+function PlatformGroup({
+  platform,
+  content,
+}: {
+  platform: keyof typeof platformDetails;
+  content: ClaimPendingPlatformContent;
+}) {
+  const details = platformDetails[platform];
+  const Icon = details.icon;
+  return (
+    <section aria-label={`${details.label} - ${details.action}`} className="space-y-3">
+      <div className="flex items-center gap-2">
+        <Icon className="h-4 w-4 text-spirit-500" />
+        <h3 className="font-semibold text-neutral-navy">{details.label}</h3>
+        <span className="rounded-full bg-spirit-100 px-2 py-1 text-xs font-semibold text-spirit-700">
+          {details.action}
+        </span>
+      </div>
+      {!content.username_available ? (
+        <p className="rounded-2xl bg-amber-50 p-4 text-sm text-amber-700">
+          Username {details.label} belum terdaftar. Tambahkan username platform pada profil untuk memantau aktivitas.
+        </p>
+      ) : content.items.length === 0 ? (
+        <p className="rounded-2xl bg-emerald-50 p-4 text-sm text-emerald-700">
+          Tidak ada konten tertunda untuk {details.label}.
+        </p>
+      ) : (
+        <ul className="grid gap-3 sm:grid-cols-2">
+          {content.items.map((item, index) => (
+            <ContentItem
+              key={item.shortcode || item.video_id || `${platform}-${index}`}
+              item={item}
+              platform={platform}
+            />
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+export default function PendingContentCard({ data, loading, error, onRefresh }: Props) {
+  return (
+    <section className="space-y-5 rounded-3xl border border-spirit-200/80 bg-white/90 p-5 shadow-sm" aria-busy={loading}>
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold text-neutral-navy">Aktivitas Konten Tertunda</h2>
+          <p className="mt-1 max-w-2xl text-sm text-neutral-slate">
+            Data berdasarkan hasil sinkronisasi CICERO dan mungkin membutuhkan waktu untuk diperbarui.
+          </p>
+        </div>
+        <button type="button" onClick={onRefresh} disabled={loading} className="inline-flex items-center gap-2 rounded-xl border border-spirit-200 px-3 py-2 text-sm font-semibold text-spirit-600 disabled:opacity-60">
+          <RefreshCw className={`h-4 w-4 ${loading ? "animate-spin" : ""}`} />
+          Refresh
+        </button>
+      </div>
+
+      {loading && !data && <p role="status" className="text-sm text-neutral-slate">Memuat konten tertunda...</p>}
+      {error && (
+        <div role="alert" className="flex gap-2 rounded-2xl bg-red-50 p-4 text-sm text-red-600">
+          <TriangleAlert className="h-4 w-4 shrink-0" /> Gagal memuat konten tertunda: {error}
+        </div>
+      )}
+      {data && (
+        <>
+          <div className="grid grid-cols-2 gap-3">
+            <div className="rounded-2xl bg-gradient-to-br from-fuchsia-50 to-orange-50 p-4">
+              <p className="text-xs text-neutral-slate">Instagram tertunda</p>
+              <p className="text-2xl font-bold text-neutral-navy">{data.instagram.pending_content}</p>
+            </div>
+            <div className="rounded-2xl bg-neutral-100 p-4">
+              <p className="text-xs text-neutral-slate">TikTok tertunda</p>
+              <p className="text-2xl font-bold text-neutral-navy">{data.tiktok.pending_content}</p>
+            </div>
+          </div>
+          <PlatformGroup platform="instagram" content={data.instagram} />
+          <PlatformGroup platform="tiktok" content={data.tiktok} />
+        </>
+      )}
+    </section>
+  );
+}

--- a/cicero-dashboard/utils/api.ts
+++ b/cicero-dashboard/utils/api.ts
@@ -3910,6 +3910,40 @@ export type ClaimCredentialPayload = {
   password: string;
 };
 
+export type ClaimPendingContentItem = {
+  shortcode?: string;
+  video_id?: string;
+  url: string | null;
+  caption: string | null;
+  content_time: string | null;
+};
+
+export type ClaimPendingPlatformContent = {
+  username_available: boolean;
+  usernames: string[];
+  total_content: number;
+  completed_content: number;
+  pending_content: number;
+  items: ClaimPendingContentItem[];
+  completed_ids: string[];
+};
+
+export type ClaimPendingContentResponse = {
+  success: boolean;
+  data: {
+    user_id: string;
+    timezone: string;
+    filters: {
+      periode: "harian" | "mingguan" | "bulanan" | "semua";
+      tanggal: string | null;
+      start_date: string | null;
+      end_date: string | null;
+    };
+    instagram: ClaimPendingPlatformContent;
+    tiktok: ClaimPendingPlatformContent;
+  };
+};
+
 export type ClaimPasswordResetRequestPayload = {
   nrp: string;
   email?: string;
@@ -4069,6 +4103,23 @@ export async function getClaimUserData(
   }
 
   return data;
+}
+
+export async function getClaimPendingContent(): Promise<ClaimPendingContentResponse> {
+  const url = buildApiUrl("/api/claim/pending-content");
+  const res = await fetch(url, {
+    method: "GET",
+    credentials: "include",
+  });
+  const data = await res.json().catch(() => null);
+
+  if (!res.ok) {
+    throw new Error(
+      extractResponseMessage(data, "Gagal memuat konten yang belum tercatat"),
+    );
+  }
+
+  return data as ClaimPendingContentResponse;
 }
 
 // Update user data after credential verification


### PR DESCRIPTION
### Motivation
- Backend exposes `GET /api/claim/pending-content` returning per-platform pending engagement items; the dashboard must surface this to claim users.  
- The claim edit page should load profile and pending-content independently so a failure in one does not block the other.  
- Keep `page.jsx` manageable by moving pending-content UI into a dedicated component and provide explicit states and a manual refresh.  

### Description
- Added new API types and client function `getClaimPendingContent()` in `cicero-dashboard/utils/api.ts` that calls `GET /api/claim/pending-content` with `credentials:

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a75e8b5eeb0832787438888bbec326a)