### PR TITLE
Load verified NRP on claim edit page

### DIFF
--- a/cicero-dashboard/__tests__/claimEditPage.test.tsx
+++ b/cicero-dashboard/__tests__/claimEditPage.test.tsx
@@ -1,0 +1,57 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import EditUserPage from "@/app/claim/edit/page";
+import { getClaimPendingContent, getClaimProfile } from "@/utils/api";
+
+const replace = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ replace }),
+}));
+
+jest.mock("@/components/claim/ClaimLayout", () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock("@/components/claim/PendingContentCard", () => ({
+  __esModule: true,
+  default: () => <div data-testid="pending-content" />,
+}));
+
+jest.mock("@/utils/api", () => ({
+  getClaimPendingContent: jest.fn(),
+  getClaimProfile: jest.fn(),
+  normalizeWhatsapp: jest.fn((value: string) => value),
+  updateClaimProfile: jest.fn(),
+}));
+
+describe("EditUserPage", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    sessionStorage.setItem("claim_token", "claim-jwt");
+    replace.mockClear();
+    (getClaimProfile as jest.Mock).mockResolvedValue({
+      success: true,
+      data: {
+        user_id: "12345",
+        nama: "Pengguna Claim",
+        email: "claim@example.com",
+        whatsapp: "628123456789",
+      },
+    });
+    (getClaimPendingContent as jest.Mock).mockResolvedValue({ data: null });
+  });
+
+  it("merender saat loading lalu menampilkan NRP terverifikasi dari profil", async () => {
+    render(<EditUserPage />);
+
+    expect(screen.getByRole("status")).toHaveTextContent("Memuat profil...");
+    expect(await screen.findByDisplayValue("12345")).toBe(
+      screen.getByLabelText("NRP"),
+    );
+    expect(screen.getByLabelText("NRP")).toHaveAttribute("readonly");
+    expect(getClaimProfile).toHaveBeenCalledWith("claim-jwt");
+    expect(getClaimPendingContent).toHaveBeenCalledWith("claim-jwt");
+  });
+});

--- a/cicero-dashboard/app/claim/edit/page.jsx
+++ b/cicero-dashboard/app/claim/edit/page.jsx
@@ -21,6 +21,7 @@ import {
 
 export default function EditUserPage() {
   const [claimToken, setClaimToken] = useState("");
+  const [nrp, setNrp] = useState("");
   const [kesatuan, setKesatuan] = useState("");
   const [nama, setNama] = useState("");
   const [pangkat, setPangkat] = useState("");
@@ -67,6 +68,7 @@ export default function EditUserPage() {
     try {
       const res = await getClaimProfile(token);
       const user = res.data || res.user || res;
+      setNrp(user.user_id || "");
       setRole(user.ditbinmas ? "ditbinmas" : "");
       setKesatuan(user.nama_client || user.client_name || user.client_id || "");
       setNama(user.nama || "");
@@ -342,8 +344,14 @@ export default function EditUserPage() {
               />
             </div>
             <div className="space-y-2">
-              <label className="text-sm font-medium text-neutral-navy">NRP</label>
+              <label
+                htmlFor="nrp"
+                className="text-sm font-medium text-neutral-navy"
+              >
+                NRP
+              </label>
               <input
+                id="nrp"
                 type="text"
                 value={nrp}
                 readOnly


### PR DESCRIPTION
### Motivation

- Ensure the claim profile editor shows the verified personnel identifier (NRP) coming from the claim profile payload rather than re-using or restoring any stored credentials.
- Preserve the existing authentication flow that relies on `claim_token` and server-side profile APIs while preventing storage of `claim_nrp` or passwords in `sessionStorage`.

### Description

- Add a dedicated `nrp` React state initialized to an empty string in `cicero-dashboard/app/claim/edit/page.jsx` and populate it from the verified `user.user_id` value inside `loadUser` after calling `getClaimProfile`.
- Bind the NRP input to the new `nrp` state, mark it `readOnly`, and add `id`/`htmlFor` so the input is accessible by its label; no credential values are written to `sessionStorage`.
- Add a regression test `cicero-dashboard/__tests__/claimEditPage.test.tsx` that mocks `getClaimProfile` to return `{ success: true, data: { user_id: "12345", ... } }`, mocks `getClaimPendingContent`, renders `EditUserPage`, and asserts the loading indicator, that the `NRP` input displays `12345`, and that the input is read-only.
- Keep profile authentication and updates unchanged to use `claim_token`/cookie through `getClaimProfile` and `updateClaimProfile` and avoid restoring `claim_nrp` or passwords to `sessionStorage`.

### Testing

- Ran the new test only with `npm test -- --runInBand __tests__/claimEditPage.test.tsx`, and it passed.
- Ran the full test suite with `npm test -- --runInBand`, where the new test and 252 other tests passed but one pre-existing unrelated test still fails: `__tests__/Sidebar.test.tsx` (the Org Operator case looking for `Anev Polres`).
- Verified storage usage by scanning for `sessionStorage.setItem/getItem` for `claim_nrp`/`claim_password` and confirmed no changes introduced those stores, only `claim_token` is used for authentication flows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a8c341ea08327ab72680e6f5751eb)