### PR TITLE
fix(claim): switch to authenticated /api/claim/me flow and stop storing claim credentials

### DIFF
--- a/cicero-dashboard/README.md
+++ b/cicero-dashboard/README.md
@@ -326,8 +326,8 @@ Flow claim sekarang mengikuti update backend terbaru (tanpa OTP email). Halaman 
 
 1. **Registrasi claim** (`POST /api/claim/register`) dengan payload `nrp` + `password`.
 2. **Login claim** (`POST /api/auth/user-login`) dengan payload `nrp` + `password`.
-3. Setelah login sukses, frontend menyimpan `claim_nrp` + `claim_password` di `sessionStorage` lalu mengarahkan pengguna ke `app/claim/edit/page.jsx`.
-4. Halaman edit mengambil data melalui `getClaimUserData(nrp, password)` (`POST /api/claim/user-data`) dan menyimpan perubahan via `updateUserViaClaim` (`PUT /api/claim/update`) menggunakan kredensial yang sama.
+3. Setelah login sukses, frontend hanya menyimpan token kompatibilitas Bearer (jika backend mengirimkannya), tidak menyimpan NRP atau password, lalu mengarahkan pengguna ke `app/claim/edit/page.jsx`.
+4. Halaman edit memvalidasi sesi cookie HttpOnly melalui `getClaimProfile()` (`GET /api/claim/me`) dan menyimpan perubahan via `updateClaimProfile()` (`PUT /api/claim/me`) tanpa mengirim NRP, user ID, atau password.
 
 ### Aturan password strength di UI registrasi claim
 

--- a/cicero-dashboard/__tests__/api.test.ts
+++ b/cicero-dashboard/__tests__/api.test.ts
@@ -8,9 +8,9 @@ import {
   getUserDirectory,
   loginClaimUser,
   registerClaimCredential,
-  getClaimUserData,
+  getClaimProfile,
   normalizeWhatsapp,
-  updateUserViaClaim,
+  updateClaimProfile,
 } from "../utils/api";
 
 const ORIGINAL_API_URL = process.env.NEXT_PUBLIC_API_URL;
@@ -212,7 +212,7 @@ test("getDashboardStats includes role, scope, and regional_id when provided", as
   expect(url).toContain("regional_id=R-12");
 });
 
