### PR TITLE
feat(claim): add pending-content complaint triage UI and API client

### DIFF
--- a/cicero-dashboard/__tests__/PendingContentCard.test.tsx
+++ b/cicero-dashboard/__tests__/PendingContentCard.test.tsx
@@ -1,7 +1,15 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 import PendingContentCard from "@/components/claim/PendingContentCard";
 import type { ClaimPendingContentResponse } from "@/utils/api";
+
+const triageClaimComplaint = jest.fn();
+const escalateClaimComplaint = jest.fn();
+jest.mock("@/utils/api", () => ({
+  ...jest.requireActual("@/utils/api"),
+  triageClaimComplaint: (...args: unknown[]) => triageClaimComplaint(...args),
+  escalateClaimComplaint: (...args: unknown[]) => escalateClaimComplaint(...args),
+}));
 
 const platform = (overrides = {}) => ({
   username_available: true,
@@ -24,6 +32,7 @@ const responseData = (overrides = {}): ClaimPendingContentResponse["data"] => ({
 });
 
 describe("PendingContentCard", () => {
+  beforeEach(() => jest.clearAllMocks());
   it("menampilkan state response kosong per platform", () => {
     render(<PendingContentCard data={responseData()} loading={false} error="" onRefresh={jest.fn()} />);
     expect(screen.getByText("Tidak ada konten tertunda untuk Instagram.")).toBeTruthy();
@@ -80,5 +89,51 @@ describe("PendingContentCard", () => {
     expect(links[0].getAttribute("href")).toBe("https://www.instagram.com/p/C");
     expect(links[0].getAttribute("target")).toBe("_blank");
     expect(links[0].getAttribute("rel")).toBe("noopener noreferrer");
+  });
+
+  it.each([
+    ["instagram", "IG1", "shortcode", "Instagram"],
+    ["tiktok", "TT1", "video_id", "TikTok"],
+  ] as const)("mengirim triase item %s dengan token dan identifier platform", async (platformName, id, identifierField, label) => {
+    triageClaimComplaint.mockResolvedValue({
+      platform: platformName, content_id: id, triage_code: "ENGAGEMENT_NOT_IN_SNAPSHOT", triage_quality: "medium",
+      title: "Aktivitas belum terlihat", summary: "Bukti belum ditemukan.", evidence: [{ label: "Username tersimpan", value: "cicero", status: "tersedia" }],
+      solutions: [{ order: 1, label: "Periksa kembali konten." }], last_collected_at: null, can_retry: true, retry_after: null, can_escalate: true,
+    });
+    const item = platformName === "instagram" ? { shortcode: id } : { video_id: id };
+    render(<PendingContentCard claimToken="claim-jwt" loading={false} error="" onRefresh={jest.fn()} data={responseData({ [platformName]: platform({ pending_content: 1, items: [{ ...item, url: null, caption: `Konten ${label}`, content_time: null }] }) })} />);
+    fireEvent.click(screen.getByRole("button", { name: "Komplain" }));
+    expect(screen.getByText(label, { selector: "dd" })).toBeTruthy();
+    expect(screen.getByText("@cicero")).toBeTruthy();
+    fireEvent.change(screen.getByLabelText("Perkiraan waktu pelaksanaan"), { target: { value: "2026-08-09T10:30" } });
+    fireEvent.click(screen.getByRole("button", { name: "Kirim Komplain" }));
+    await waitFor(() => expect(triageClaimComplaint).toHaveBeenCalled());
+    expect(triageClaimComplaint).toHaveBeenCalledWith("claim-jwt", expect.objectContaining({ platform: platformName, issue_type: "activity_not_recorded", [identifierField]: id }));
+    expect(screen.getByText("Aktivitas belum terlihat")).toBeTruthy();
+    expect(screen.getByText("Kualitas triase: medium")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Periksa ulang" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Eskalasi" })).toBeTruthy();
+  });
+
+  it("tidak menyediakan Komplain saat akun belum terisi", () => {
+    render(<PendingContentCard claimToken="claim-jwt" loading={false} error="" onRefresh={jest.fn()} data={responseData({ instagram: platform({ username_available: false, usernames: [], pending_content: 1, items: [{ shortcode: "IG1" }] }) })} />);
+    expect(screen.queryByRole("button", { name: "Komplain" })).toBeNull();
+  });
+
+  it("refresh sinkronisasi setelah backend menyatakan aktivitas sudah tercatat", async () => {
+    const onRefresh = jest.fn().mockResolvedValue(undefined);
+    triageClaimComplaint.mockResolvedValue({
+      platform: "instagram", content_id: "IG1", triage_code: "ACTIVITY_ALREADY_RECORDED", triage_quality: "high",
+      title: "Aktivitas sudah tercatat", summary: "Muat ulang untuk hasil terbaru.", evidence: [], solutions: [{ order: 1, label: "Muat ulang." }],
+      last_collected_at: "2026-08-09T03:05:00.000Z", can_retry: false, retry_after: null, can_escalate: false,
+    });
+    render(<PendingContentCard claimToken="claim-jwt" loading={false} error="" onRefresh={onRefresh} data={responseData({ instagram: platform({ pending_content: 1, items: [{ shortcode: "IG1", url: null, caption: "Konten", content_time: null }] }) })} />);
+    fireEvent.click(screen.getByRole("button", { name: "Komplain" }));
+    const submit = screen.getByRole("button", { name: "Kirim Komplain" });
+    fireEvent.click(submit); fireEvent.click(submit);
+    await waitFor(() => expect(onRefresh).toHaveBeenCalledTimes(1));
+    expect(triageClaimComplaint).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("Aktivitas sudah tercatat")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Eskalasi" })).toBeNull();
   });
 });

--- a/cicero-dashboard/app/claim/edit/page.jsx
+++ b/cicero-dashboard/app/claim/edit/page.jsx
@@ -22,6 +22,7 @@ import {
 export default function EditUserPage() {
   const [nrp, setNrp] = useState("");
   const [password, setPassword] = useState("");
+  const [claimToken, setClaimToken] = useState("");
   const [kesatuan, setKesatuan] = useState("");
   const [nama, setNama] = useState("");
   const [pangkat, setPangkat] = useState("");
@@ -58,14 +59,16 @@ export default function EditUserPage() {
     if (typeof window !== "undefined") {
       const n = sessionStorage.getItem("claim_nrp");
       const w = sessionStorage.getItem("claim_password");
-      if (!n || !w) {
+      const token = sessionStorage.getItem("claim_token");
+      if (!n || !w || !token) {
         router.replace("/claim");
         return;
       }
       setNrp(n);
       setPassword(w);
+      setClaimToken(token);
       loadUser(n, w);
-      loadPendingContent();
+      loadPendingContent(token);
     }
   }, [router]);
 
@@ -120,11 +123,11 @@ export default function EditUserPage() {
     }
   }
 
-  async function loadPendingContent() {
+  async function loadPendingContent(token = claimToken) {
     setContentLoading(true);
     setContentError("");
     try {
-      const response = await getClaimPendingContent();
+      const response = await getClaimPendingContent(token);
       setPendingContent(response.data);
     } catch (err) {
       setContentError(err?.message?.trim() || "Terjadi kesalahan pada server");
@@ -283,6 +286,8 @@ export default function EditUserPage() {
           loading={contentLoading}
           error={contentError}
           onRefresh={loadPendingContent}
+          claimToken={claimToken}
+          onOpenProfile={() => document.getElementById("claim-profile-form")?.scrollIntoView({ behavior: "smooth" })}
         />
 
         <section className="rounded-3xl border border-spirit-200/80 bg-gradient-to-br from-white/80 via-spirit-50/70 to-trust-50/70 px-6 py-5 text-sm text-neutral-slate shadow-inner">
@@ -308,7 +313,7 @@ export default function EditUserPage() {
           </div>
         </section>
 
-        <form onSubmit={handleSubmit} className="space-y-5">
+        <form id="claim-profile-form" onSubmit={handleSubmit} className="space-y-5">
           {profileLoading && (
             <p role="status" className="text-sm text-neutral-slate">Memuat profil...</p>
           )}

--- a/cicero-dashboard/app/claim/page.jsx
+++ b/cicero-dashboard/app/claim/page.jsx
@@ -54,10 +54,11 @@ export default function ClaimPage() {
     }
   }, []);
 
-  const saveClaimSession = (trimmedNrp, trimmedPassword) => {
+  const saveClaimSession = (trimmedNrp, trimmedPassword, token) => {
     if (typeof window === "undefined") return;
     sessionStorage.setItem("claim_nrp", trimmedNrp);
     sessionStorage.setItem("claim_password", trimmedPassword);
+    if (token) sessionStorage.setItem("claim_token", token);
   };
 
   const clearForm = () => {
@@ -121,7 +122,7 @@ export default function ClaimPage() {
     try {
       const res = await loginClaimUser({ nrp: trimmedNrp, password: trimmedPassword });
       if (res.success !== false) {
-        saveClaimSession(trimmedNrp, trimmedPassword);
+        saveClaimSession(trimmedNrp, trimmedPassword, res.token);
         router.push("/claim/edit");
       } else {
         setError(res.message || "Login gagal.");

--- a/cicero-dashboard/components/claim/PendingContentCard.tsx
+++ b/cicero-dashboard/components/claim/PendingContentCard.tsx
@@ -1,161 +1,167 @@
-import { ExternalLink, Instagram, RefreshCw, TriangleAlert } from "lucide-react";
+"use client";
 
-import type {
-  ClaimPendingContentResponse,
-  ClaimPendingContentItem,
-  ClaimPendingPlatformContent,
+import * as Dialog from "@radix-ui/react-dialog";
+import { useEffect, useState } from "react";
+import { ExternalLink, Instagram, RefreshCw, TriangleAlert, X } from "lucide-react";
+
+import {
+  escalateClaimComplaint,
+  triageClaimComplaint,
+  type ClaimComplaintTriage,
+  type ClaimPendingContentResponse,
+  type ClaimPendingContentItem,
+  type ClaimPendingPlatformContent,
 } from "@/utils/api";
 
+type Platform = "instagram" | "tiktok";
 type Props = {
   data: ClaimPendingContentResponse["data"] | null;
   loading: boolean;
   error: string;
-  onRefresh: () => void;
+  onRefresh: () => void | Promise<void>;
+  claimToken?: string;
+  onOpenProfile?: () => void;
 };
 
+type Selection = { item: ClaimPendingContentItem; platform: Platform; username: string };
 const platformDetails = {
   instagram: { label: "Instagram", action: "Like", icon: Instagram },
   tiktok: { label: "TikTok", action: "Comment", icon: ExternalLink },
 } as const;
 
-function safeContentUrl(value: string | null, platform: keyof typeof platformDetails) {
+function safeContentUrl(value: string | null, platform: Platform) {
   if (!value) return null;
   try {
     const parsed = new URL(value);
     if (parsed.protocol !== "https:") return null;
-    const hostname = parsed.hostname.toLowerCase();
-    const allowedHosts =
-      platform === "instagram"
-        ? ["instagram.com", "www.instagram.com"]
-        : ["tiktok.com", "www.tiktok.com", "m.tiktok.com"];
-    return allowedHosts.includes(hostname) ? parsed.toString() : null;
-  } catch {
-    return null;
-  }
+    const allowedHosts = platform === "instagram"
+      ? ["instagram.com", "www.instagram.com"]
+      : ["tiktok.com", "www.tiktok.com", "m.tiktok.com"];
+    return allowedHosts.includes(parsed.hostname.toLowerCase()) ? parsed.toString() : null;
+  } catch { return null; }
 }
 
 function formatContentDate(value: string | null) {
   if (!value) return "Tanggal tidak tersedia";
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return "Tanggal tidak tersedia";
-  return new Intl.DateTimeFormat("id-ID", {
-    dateStyle: "medium",
-    timeZone: "Asia/Jakarta",
-  }).format(date);
+  return new Intl.DateTimeFormat("id-ID", { dateStyle: "medium", timeZone: "Asia/Jakarta" }).format(date);
 }
 
-function ContentItem({
-  item,
-  platform,
-}: {
-  item: ClaimPendingContentItem;
-  platform: keyof typeof platformDetails;
+function ContentItem({ item, platform, username, onComplaint }: {
+  item: ClaimPendingContentItem; platform: Platform; username: string; onComplaint: (selection: Selection) => void;
 }) {
   const url = safeContentUrl(item.url, platform);
   return (
     <li className="rounded-2xl border border-neutral-200 bg-white p-4 shadow-sm">
-      <p className="line-clamp-2 text-sm font-medium text-neutral-navy">
-        {item.caption?.trim() || "Caption tidak tersedia"}
-      </p>
+      <p className="line-clamp-2 text-sm font-medium text-neutral-navy">{item.caption?.trim() || "Caption tidak tersedia"}</p>
       <div className="mt-3 flex flex-wrap items-center justify-between gap-3 text-xs text-neutral-slate">
-        <div className="space-y-1">
-          <p>{formatContentDate(item.content_time)}</p>
-          <p className="font-semibold text-amber-600">Belum tercatat</p>
+        <div className="space-y-1"><p>{formatContentDate(item.content_time)}</p><p className="font-semibold text-amber-600">Belum tercatat</p></div>
+        <div className="flex gap-2">
+          {url && <a href={url} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1.5 rounded-xl border border-spirit-200 px-3 py-2 font-semibold text-spirit-600">Buka Konten <ExternalLink className="h-3.5 w-3.5" /></a>}
+          <button type="button" onClick={() => onComplaint({ item, platform, username })} className="rounded-xl bg-amber-500 px-3 py-2 font-semibold text-white hover:bg-amber-600">Komplain</button>
         </div>
-        {url && (
-          <a
-            href={url}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center gap-1.5 rounded-xl border border-spirit-200 px-3 py-2 font-semibold text-spirit-600 transition hover:bg-spirit-50"
-          >
-            Buka Konten <ExternalLink className="h-3.5 w-3.5" />
-          </a>
-        )}
       </div>
     </li>
   );
 }
 
-function PlatformGroup({
-  platform,
-  content,
-}: {
-  platform: keyof typeof platformDetails;
-  content: ClaimPendingPlatformContent;
-}) {
-  const details = platformDetails[platform];
-  const Icon = details.icon;
-  return (
-    <section aria-label={`${details.label} - ${details.action}`} className="space-y-3">
-      <div className="flex items-center gap-2">
-        <Icon className="h-4 w-4 text-spirit-500" />
-        <h3 className="font-semibold text-neutral-navy">{details.label}</h3>
-        <span className="rounded-full bg-spirit-100 px-2 py-1 text-xs font-semibold text-spirit-700">
-          {details.action}
-        </span>
-      </div>
-      {!content.username_available ? (
-        <p className="rounded-2xl bg-amber-50 p-4 text-sm text-amber-700">
-          Username {details.label} belum terdaftar. Tambahkan username platform pada profil untuk memantau aktivitas.
-        </p>
-      ) : content.items.length === 0 ? (
-        <p className="rounded-2xl bg-emerald-50 p-4 text-sm text-emerald-700">
-          Tidak ada konten tertunda untuk {details.label}.
-        </p>
-      ) : (
-        <ul className="grid gap-3 sm:grid-cols-2">
-          {content.items.map((item, index) => (
-            <ContentItem
-              key={item.shortcode || item.video_id || `${platform}-${index}`}
-              item={item}
-              platform={platform}
-            />
-          ))}
-        </ul>
-      )}
-    </section>
-  );
+function PlatformGroup({ platform, content, onComplaint }: { platform: Platform; content: ClaimPendingPlatformContent; onComplaint: (selection: Selection) => void }) {
+  const details = platformDetails[platform]; const Icon = details.icon;
+  return <section aria-label={`${details.label} - ${details.action}`} className="space-y-3">
+    <div className="flex items-center gap-2"><Icon className="h-4 w-4 text-spirit-500" /><h3 className="font-semibold text-neutral-navy">{details.label}</h3><span className="rounded-full bg-spirit-100 px-2 py-1 text-xs font-semibold text-spirit-700">{details.action}</span></div>
+    {!content.username_available ? <p className="rounded-2xl bg-amber-50 p-4 text-sm text-amber-700">Username {details.label} belum terdaftar. Tambahkan username platform pada profil untuk memantau aktivitas.</p>
+      : content.items.length === 0 ? <p className="rounded-2xl bg-emerald-50 p-4 text-sm text-emerald-700">Tidak ada konten tertunda untuk {details.label}.</p>
+      : <ul className="grid gap-3 sm:grid-cols-2">{content.items.map((item, index) => <ContentItem key={item.shortcode || item.video_id || `${platform}-${index}`} item={item} platform={platform} username={content.usernames[0] || ""} onComplaint={onComplaint} />)}</ul>}
+  </section>;
 }
 
-export default function PendingContentCard({ data, loading, error, onRefresh }: Props) {
-  return (
-    <section className="space-y-5 rounded-3xl border border-spirit-200/80 bg-white/90 p-5 shadow-sm" aria-busy={loading}>
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        <div>
-          <h2 className="text-lg font-semibold text-neutral-navy">Aktivitas Konten Tertunda</h2>
-          <p className="mt-1 max-w-2xl text-sm text-neutral-slate">
-            Data berdasarkan hasil sinkronisasi CICERO dan mungkin membutuhkan waktu untuk diperbarui.
-          </p>
-        </div>
-        <button type="button" onClick={onRefresh} disabled={loading} className="inline-flex items-center gap-2 rounded-xl border border-spirit-200 px-3 py-2 text-sm font-semibold text-spirit-600 disabled:opacity-60">
-          <RefreshCw className={`h-4 w-4 ${loading ? "animate-spin" : ""}`} />
-          Refresh
-        </button>
-      </div>
+function ComplaintDialog({ selection, token, filters, onClose, onRefresh, onOpenProfile }: {
+  selection: Selection; token: string; filters: ClaimPendingContentResponse["data"]["filters"];
+  onClose: () => void; onRefresh: () => void | Promise<void>; onOpenProfile?: () => void;
+}) {
+  const [performedAt, setPerformedAt] = useState("");
+  const [result, setResult] = useState<ClaimComplaintTriage | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [escalating, setEscalating] = useState(false);
+  const [error, setError] = useState("");
+  const [now, setNow] = useState(Date.now());
+  const identifier = selection.platform === "instagram" ? selection.item.shortcode : selection.item.video_id;
+  const retryAt = result?.retry_after ? Date.parse(result.retry_after) : 0;
+  const retryReady = !retryAt || now >= retryAt;
 
-      {loading && !data && <p role="status" className="text-sm text-neutral-slate">Memuat konten tertunda...</p>}
-      {error && (
-        <div role="alert" className="flex gap-2 rounded-2xl bg-red-50 p-4 text-sm text-red-600">
-          <TriangleAlert className="h-4 w-4 shrink-0" /> Gagal memuat konten tertunda: {error}
+  useEffect(() => {
+    if (!retryAt || retryReady) return;
+    const timer = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(timer);
+  }, [retryAt, retryReady]);
+
+  async function submit() {
+    if (!identifier || submitting) return;
+    setSubmitting(true); setError("");
+    try {
+      const triage = await triageClaimComplaint(token, {
+        platform: selection.platform,
+        issue_type: "activity_not_recorded",
+        ...(selection.platform === "instagram" ? { shortcode: identifier } : { video_id: identifier }),
+        ...(performedAt ? { performed_at: new Date(performedAt).toISOString() } : {}),
+        periode: filters.periode,
+        ...(filters.tanggal ? { tanggal: filters.tanggal } : {}),
+        ...(filters.start_date ? { start_date: filters.start_date } : {}),
+        ...(filters.end_date ? { end_date: filters.end_date } : {}),
+      });
+      setResult(triage);
+      if (triage.triage_code === "ACTIVITY_ALREADY_RECORDED") await onRefresh();
+    } catch (err) { setError(err instanceof Error ? err.message : "Gagal memeriksa kendala aktivitas"); }
+    finally { setSubmitting(false); }
+  }
+
+  async function escalate() {
+    if (!result || escalating) return;
+    setEscalating(true); setError("");
+    try { await escalateClaimComplaint(token, result); onClose(); }
+    catch (err) { setError(err instanceof Error ? err.message : "Gagal mengeskalasi komplain"); }
+    finally { setEscalating(false); }
+  }
+
+  const needsProfileUpdate = result && ["SOCIAL_USERNAME_MISSING", "SOCIAL_USERNAME_MISMATCH"].includes(result.triage_code);
+  return <Dialog.Root open onOpenChange={(open) => !open && onClose()}>
+    <Dialog.Portal><Dialog.Overlay className="fixed inset-0 z-50 bg-black/60" />
+      <Dialog.Content className="fixed left-1/2 top-1/2 z-50 max-h-[90vh] w-[calc(100%-2rem)] max-w-xl -translate-x-1/2 -translate-y-1/2 overflow-y-auto rounded-3xl bg-white p-6 shadow-xl">
+        <Dialog.Title className="text-xl font-semibold text-neutral-navy">Konfirmasi Komplain Aktivitas</Dialog.Title>
+        <Dialog.Description className="mt-1 text-sm text-neutral-slate">Tipe kendala tetap: aktivitas sudah dilakukan tetapi belum tercatat.</Dialog.Description>
+        <Dialog.Close aria-label="Tutup" className="absolute right-5 top-5"><X className="h-5 w-5" /></Dialog.Close>
+        <dl className="mt-5 grid gap-2 rounded-2xl bg-neutral-50 p-4 text-sm">
+          <div><dt className="font-semibold">Platform</dt><dd>{platformDetails[selection.platform].label}</dd></div>
+          <div><dt className="font-semibold">Konten</dt><dd>{selection.item.caption?.trim() || identifier}</dd></div>
+          <div><dt className="font-semibold">Username tersimpan</dt><dd>{selection.username ? `@${selection.username.replace(/^@/, "")}` : "Belum tersedia"}</dd></div>
+        </dl>
+        {!result && <label className="mt-4 block text-sm font-semibold">Perkiraan waktu pelaksanaan (opsional)<input aria-label="Perkiraan waktu pelaksanaan" type="datetime-local" value={performedAt} onChange={(event) => setPerformedAt(event.target.value)} className="mt-2 w-full rounded-xl border border-neutral-300 px-3 py-2 font-normal" /></label>}
+        {error && <p role="alert" className="mt-4 rounded-xl bg-red-50 p-3 text-sm text-red-600">{error}</p>}
+        {result && <section className="mt-5 space-y-4" aria-label="Hasil triase">
+          <div><h3 className="text-lg font-bold text-neutral-navy">{result.title}</h3><p className="text-sm text-neutral-slate">{result.summary}</p><p className="mt-2 text-xs font-semibold uppercase">Kualitas triase: {result.triage_quality}</p></div>
+          <div><h4 className="font-semibold">Bukti</h4><dl className="mt-2 space-y-2">{result.evidence.map((entry, index) => <div key={`${entry.label}-${index}`} className="rounded-xl bg-neutral-50 p-3 text-sm"><dt className="font-semibold">{entry.label}</dt><dd>{entry.value ?? "Tidak tersedia"} <span className="text-neutral-slate">({entry.status})</span></dd></div>)}</dl></div>
+          <div><h4 className="font-semibold">Langkah solusi</h4><ol className="mt-2 list-decimal space-y-1 pl-5 text-sm">{[...result.solutions].sort((a, b) => a.order - b.order).map((step) => <li key={`${step.order}-${step.label}`}>{step.label}</li>)}</ol></div>
+          {result.last_collected_at && <p className="text-xs text-neutral-slate">Sinkronisasi terakhir: {new Date(result.last_collected_at).toLocaleString("id-ID", { timeZone: "Asia/Jakarta" })}</p>}
+        </section>}
+        <div className="mt-6 flex flex-wrap justify-end gap-2">
+          {result?.triage_code === "ACTIVITY_ALREADY_RECORDED" && <button type="button" onClick={onRefresh} className="rounded-xl border px-4 py-2 text-sm font-semibold">Refresh pending content</button>}
+          {needsProfileUpdate && <button type="button" onClick={() => { onClose(); onOpenProfile?.(); }} className="rounded-xl border px-4 py-2 text-sm font-semibold">Buka Update Data Personil</button>}
+          {result?.can_retry && <button type="button" disabled={!retryReady || submitting} onClick={submit} className="rounded-xl border px-4 py-2 text-sm font-semibold disabled:opacity-50">{retryReady ? "Periksa ulang" : `Periksa setelah ${new Date(retryAt).toLocaleString("id-ID")}`}</button>}
+          {result?.can_escalate && <button type="button" disabled={escalating} onClick={escalate} className="rounded-xl bg-red-600 px-4 py-2 text-sm font-semibold text-white disabled:opacity-50">{escalating ? "Mengeskalasi..." : "Eskalasi"}</button>}
+          {!result && <button type="button" disabled={submitting || !identifier || !token} onClick={submit} className="rounded-xl bg-spirit-600 px-4 py-2 text-sm font-semibold text-white disabled:opacity-50">{submitting ? "Memeriksa..." : "Kirim Komplain"}</button>}
         </div>
-      )}
-      {data && (
-        <>
-          <div className="grid grid-cols-2 gap-3">
-            <div className="rounded-2xl bg-gradient-to-br from-fuchsia-50 to-orange-50 p-4">
-              <p className="text-xs text-neutral-slate">Instagram tertunda</p>
-              <p className="text-2xl font-bold text-neutral-navy">{data.instagram.pending_content}</p>
-            </div>
-            <div className="rounded-2xl bg-neutral-100 p-4">
-              <p className="text-xs text-neutral-slate">TikTok tertunda</p>
-              <p className="text-2xl font-bold text-neutral-navy">{data.tiktok.pending_content}</p>
-            </div>
-          </div>
-          <PlatformGroup platform="instagram" content={data.instagram} />
-          <PlatformGroup platform="tiktok" content={data.tiktok} />
-        </>
-      )}
-    </section>
-  );
+      </Dialog.Content></Dialog.Portal>
+  </Dialog.Root>;
+}
+
+export default function PendingContentCard({ data, loading, error, onRefresh, claimToken = "", onOpenProfile }: Props) {
+  const [selection, setSelection] = useState<Selection | null>(null);
+  return <section className="space-y-5 rounded-3xl border border-spirit-200/80 bg-white/90 p-5 shadow-sm" aria-busy={loading}>
+    <div className="flex flex-wrap items-start justify-between gap-3"><div><h2 className="text-lg font-semibold text-neutral-navy">Aktivitas Konten Tertunda</h2><p className="mt-1 max-w-2xl text-sm text-neutral-slate">Data berdasarkan hasil sinkronisasi CICERO dan mungkin membutuhkan waktu untuk diperbarui.</p></div><button type="button" onClick={onRefresh} disabled={loading} className="inline-flex items-center gap-2 rounded-xl border border-spirit-200 px-3 py-2 text-sm font-semibold text-spirit-600 disabled:opacity-60"><RefreshCw className={`h-4 w-4 ${loading ? "animate-spin" : ""}`} />Refresh</button></div>
+    {loading && !data && <p role="status" className="text-sm text-neutral-slate">Memuat konten tertunda...</p>}
+    {error && <div role="alert" className="flex gap-2 rounded-2xl bg-red-50 p-4 text-sm text-red-600"><TriangleAlert className="h-4 w-4 shrink-0" /> Gagal memuat konten tertunda: {error}</div>}
+    {data && <><div className="grid grid-cols-2 gap-3"><div className="rounded-2xl bg-gradient-to-br from-fuchsia-50 to-orange-50 p-4"><p className="text-xs text-neutral-slate">Instagram tertunda</p><p className="text-2xl font-bold text-neutral-navy">{data.instagram.pending_content}</p></div><div className="rounded-2xl bg-neutral-100 p-4"><p className="text-xs text-neutral-slate">TikTok tertunda</p><p className="text-2xl font-bold text-neutral-navy">{data.tiktok.pending_content}</p></div></div><PlatformGroup platform="instagram" content={data.instagram} onComplaint={setSelection} /><PlatformGroup platform="tiktok" content={data.tiktok} onComplaint={setSelection} /></>}
+    {selection && data && <ComplaintDialog selection={selection} token={claimToken} filters={data.filters} onClose={() => setSelection(null)} onRefresh={onRefresh} onOpenProfile={onOpenProfile} />}
+  </section>;
 }

--- a/cicero-dashboard/utils/api.ts
+++ b/cicero-dashboard/utils/api.ts
@@ -3944,6 +3944,33 @@ export type ClaimPendingContentResponse = {
   };
 };
 
+export type ClaimComplaintTriage = {
+  platform: "instagram" | "tiktok";
+  content_id: string;
+  triage_code: string;
+  triage_quality: "low" | "medium" | "high";
+  title: string;
+  summary: string;
+  evidence: Array<{ label: string; value: string | null; status: string }>;
+  solutions: Array<{ order: number; label: string }>;
+  last_collected_at: string | null;
+  can_retry: boolean;
+  retry_after: string | null;
+  can_escalate: boolean;
+};
+
+export type ClaimComplaintTriagePayload = {
+  platform: "instagram" | "tiktok";
+  issue_type: "activity_not_recorded";
+  shortcode?: string;
+  video_id?: string;
+  performed_at?: string;
+  periode?: "harian" | "mingguan" | "bulanan" | "semua";
+  tanggal?: string;
+  start_date?: string;
+  end_date?: string;
+};
+
 export type ClaimPasswordResetRequestPayload = {
   nrp: string;
   email?: string;
@@ -4105,10 +4132,15 @@ export async function getClaimUserData(
   return data;
 }
 
-export async function getClaimPendingContent(): Promise<ClaimPendingContentResponse> {
+function claimAuthHeaders(token?: string) {
+  return token ? { Authorization: `Bearer ${token}` } : undefined;
+}
+
+export async function getClaimPendingContent(token?: string): Promise<ClaimPendingContentResponse> {
   const url = buildApiUrl("/api/claim/pending-content");
   const res = await fetch(url, {
     method: "GET",
+    headers: claimAuthHeaders(token),
     credentials: "include",
   });
   const data = await res.json().catch(() => null);
@@ -4120,6 +4152,54 @@ export async function getClaimPendingContent(): Promise<ClaimPendingContentRespo
   }
 
   return data as ClaimPendingContentResponse;
+}
+
+export async function triageClaimComplaint(
+  token: string,
+  payload: ClaimComplaintTriagePayload,
+): Promise<ClaimComplaintTriage> {
+  const res = await fetch(buildApiUrl("/api/claim/complaints/triage"), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...claimAuthHeaders(token),
+    },
+    credentials: "include",
+    body: JSON.stringify(payload),
+  });
+  const response = await res.json().catch(() => null);
+  if (!res.ok) {
+    throw new Error(extractResponseMessage(response, "Gagal memeriksa kendala aktivitas"));
+  }
+  return response.data as ClaimComplaintTriage;
+}
+
+export async function escalateClaimComplaint(
+  token: string,
+  triage: ClaimComplaintTriage,
+): Promise<void> {
+  const createResponse = await fetch(buildApiUrl("/api/claim/complaints"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...claimAuthHeaders(token) },
+    credentials: "include",
+    body: JSON.stringify({ triage }),
+  });
+  const created = await createResponse.json().catch(() => null);
+  if (!createResponse.ok || !created?.data?.complaint_id) {
+    throw new Error(extractResponseMessage(created, "Gagal membuat eskalasi komplain"));
+  }
+  const escalationResponse = await fetch(
+    buildApiUrl(`/api/claim/complaints/${encodeURIComponent(created.data.complaint_id)}/escalate`),
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...claimAuthHeaders(token) },
+      credentials: "include",
+    },
+  );
+  const escalated = await escalationResponse.json().catch(() => null);
+  if (!escalationResponse.ok) {
+    throw new Error(extractResponseMessage(escalated, "Gagal mengeskalasi komplain"));
+  }
 }
 
 // Update user data after credential verification


### PR DESCRIPTION
### Motivation

- Provide operators a safe, backend-driven workflow to triage pending Instagram/TikTok items without guessing diagnoses in the frontend. 
- Ensure complaint requests use the authenticated claim user identity (token) and backend DTO fields so the backend remains authoritative about actionability. 
- Make the UI actionable: only show `Komplain` for Instagram/TikTok pending items, show confirmation dialog with required metadata, and surface backend-provided solutions and actions.

### Description

- Added typed API helpers in `utils/api.ts` including `triageClaimComplaint`, `escalateClaimComplaint`, and `getClaimPendingContent(token?)` that attach a Bearer `token` and call `POST /api/claim/complaints/triage` and related endpoints. 
- Persist claim auth token to `sessionStorage` at login (`claim_token`) and plumb that token into the claim edit flow so pending-content and triage requests are executed as the claim user. 
- Reworked `PendingContentCard` to render platform groups and a `Komplain` button only for Instagram/TikTok items with usernames, open a Radix dialog to confirm a fixed issue type and optional `performed_at`, and prevent double-submit while requests are ongoing. 
- Dialog renders backend DTO fields (`title`, `summary`, `triage_quality`, `evidence`, `solutions`, `last_collected_at`, `retry_after`, `can_escalate`) without making any frontend diagnosis and provides actions driven by the DTO: refresh pending content, open Update Data Personil, retry after scheduled time, or escalate via the backend. 
- When the triage response `triage_code` is `ACTIVITY_ALREADY_RECORDED`, the UI triggers a refresh of `GET /api/claim/pending-content` so completed items can be removed by the backend. 
- Added unit tests and mocks to cover Instagram/TikTok complaint flows, missing-username behavior, double-submit prevention, `ACTIVITY_ALREADY_RECORDED` handling, and interaction with the typed API client (`triageClaimComplaint`/`escalateClaimComplaint`).

### Testing

- Ran the focused Jest suites `__tests__/PendingContentCard.test.tsx` and `__tests__/claimPendingContentApi.test.ts` and they passed: `2 suites, 13 tests` all green. 
- Performed a production Next.js build (`npm run build`) and the app compiled successfully and generated static pages. 
- Ran a repository `tsc --noEmit` check which reported pre-existing TypeScript errors in unrelated test files (executive-summary and other tests); the changes in this PR do not introduce those errors and the Next build completed. 
- All new and modified unit tests for the claim/triage UI passed in CI-local runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7919f8c8d88327b16ba13626ad5cb2)