-test("updateUserViaClaim throws backend validation messages", async () => {
+test("updateClaimProfile throws backend validation messages", async () => {
   (global.fetch as jest.Mock).mockResolvedValueOnce({
     ok: false,
     headers: { get: () => "application/json" },
@@ -220,7 +220,7 @@ test("updateUserViaClaim throws backend validation messages", async () => {
   });
 
   await expect(
-    updateUserViaClaim({ nrp: "1", password: "Abcd1234!", insta: "bad" }),
+    updateClaimProfile({ insta: "bad" }),
   ).rejects.toThrow("Link Instagram tidak valid");
 });
 
@@ -331,17 +331,22 @@ test("loginClaimUser calls user-login endpoint", async () => {
   expect(response.token).toBe("jwt-token");
 });
 
-test("getClaimUserData sends password credential instead of email", async () => {
+test("getClaimProfile uses authenticated claim profile endpoint", async () => {
   (global.fetch as jest.Mock).mockResolvedValueOnce({
     ok: true,
     json: () => Promise.resolve({ success: true, data: { nrp: "123" } }),
   });
 
-  await getClaimUserData("123", "Abcd1234!");
+  await getClaimProfile("jwt-token");
 
   const [url, options] = (global.fetch as jest.Mock).mock.calls[0];
-  expect(url).toContain("/api/claim/user-data");
-  expect(JSON.parse(options.body)).toEqual({ nrp: "123", password: "Abcd1234!" });
+  expect(url).toContain("/api/claim/me");
+  expect(options).toMatchObject({
+    method: "GET",
+    credentials: "include",
+    headers: { Authorization: "Bearer jwt-token" },
+  });
+  expect(options.body).toBeUndefined();
 });
 
 test("claim update sends whatsapp with 62 prefix for local numbers", async () => {
@@ -356,15 +361,30 @@ test("claim update sends whatsapp with 62 prefix for local numbers", async () =>
       ? normalizeWhatsapp(whatsappInput)
       : whatsappInput.trim();
 
-  await updateUserViaClaim({
-    nrp: "123",
-    password: "Abcd1234!",
+  await updateClaimProfile({
     whatsapp: whatsappNormalized,
+  }, "jwt-token");
+
+  const [url, options] = (global.fetch as jest.Mock).mock.calls[0];
+  expect(url).toContain("/api/claim/me");
+  expect(options.credentials).toBe("include");
+  expect(options.headers.Authorization).toBe("Bearer jwt-token");
+  expect(JSON.parse(options.body)).toEqual({ whatsapp: "628123" });
+});
+
+test("claim profile update strips identity and password fields defensively", async () => {
+  (global.fetch as jest.Mock).mockResolvedValueOnce({
+    ok: true,
+    json: () => Promise.resolve({ success: true, data: {} }),
   });
 
+  await updateClaimProfile({
+    nama: "User Claim",
+    nrp: "attacker",
+    user_id: "other-user",
+    password: "secret",
+  } as any);
+
   const [, options] = (global.fetch as jest.Mock).mock.calls[0];
-  expect(JSON.parse(options.body)).toMatchObject({
-    whatsapp: "628123",
-    no_wa: "628123",
-  });
+  expect(JSON.parse(options.body)).toEqual({ nama: "User Claim" });
 });

--- a/cicero-dashboard/__tests__/claimPage.test.tsx
+++ b/cicero-dashboard/__tests__/claimPage.test.tsx
@@ -1,0 +1,43 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import ClaimPage from "@/app/claim/page";
+import { loginClaimUser } from "@/utils/api";
+
+const push = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push, replace: jest.fn() }),
+}));
+
+jest.mock("@/utils/api", () => ({
+  loginClaimUser: jest.fn(),
+  registerClaimCredential: jest.fn(),
+  requestClaimPasswordResetOtp: jest.fn(),
+  verifyClaimPasswordResetOtp: jest.fn(),
+  confirmClaimPasswordReset: jest.fn(),
+}));
+
+describe("ClaimPage session", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    push.mockClear();
+    (loginClaimUser as jest.Mock).mockResolvedValue({
+      success: true,
+      token: "claim-jwt",
+    });
+  });
+
+  it("tidak menyimpan password claim ke sessionStorage setelah login", async () => {
+    render(<ClaimPage />);
+
+    fireEvent.change(screen.getByLabelText("NRP"), { target: { value: "12345" } });
+    fireEvent.change(screen.getByLabelText("Password"), {
+      target: { value: "Password1!" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /login & lanjutkan/i }));
+
+    await waitFor(() => expect(push).toHaveBeenCalledWith("/claim/edit"));
+    expect(sessionStorage.getItem("claim_password")).toBeNull();
+    expect(sessionStorage.getItem("claim_nrp")).toBeNull();
+    expect(sessionStorage.getItem("claim_token")).toBe("claim-jwt");
+  });
+});

--- a/cicero-dashboard/app/claim/edit/page.jsx
+++ b/cicero-dashboard/app/claim/edit/page.jsx
@@ -8,9 +8,9 @@ import ClaimLayout from "@/components/claim/ClaimLayout";
 import PendingContentCard from "@/components/claim/PendingContentCard";
 import {
   getClaimPendingContent,
-  getClaimUserData,
+  getClaimProfile,
   normalizeWhatsapp,
-  updateUserViaClaim,
+  updateClaimProfile,
 } from "@/utils/api";
 import {
   extractInstagramUsername,
@@ -20,8 +20,6 @@ import {
 } from "./socialUtils";
 
 export default function EditUserPage() {
-  const [nrp, setNrp] = useState("");
-  const [password, setPassword] = useState("");
   const [claimToken, setClaimToken] = useState("");
   const [kesatuan, setKesatuan] = useState("");
   const [nama, setNama] = useState("");
@@ -57,28 +55,19 @@ export default function EditUserPage() {
 
   useEffect(() => {
     if (typeof window !== "undefined") {
-      const n = sessionStorage.getItem("claim_nrp");
-      const w = sessionStorage.getItem("claim_password");
       const token = sessionStorage.getItem("claim_token");
-      if (!n || !w || !token) {
-        router.replace("/claim");
-        return;
-      }
-      setNrp(n);
-      setPassword(w);
-      setClaimToken(token);
-      loadUser(n, w);
-      loadPendingContent(token);
+      setClaimToken(token || "");
+      loadUser(token || "");
     }
   }, [router]);
 
-  async function loadUser(n, w) {
+  async function loadUser(token) {
     setProfileLoading(true);
     setProfileError("");
     try {
-      const res = await getClaimUserData(n, w);
+      const res = await getClaimProfile(token);
       const user = res.data || res.user || res;
-      setRole(user.role || user.user_role || user.userRole || "");
+      setRole(user.ditbinmas ? "ditbinmas" : "");
       setKesatuan(user.nama_client || user.client_name || user.client_id || "");
       setNama(user.nama || "");
       setPangkat(user.title || "");
@@ -87,16 +76,21 @@ export default function EditUserPage() {
       setDesa(user.desa || "");
       setWhatsapp(user.whatsapp || user.no_wa || user.phone || user.telp || "");
       setEmail(user.email || user.mail || user.email_address || "");
-      const instaUsername = extractInstagramUsername(user.insta);
+      const instaUsername = extractInstagramUsername(
+        user.instagram_accounts?.[0] || user.insta,
+      );
       setInsta(
         instaUsername ? `https://www.instagram.com/${instaUsername}` : "",
       );
-      const tiktokUsername = extractTiktokUsername(user.tiktok);
+      const tiktokUsername = extractTiktokUsername(
+        user.tiktok_accounts?.[0] || user.tiktok,
+      );
       setTiktok(tiktokUsername ? `https://tiktok.com/${tiktokUsername}` : "");
 
       const secondaryInstagram =
         extractInstagramUsername(
-          user.secondary_instagram_username ||
+          user.instagram_accounts?.[1] ||
+            user.secondary_instagram_username ||
             user.instagram_secondary_username ||
             user.secondary_instagram ||
             user.insta_2 ||
@@ -106,14 +100,20 @@ export default function EditUserPage() {
 
       const secondaryTiktok =
         extractTiktokUsername(
-          user.secondary_tiktok_username ||
+          user.tiktok_accounts?.[1] ||
+            user.secondary_tiktok_username ||
             user.tiktok_secondary_username ||
             user.secondary_tiktok ||
             user.tiktok_2 ||
             user.tiktok2,
         ) || "";
       setSecondaryTiktokUsername(secondaryTiktok);
+      loadPendingContent(token);
     } catch (err) {
+      if (err?.status === 401 || err?.status === 403) {
+        router.replace("/claim");
+        return;
+      }
       const message = err?.message?.trim()
         ? err.message
         : "Gagal mengambil data user";
@@ -225,9 +225,7 @@ export default function EditUserPage() {
     const isDitbinmasRole = role.trim().toLowerCase() === "ditbinmas";
     setLoading(true);
     try {
-      const res = await updateUserViaClaim({
-        nrp,
-        password,
+      const res = await updateClaimProfile({
         nama: nama.trim(),
         title: pangkat.trim(),
         divisi: satfung.trim(),
@@ -235,15 +233,12 @@ export default function EditUserPage() {
         // Aturan bisnis: field desa hanya diproses untuk personel role Ditbinmas.
         desa: isDitbinmasRole ? desa.trim() : "",
         whatsapp: normalizedWhatsapp,
-        no_wa: normalizedWhatsapp,
         email: normalizedEmail,
         insta: instaUsername,
         tiktok: tiktokUsername,
-        secondary_instagram_username: secondaryInstagram,
-        secondary_tiktok_username: secondaryTiktok,
-        instagram_secondary_username: secondaryInstagram,
-        tiktok_secondary_username: secondaryTiktok,
-      });
+        instagram_accounts: [instaUsername, secondaryInstagram].filter(Boolean),
+        tiktok_accounts: [tiktokUsername, secondaryTiktok].filter(Boolean),
+      }, claimToken);
       if (res.success) {
         setMessage("Data berhasil diperbarui");
       } else {

--- a/cicero-dashboard/app/claim/page.jsx
+++ b/cicero-dashboard/app/claim/page.jsx
@@ -54,11 +54,12 @@ export default function ClaimPage() {
     }
   }, []);
 
-  const saveClaimSession = (trimmedNrp, trimmedPassword, token) => {
+  const saveClaimSession = (token) => {
     if (typeof window === "undefined") return;
-    sessionStorage.setItem("claim_nrp", trimmedNrp);
-    sessionStorage.setItem("claim_password", trimmedPassword);
+    sessionStorage.removeItem("claim_nrp");
+    sessionStorage.removeItem("claim_password");
     if (token) sessionStorage.setItem("claim_token", token);
+    else sessionStorage.removeItem("claim_token");
   };
 
   const clearForm = () => {
@@ -122,7 +123,7 @@ export default function ClaimPage() {
     try {
       const res = await loginClaimUser({ nrp: trimmedNrp, password: trimmedPassword });
       if (res.success !== false) {
-        saveClaimSession(trimmedNrp, trimmedPassword, res.token);
+        saveClaimSession(res.token);
         router.push("/claim/edit");
       } else {
         setError(res.message || "Login gagal.");

--- a/cicero-dashboard/utils/api.ts
+++ b/cicero-dashboard/utils/api.ts
@@ -3905,6 +3905,52 @@ export type ClaimAuthResponse = {
   user?: any;
 };
 
+/** Profile fields returned by the authenticated claim profile endpoints. */
+export type ClaimProfileDto = {
+  user_id: string;
+  nama: string | null;
+  title: string | null;
+  divisi: string | null;
+  jabatan: string | null;
+  desa: string | null;
+  client_id: string | null;
+  whatsapp: string | null;
+  email: string | null;
+  insta: string | null;
+  tiktok: string | null;
+  instagram_accounts: string[];
+  tiktok_accounts: string[];
+  ditbinmas: boolean;
+  ditlantas: boolean;
+  bidhumas: boolean;
+  ditsamapta: boolean;
+  ditintelkam: boolean;
+  operator: boolean;
+};
+
+export type ClaimProfileResponse = {
+  success: boolean;
+  message?: string;
+  data: ClaimProfileDto;
+};
+
+export type UpdateClaimProfilePayload = Partial<
+  Pick<
+    ClaimProfileDto,
+    | "nama"
+    | "title"
+    | "divisi"
+    | "jabatan"
+    | "desa"
+    | "whatsapp"
+    | "email"
+    | "insta"
+    | "tiktok"
+    | "instagram_accounts"
+    | "tiktok_accounts"
+  >
+>;
+
 export type ClaimCredentialPayload = {
   nrp: string;
   password: string;
@@ -4104,36 +4150,28 @@ export async function getUserById(nrp: string): Promise<any> {
   return res.json();
 }
 
-// Fetch user data in claim flow after credential verification
-export async function getClaimUserData(
-  nrp: string,
-  password: string,
-): Promise<any> {
-  const url = buildApiUrl("/api/claim/user-data");
-  const res = await fetch(url, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    credentials: "include",
-    body: JSON.stringify({ nrp, password }),
-  });
-
-  let data: any = null;
-  try {
-    data = await res.json();
-  } catch (error) {
-    data = null;
-  }
-
-  if (!res.ok) {
-    const message = extractResponseMessage(data, "Gagal mengambil data user");
-    throw new Error(message);
-  }
-
-  return data;
-}
-
 function claimAuthHeaders(token?: string) {
   return token ? { Authorization: `Bearer ${token}` } : undefined;
+}
+
+function claimResponseError(status: number, data: any, fallback: string): Error {
+  return Object.assign(new Error(extractResponseMessage(data, fallback)), { status });
+}
+
+export async function getClaimProfile(token?: string): Promise<ClaimProfileResponse> {
+  const url = buildApiUrl("/api/claim/me");
+  const res = await fetch(url, {
+    method: "GET",
+    headers: claimAuthHeaders(token),
+    credentials: "include",
+  });
+  const data = await res.json().catch(() => null);
+
+  if (!res.ok) {
+    throw claimResponseError(res.status, data, "Gagal mengambil data user");
+  }
+
+  return data as ClaimProfileResponse;
 }
 
 export async function getClaimPendingContent(token?: string): Promise<ClaimPendingContentResponse> {
@@ -4202,34 +4240,18 @@ export async function escalateClaimComplaint(
   }
 }
 
-// Update user data after credential verification
-export async function updateUserViaClaim(
-  data: {
-    nrp: string;
-    password: string;
-    nama?: string;
-    title?: string;
-    divisi?: string;
-    jabatan?: string;
-    desa?: string;
-    whatsapp?: string;
-    no_wa?: string;
-    email?: string;
-    insta?: string;
-    tiktok?: string;
-  },
-): Promise<any> {
-  const url = buildApiUrl("/api/claim/update");
+export async function updateClaimProfile(
+  data: UpdateClaimProfilePayload,
+  token?: string,
+): Promise<ClaimProfileResponse> {
+  const url = buildApiUrl("/api/claim/me");
   const payload: Record<string, unknown> = { ...data };
-  if (typeof payload.whatsapp === "string" && !payload.no_wa) {
-    payload.no_wa = payload.whatsapp;
-  }
-  if (typeof payload.no_wa === "string" && !payload.whatsapp) {
-    payload.whatsapp = payload.no_wa;
-  }
+  delete payload.nrp;
+  delete payload.user_id;
+  delete payload.password;
   const res = await fetch(url, {
     method: "PUT",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...claimAuthHeaders(token) },
     credentials: "include",
     body: JSON.stringify(payload),
   });
@@ -4271,7 +4293,7 @@ export async function updateUserViaClaim(
     } catch (err) {
       // Ignore parsing errors and fall back to default message
     }
-    throw new Error(message);
+    throw Object.assign(new Error(message), { status: res.status });
   }
-  return res.json();
+  return res.json() as Promise<ClaimProfileResponse>;
 }


### PR DESCRIPTION
### Motivation

- Move the claim flow from legacy credential-based client storage to the authenticated profile endpoints (`GET /api/claim/me`, `PUT /api/claim/me`) so the frontend relies on backend HttpOnly session cookies and no longer persists sensitive credentials in Web Storage.
- Prevent accidental leakage of identity/auth fields by stripping `nrp`, `user_id`, and `password` from profile update payloads and keep compatibility for backends that still return a Bearer token.

### Description

- Added claim DTO types `ClaimProfileDto`, `ClaimProfileResponse`, and `UpdateClaimProfilePayload` to `cicero-dashboard/utils/api.ts` and implemented `getClaimProfile(token?)` to call `GET /api/claim/me` with `credentials: "include"` while optionally sending a Bearer header via `claimAuthHeaders`.
- Implemented `updateClaimProfile(data, token?)` which PUTs to `/api/claim/me` with `credentials: "include"`, adds `Authorization` if token present, and defensively removes `nrp`, `user_id`, and `password` from the outgoing body.
- Replaced legacy helpers and usages: `getClaimUserData` / `updateUserViaClaim` usages in `app/claim/edit/page.jsx` and tests were migrated to `getClaimProfile` / `updateClaimProfile`, removed storing `claim_nrp`/`claim_password` and removed local password state in the edit page.
- Updated `app/claim/page.jsx` `saveClaimSession` to never persist claim password/NRP (only stores a compatibility token if provided) and updated `app/claim/edit/page.jsx` to determine session validity from `GET /api/claim/me` and redirect to `/claim` on `401/403` responses.
- Adjusted social-account read/write to prefer `instagram_accounts` / `tiktok_accounts` from backend DTO and send updates as `instagram_accounts`/`tiktok_accounts` arrays.
- Added tests: new `__tests__/claimPage.test.tsx` (ensures password/NRP are not stored, token stored if returned) and updated `__tests__/api.test.ts` to assert `getClaimProfile`/`updateClaimProfile` behaviors and that sensitive fields are stripped; updated README claim flow text accordingly.

### Testing

- Ran focused claim-related suites: `__tests__/api.test.ts`, `__tests__/claimPage.test.tsx`, and `__tests__/claimPendingContentApi.test.ts` and all passed.
- Ran full test suite: 251 tests passed, 1 test failed (`Sidebar.test.tsx`) which is unrelated to claim flow changes and appears to be an existing UI/test fragility outside the scope of this PR.
- TypeScript check (`npx tsc --noEmit`) surfaced unrelated type errors in other tests/files (pre-existing), so no blocking type issues were introduced by these claim changes.
- All changes are limited to the `/claim` flow and claim-specific API helpers; no other authentication or dashboard pages were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a11f857dc83279c6636bfb24d501a)