### PR TITLE
Claim edit: support canonical instagram/tiktok account arrays, dynamic account rows, deterministic normalization and validation

### DIFF
--- a/cicero-dashboard/__tests__/claimEditPage.test.tsx
+++ b/cicero-dashboard/__tests__/claimEditPage.test.tsx
@@ -1,12 +1,17 @@
 import "@testing-library/jest-dom";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import EditUserPage from "@/app/claim/edit/page";
-import { getClaimPendingContent, getClaimProfile } from "@/utils/api";
+import {
+  getClaimPendingContent,
+  getClaimProfile,
+  updateClaimProfile,
+} from "@/utils/api";
 
 const replace = jest.fn();
+const mockRouter = { replace };
 
 jest.mock("next/navigation", () => ({
-  useRouter: () => ({ replace }),
+  useRouter: () => mockRouter,
 }));
 
 jest.mock("@/components/claim/ClaimLayout", () => ({
@@ -28,6 +33,7 @@ jest.mock("@/utils/api", () => ({
 
 describe("EditUserPage", () => {
   beforeEach(() => {
+    jest.clearAllMocks();
     sessionStorage.clear();
     sessionStorage.setItem("claim_token", "claim-jwt");
     replace.mockClear();
@@ -38,9 +44,14 @@ describe("EditUserPage", () => {
         nama: "Pengguna Claim",
         email: "claim@example.com",
         whatsapp: "628123456789",
+        insta: "alias_instagram",
+        tiktok: "@alias_tiktok",
+        instagram_accounts: ["utama.ig", "kedua_ig"],
+        tiktok_accounts: ["@utama.tt", "@kedua_tt"],
       },
     });
     (getClaimPendingContent as jest.Mock).mockResolvedValue({ data: null });
+    (updateClaimProfile as jest.Mock).mockResolvedValue({ success: true });
   });
 
   it("merender saat loading lalu menampilkan NRP terverifikasi dari profil", async () => {
@@ -53,5 +64,94 @@ describe("EditUserPage", () => {
     expect(screen.getByLabelText("NRP")).toHaveAttribute("readonly");
     expect(getClaimProfile).toHaveBeenCalledWith("claim-jwt");
     expect(getClaimPendingContent).toHaveBeenCalledWith("claim-jwt");
+  });
+
+  it("memuat seluruh array kanonis dan tidak memakai alias", async () => {
+    render(<EditUserPage />);
+
+    expect(await screen.findByDisplayValue("utama.ig")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("kedua_ig")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("@utama.tt")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("@kedua_tt")).toBeInTheDocument();
+    expect(
+      screen.queryByDisplayValue("alias_instagram"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("memakai alias utama hanya ketika array tidak tersedia", async () => {
+    (getClaimProfile as jest.Mock).mockResolvedValueOnce({
+      success: true,
+      data: {
+        user_id: "12345",
+        nama: "Pengguna Claim",
+        email: "claim@example.com",
+        whatsapp: "628123456789",
+        insta: "fallback_ig",
+        tiktok: "fallback_tt",
+      },
+    });
+    render(<EditUserPage />);
+
+    expect(await screen.findByDisplayValue("fallback_ig")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("@fallback_tt")).toBeInTheDocument();
+  });
+
+  it("menambah dan menghapus baris tetapi mempertahankan satu baris", async () => {
+    render(<EditUserPage />);
+    await screen.findByDisplayValue("utama.ig");
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Tambah akun Instagram" }),
+    );
+    expect(screen.getByLabelText("Username Instagram 3")).toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Hapus akun Instagram 3" }),
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: "Hapus akun Instagram 2" }),
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: "Hapus akun Instagram 1" }),
+    );
+    expect(screen.getByLabelText("Username Instagram 1")).toHaveValue("");
+  });
+
+  it("menormalisasi input dan hanya mengirim payload array", async () => {
+    render(<EditUserPage />);
+    await screen.findByDisplayValue("utama.ig");
+    fireEvent.change(screen.getByLabelText("Username Instagram 1"), {
+      target: { value: "https://instagram.com/Polri/" },
+    });
+    fireEvent.change(screen.getByLabelText("Username TikTok 1"), {
+      target: { value: "humas_polri" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Simpan" }));
+
+    await waitFor(() => expect(updateClaimProfile).toHaveBeenCalled());
+    const [payload, token] = (updateClaimProfile as jest.Mock).mock.calls[0];
+    expect(token).toBe("claim-jwt");
+    expect(payload.instagram_accounts).toEqual(["Polri", "kedua_ig"]);
+    expect(payload.tiktok_accounts).toEqual(["@humas_polri", "@kedua_tt"]);
+    expect(payload).not.toHaveProperty("insta");
+    expect(payload).not.toHaveProperty("tiktok");
+    expect(
+      Object.keys(payload).some(
+        (key) => key.includes("secondary") || key.endsWith("_2"),
+      ),
+    ).toBe(false);
+  });
+
+  it("menolak duplikasi setelah normalisasi case-insensitive", async () => {
+    render(<EditUserPage />);
+    await screen.findByDisplayValue("utama.ig");
+    fireEvent.change(screen.getByLabelText("Username Instagram 2"), {
+      target: { value: "@UTAMA.IG" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Simpan" }));
+
+    expect(
+      await screen.findByText(/Instagram terduplikasi/),
+    ).toBeInTheDocument();
+    expect(updateClaimProfile).not.toHaveBeenCalled();
   });
 });

--- a/cicero-dashboard/__tests__/socialUsernameParsing.test.ts
+++ b/cicero-dashboard/__tests__/socialUsernameParsing.test.ts
@@ -1,36 +1,31 @@
 import {
   extractInstagramUsername,
   extractTiktokUsername,
+  normalizeSocialAccountList,
 } from "@/app/claim/edit/socialUtils";
 
 describe("extractInstagramUsername", () => {
   it("returns username for plain handles", () => {
-    expect(extractInstagramUsername("username"))
-      .toBe("username");
-    expect(extractInstagramUsername("@user.name"))
-      .toBe("user.name");
+    expect(extractInstagramUsername("username")).toBe("username");
+    expect(extractInstagramUsername("@user.name")).toBe("user.name");
   });
 
   it("rejects domain-like input without protocol", () => {
-    expect(extractInstagramUsername("instagram.com/akun"))
-      .toBe("");
-    expect(extractInstagramUsername("instagram.com"))
-      .toBe("");
+    expect(extractInstagramUsername("instagram.com/akun")).toBe("");
+    expect(extractInstagramUsername("instagram.com")).toBe("");
   });
 
   it("extracts username from valid URLs", () => {
-    expect(
-      extractInstagramUsername("https://www.instagram.com/user/")
-    ).toBe("user");
-    expect(
-      extractInstagramUsername("https://m.instagram.com/user")
-    ).toBe("user");
+    expect(extractInstagramUsername("https://www.instagram.com/user/")).toBe(
+      "user",
+    );
+    expect(extractInstagramUsername("https://m.instagram.com/user")).toBe(
+      "user",
+    );
   });
 
   it("returns empty string for URLs with other hosts", () => {
-    expect(
-      extractInstagramUsername("https://example.com/user")
-    ).toBe("");
+    expect(extractInstagramUsername("https://example.com/user")).toBe("");
   });
 
   it("rejects usernames containing spaces", () => {
@@ -40,35 +35,66 @@ describe("extractInstagramUsername", () => {
 
 describe("extractTiktokUsername", () => {
   it("returns username for plain handles", () => {
-    expect(extractTiktokUsername("username"))
-      .toBe("username");
-    expect(extractTiktokUsername("@user_name"))
-      .toBe("user_name");
+    expect(extractTiktokUsername("username")).toBe("@username");
+    expect(extractTiktokUsername("@user_name")).toBe("@user_name");
   });
 
   it("rejects domain-like input without protocol", () => {
-    expect(extractTiktokUsername("tiktok.com/@akun"))
-      .toBe("");
-    expect(extractTiktokUsername("tiktok.com"))
-      .toBe("");
+    expect(extractTiktokUsername("tiktok.com/@akun")).toBe("");
+    expect(extractTiktokUsername("tiktok.com")).toBe("");
   });
 
   it("extracts username from valid URLs", () => {
-    expect(
-      extractTiktokUsername("https://www.tiktok.com/@user")
-    ).toBe("user");
-    expect(
-      extractTiktokUsername("https://m.tiktok.com/@user/video/123")
-    ).toBe("user");
+    expect(extractTiktokUsername("https://www.tiktok.com/@user")).toBe("@user");
+    expect(extractTiktokUsername("https://m.tiktok.com/@user/video/123")).toBe(
+      "@user",
+    );
   });
 
   it("returns empty string for URLs with other hosts", () => {
-    expect(
-      extractTiktokUsername("https://example.com/@user")
-    ).toBe("");
+    expect(extractTiktokUsername("https://example.com/@user")).toBe("");
   });
 
   it("rejects usernames containing spaces", () => {
     expect(extractTiktokUsername("user name")).toBe("");
+  });
+});
+
+describe("normalizeSocialAccountList", () => {
+  it("normalizes supported input forms to backend canonical values", () => {
+    expect(
+      normalizeSocialAccountList(
+        ["@Polri", "https://instagram.com/humas.polri/"],
+        "instagram",
+      ),
+    ).toEqual({ ok: true, accounts: ["Polri", "humas.polri"] });
+    expect(
+      normalizeSocialAccountList(
+        ["polri", "https://www.tiktok.com/@humas.polri"],
+        "tiktok",
+      ),
+    ).toEqual({ ok: true, accounts: ["@polri", "@humas.polri"] });
+  });
+
+  it.each([
+    [["satu", "", "tiga"], "tidak boleh kosong"],
+    [["Polri", "@polri"], "terduplikasi"],
+    [["CICERO_DEVS"], "tidak diperbolehkan"],
+    [["https://example.com/user"], "tidak valid"],
+  ])("rejects invalid Instagram lists", (values, message) => {
+    const result = normalizeSocialAccountList(values, "instagram");
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.message).toContain(message);
+  });
+
+  it("allows trailing empty rows and an entirely empty single row", () => {
+    expect(normalizeSocialAccountList(["akun", ""], "instagram")).toEqual({
+      ok: true,
+      accounts: ["akun"],
+    });
+    expect(normalizeSocialAccountList([""], "tiktok")).toEqual({
+      ok: true,
+      accounts: [],
+    });
   });
 });

--- a/cicero-dashboard/app/claim/edit/page.jsx
+++ b/cicero-dashboard/app/claim/edit/page.jsx
@@ -2,7 +2,14 @@
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { CheckCircle2, Edit3, Info, TriangleAlert } from "lucide-react";
+import {
+  CheckCircle2,
+  Edit3,
+  Info,
+  Plus,
+  Trash2,
+  TriangleAlert,
+} from "lucide-react";
 
 import ClaimLayout from "@/components/claim/ClaimLayout";
 import PendingContentCard from "@/components/claim/PendingContentCard";
@@ -15,9 +22,71 @@ import {
 import {
   extractInstagramUsername,
   extractTiktokUsername,
-  isValidInstagram,
-  isValidTiktok,
+  normalizeSocialAccountList,
 } from "./socialUtils";
+
+function SocialAccountFields({ platform, values, errors, onChange }) {
+  const key = platform.toLowerCase();
+  const updateRow = (index, value) =>
+    onChange(
+      values.map((item, itemIndex) => (itemIndex === index ? value : item)),
+    );
+  const removeRow = (index) =>
+    onChange(
+      values.length === 1
+        ? [""]
+        : values.filter((_, itemIndex) => itemIndex !== index),
+    );
+  return (
+    <fieldset className="space-y-3 rounded-2xl border border-spirit-200/80 bg-white/70 p-4">
+      <legend className="px-1 text-sm font-semibold text-neutral-navy">
+        Akun {platform}
+      </legend>
+      <p className="text-xs text-neutral-slate">
+        Masukkan username, @username, atau URL profil {platform}.
+      </p>
+      {values.map((value, index) => (
+        <div key={`${key}-${index}`} className="space-y-1">
+          <label
+            htmlFor={`${key}-account-${index}`}
+            className="text-xs font-medium text-neutral-navy"
+          >
+            Username {platform} {index + 1}
+          </label>
+          <div className="flex gap-2">
+            <input
+              id={`${key}-account-${index}`}
+              type="text"
+              value={value}
+              onChange={(event) => updateRow(index, event.target.value)}
+              placeholder="username, @username, atau URL profil"
+              aria-invalid={Boolean(errors[index])}
+              className="min-w-0 flex-1 rounded-2xl border border-spirit-200/80 bg-white px-4 py-3 text-sm text-neutral-navy shadow-inner focus:border-spirit-400 focus:outline-none focus:ring-2 focus:ring-spirit-200"
+            />
+            <button
+              type="button"
+              onClick={() => removeRow(index)}
+              aria-label={`Hapus akun ${platform} ${index + 1}`}
+              className="rounded-2xl border border-red-200 px-3 text-red-500 hover:bg-red-50"
+            >
+              <Trash2 className="h-4 w-4" />
+            </button>
+          </div>
+          {errors[index] && (
+            <p className="text-xs text-red-500">{errors[index]}</p>
+          )}
+        </div>
+      ))}
+      <button
+        type="button"
+        onClick={() => onChange([...values, ""])}
+        className="inline-flex items-center gap-2 rounded-xl border border-spirit-300 px-3 py-2 text-xs font-medium text-spirit-600 hover:bg-spirit-50"
+      >
+        <Plus className="h-4 w-4" /> Tambah akun {platform}
+      </button>
+    </fieldset>
+  );
+}
 
 export default function EditUserPage() {
   const [claimToken, setClaimToken] = useState("");
@@ -31,11 +100,8 @@ export default function EditUserPage() {
   const [role, setRole] = useState("");
   const [whatsapp, setWhatsapp] = useState("");
   const [email, setEmail] = useState("");
-  const [insta, setInsta] = useState("");
-  const [tiktok, setTiktok] = useState("");
-  const [secondaryInstagramUsername, setSecondaryInstagramUsername] =
-    useState("");
-  const [secondaryTiktokUsername, setSecondaryTiktokUsername] = useState("");
+  const [instagramAccounts, setInstagramAccounts] = useState([""]);
+  const [tiktokAccounts, setTiktokAccounts] = useState([""]);
   const [loading, setLoading] = useState(false);
   const [profileLoading, setProfileLoading] = useState(true);
   const [profileError, setProfileError] = useState("");
@@ -47,10 +113,8 @@ export default function EditUserPage() {
   const [fieldErrors, setFieldErrors] = useState({
     whatsapp: "",
     email: "",
-    insta: "",
-    tiktok: "",
-    secondaryInstagramUsername: "",
-    secondaryTiktokUsername: "",
+    instagramAccounts: [],
+    tiktokAccounts: [],
   });
   const router = useRouter();
 
@@ -78,38 +142,26 @@ export default function EditUserPage() {
       setDesa(user.desa || "");
       setWhatsapp(user.whatsapp || user.no_wa || user.phone || user.telp || "");
       setEmail(user.email || user.mail || user.email_address || "");
-      const instaUsername = extractInstagramUsername(
-        user.instagram_accounts?.[0] || user.insta,
+      const instagramSource = Array.isArray(user.instagram_accounts)
+        ? user.instagram_accounts
+        : user.insta
+          ? [user.insta]
+          : [];
+      const tiktokSource = Array.isArray(user.tiktok_accounts)
+        ? user.tiktok_accounts
+        : user.tiktok
+          ? [user.tiktok]
+          : [];
+      const normalizedInstagram = instagramSource
+        .map(extractInstagramUsername)
+        .filter(Boolean);
+      const normalizedTiktok = tiktokSource
+        .map(extractTiktokUsername)
+        .filter(Boolean);
+      setInstagramAccounts(
+        normalizedInstagram.length ? normalizedInstagram : [""],
       );
-      setInsta(
-        instaUsername ? `https://www.instagram.com/${instaUsername}` : "",
-      );
-      const tiktokUsername = extractTiktokUsername(
-        user.tiktok_accounts?.[0] || user.tiktok,
-      );
-      setTiktok(tiktokUsername ? `https://tiktok.com/${tiktokUsername}` : "");
-
-      const secondaryInstagram =
-        extractInstagramUsername(
-          user.instagram_accounts?.[1] ||
-            user.secondary_instagram_username ||
-            user.instagram_secondary_username ||
-            user.secondary_instagram ||
-            user.insta_2 ||
-            user.insta2,
-        ) || "";
-      setSecondaryInstagramUsername(secondaryInstagram);
-
-      const secondaryTiktok =
-        extractTiktokUsername(
-          user.tiktok_accounts?.[1] ||
-            user.secondary_tiktok_username ||
-            user.tiktok_secondary_username ||
-            user.secondary_tiktok ||
-            user.tiktok_2 ||
-            user.tiktok2,
-        ) || "";
-      setSecondaryTiktokUsername(secondaryTiktok);
+      setTiktokAccounts(normalizedTiktok.length ? normalizedTiktok : [""]);
       loadPendingContent(token);
     } catch (err) {
       if (err?.status === 401 || err?.status === 403) {
@@ -156,10 +208,8 @@ export default function EditUserPage() {
     const nextFieldErrors = {
       whatsapp: "",
       email: "",
-      insta: "",
-      tiktok: "",
-      secondaryInstagramUsername: "",
-      secondaryTiktokUsername: "",
+      instagramAccounts: [],
+      tiktokAccounts: [],
     };
     const whatsappInput = whatsapp.trim();
     const sanitizedWhatsapp = whatsappInput.replace(/(?!^\+)[^\d]/g, "");
@@ -190,57 +240,49 @@ export default function EditUserPage() {
       setError("Email wajib diisi dengan format valid");
     }
 
-    if (insta && !isValidInstagram(insta)) {
-      nextFieldErrors.insta =
-        "Gunakan format https://www.instagram.com/nama_pengguna (contoh: https://www.instagram.com/polri)";
-    }
-
-    if (tiktok && !isValidTiktok(tiktok)) {
-      nextFieldErrors.tiktok =
-        "Gunakan format https://www.tiktok.com/@nama_pengguna (contoh: https://www.tiktok.com/@polri)";
-    }
-
-    if (
-      secondaryInstagramUsername &&
-      !isValidInstagram(secondaryInstagramUsername)
-    ) {
-      nextFieldErrors.secondaryInstagramUsername =
-        "Isi username Instagram akun kedua tanpa spasi (contoh: humas_polres).";
-    }
-
-    if (secondaryTiktokUsername && !isValidTiktok(secondaryTiktokUsername)) {
-      nextFieldErrors.secondaryTiktokUsername =
-        "Isi username TikTok akun kedua tanpa spasi (contoh: humas_polres).";
-    }
+    const normalizedInstagram = normalizeSocialAccountList(
+      instagramAccounts,
+      "instagram",
+    );
+    const normalizedTiktok = normalizeSocialAccountList(
+      tiktokAccounts,
+      "tiktok",
+    );
+    if (!normalizedInstagram.ok)
+      nextFieldErrors.instagramAccounts[normalizedInstagram.index] =
+        normalizedInstagram.message;
+    if (!normalizedTiktok.ok)
+      nextFieldErrors.tiktokAccounts[normalizedTiktok.index] =
+        normalizedTiktok.message;
 
     setFieldErrors(nextFieldErrors);
 
-    if (Object.values(nextFieldErrors).some(Boolean)) {
+    if (
+      nextFieldErrors.whatsapp ||
+      nextFieldErrors.email ||
+      nextFieldErrors.instagramAccounts.some(Boolean) ||
+      nextFieldErrors.tiktokAccounts.some(Boolean)
+    ) {
       return;
     }
-    const instaUsername = extractInstagramUsername(insta);
-    const tiktokUsername = extractTiktokUsername(tiktok);
-    const secondaryInstagram = extractInstagramUsername(
-      secondaryInstagramUsername,
-    );
-    const secondaryTiktok = extractTiktokUsername(secondaryTiktokUsername);
     const isDitbinmasRole = role.trim().toLowerCase() === "ditbinmas";
     setLoading(true);
     try {
-      const res = await updateClaimProfile({
-        nama: nama.trim(),
-        title: pangkat.trim(),
-        divisi: satfung.trim(),
-        jabatan: jabatan.trim(),
-        // Aturan bisnis: field desa hanya diproses untuk personel role Ditbinmas.
-        desa: isDitbinmasRole ? desa.trim() : "",
-        whatsapp: normalizedWhatsapp,
-        email: normalizedEmail,
-        insta: instaUsername,
-        tiktok: tiktokUsername,
-        instagram_accounts: [instaUsername, secondaryInstagram].filter(Boolean),
-        tiktok_accounts: [tiktokUsername, secondaryTiktok].filter(Boolean),
-      }, claimToken);
+      const res = await updateClaimProfile(
+        {
+          nama: nama.trim(),
+          title: pangkat.trim(),
+          divisi: satfung.trim(),
+          jabatan: jabatan.trim(),
+          // Aturan bisnis: field desa hanya diproses untuk personel role Ditbinmas.
+          desa: isDitbinmasRole ? desa.trim() : "",
+          whatsapp: normalizedWhatsapp,
+          email: normalizedEmail,
+          instagram_accounts: normalizedInstagram.accounts,
+          tiktok_accounts: normalizedTiktok.accounts,
+        },
+        claimToken,
+      );
       if (res.success) {
         setMessage("Data berhasil diperbarui");
       } else {
@@ -284,7 +326,11 @@ export default function EditUserPage() {
           error={contentError}
           onRefresh={loadPendingContent}
           claimToken={claimToken}
-          onOpenProfile={() => document.getElementById("claim-profile-form")?.scrollIntoView({ behavior: "smooth" })}
+          onOpenProfile={() =>
+            document
+              .getElementById("claim-profile-form")
+              ?.scrollIntoView({ behavior: "smooth" })
+          }
         />
 
         <section className="rounded-3xl border border-spirit-200/80 bg-gradient-to-br from-white/80 via-spirit-50/70 to-trust-50/70 px-6 py-5 text-sm text-neutral-slate shadow-inner">
@@ -292,27 +338,39 @@ export default function EditUserPage() {
             <Info className="mt-0.5 h-5 w-5 text-spirit-500" />
             <div className="space-y-3">
               <p className="text-neutral-navy">
-                Verifikasi kembali nama, pangkat, satfung, dan jabatan sesuai data resmi sebelum menyimpan perubahan.
+                Verifikasi kembali nama, pangkat, satfung, dan jabatan sesuai
+                data resmi sebelum menyimpan perubahan.
               </p>
               <p>
-                Untuk Instagram, buka profilmu lalu ketuk tombol bagikan dan salin tautan penuh dengan format <span className="font-medium text-spirit-600">https://www.instagram.com/nama_pengguna</span>.
+                Untuk Instagram, masukkan username, @username, atau tautan
+                profil yang disalin dari aplikasi.
               </p>
               <p>
-                Untuk TikTok, buka profil di aplikasi atau web, pilih bagikan profil, kemudian salin tautan dengan format <span className="font-medium text-spirit-600">https://www.tiktok.com/@nama_pengguna</span>.
+                Untuk TikTok, masukkan username, @username, atau tautan profil
+                yang disalin dari aplikasi.
               </p>
               <p>
-                Pastikan kedua akun disetel publik agar tim kami dapat melakukan verifikasi.
+                Pastikan kedua akun disetel publik agar tim kami dapat melakukan
+                verifikasi.
               </p>
               <p>
-                Setelah menyesuaikan data dan menempelkan tautan, klik tombol <span className="font-medium text-spirit-600">Simpan</span> agar sistem memperbarui profilmu.
+                Setelah menyesuaikan data akun, klik tombol{" "}
+                <span className="font-medium text-spirit-600">Simpan</span> agar
+                sistem memperbarui profilmu.
               </p>
             </div>
           </div>
         </section>
 
-        <form id="claim-profile-form" onSubmit={handleSubmit} className="space-y-5">
+        <form
+          id="claim-profile-form"
+          onSubmit={handleSubmit}
+          className="space-y-5"
+        >
           {profileLoading && (
-            <p role="status" className="text-sm text-neutral-slate">Memuat profil...</p>
+            <p role="status" className="text-sm text-neutral-slate">
+              Memuat profil...
+            </p>
           )}
           {profileError && (
             <div className="flex items-start gap-3 rounded-2xl border border-red-200/70 bg-red-50/80 px-4 py-3 text-sm text-red-600 shadow-sm">
@@ -335,7 +393,9 @@ export default function EditUserPage() {
 
           <div className="grid gap-5 sm:grid-cols-2">
             <div className="space-y-2">
-              <label className="text-sm font-medium text-neutral-navy">Kesatuan</label>
+              <label className="text-sm font-medium text-neutral-navy">
+                Kesatuan
+              </label>
               <input
                 type="text"
                 value={kesatuan}
@@ -362,7 +422,9 @@ export default function EditUserPage() {
 
           <div className="grid gap-5 sm:grid-cols-2">
             <div className="space-y-2">
-              <label className="text-sm font-medium text-neutral-navy">Nama</label>
+              <label className="text-sm font-medium text-neutral-navy">
+                Nama
+              </label>
               <input
                 type="text"
                 value={nama}
@@ -372,7 +434,9 @@ export default function EditUserPage() {
               />
             </div>
             <div className="space-y-2">
-              <label className="text-sm font-medium text-neutral-navy">Pangkat</label>
+              <label className="text-sm font-medium text-neutral-navy">
+                Pangkat
+              </label>
               <input
                 type="text"
                 value={pangkat}
@@ -384,7 +448,9 @@ export default function EditUserPage() {
 
           <div className="grid gap-5 sm:grid-cols-2">
             <div className="space-y-2">
-              <label className="text-sm font-medium text-neutral-navy">Satfung</label>
+              <label className="text-sm font-medium text-neutral-navy">
+                Satfung
+              </label>
               <input
                 type="text"
                 value={satfung}
@@ -393,7 +459,9 @@ export default function EditUserPage() {
               />
             </div>
             <div className="space-y-2">
-              <label className="text-sm font-medium text-neutral-navy">Jabatan</label>
+              <label className="text-sm font-medium text-neutral-navy">
+                Jabatan
+              </label>
               <input
                 type="text"
                 value={jabatan}
@@ -406,7 +474,9 @@ export default function EditUserPage() {
           {/* Aturan bisnis: Desa Binaan hanya relevan/ditampilkan untuk role Ditbinmas. */}
           {isDitbinmasRole && (
             <div className="space-y-2">
-              <label className="text-sm font-medium text-neutral-navy">Desa Binaan</label>
+              <label className="text-sm font-medium text-neutral-navy">
+                Desa Binaan
+              </label>
               <input
                 type="text"
                 value={desa}
@@ -417,12 +487,15 @@ export default function EditUserPage() {
           )}
 
           <section className="rounded-2xl border border-spirit-200/80 bg-spirit-50/70 px-4 py-4 text-sm text-neutral-navy shadow-inner">
-            silahkan isi / perbaiki no whatsapp dan email agar kami dapat lebih mudah mengirimkan informasi terbaru kepada anda.
+            silahkan isi / perbaiki no whatsapp dan email agar kami dapat lebih
+            mudah mengirimkan informasi terbaru kepada anda.
           </section>
 
           <div className="grid gap-5 sm:grid-cols-2">
             <div className="space-y-2">
-              <label className="text-sm font-medium text-neutral-navy">No WhatsApp</label>
+              <label className="text-sm font-medium text-neutral-navy">
+                No WhatsApp
+              </label>
               <input
                 type="tel"
                 inputMode="numeric"
@@ -434,14 +507,13 @@ export default function EditUserPage() {
                   const sanitizedDigits = sanitizedValue.replace(/^\+/, "");
                   setFieldErrors((prev) => ({
                     ...prev,
-                    whatsapp:
-                      !sanitizedValue
-                        ? ""
-                        : sanitizedDigits.length < 8
-                          ? "No WhatsApp terlalu pendek (minimal 8 digit)."
-                          : /^\d+$/.test(sanitizedDigits)
-                            ? ""
-                            : "No WhatsApp hanya boleh berisi angka. Tanda + hanya boleh di awal.",
+                    whatsapp: !sanitizedValue
+                      ? ""
+                      : sanitizedDigits.length < 8
+                        ? "No WhatsApp terlalu pendek (minimal 8 digit)."
+                        : /^\d+$/.test(sanitizedDigits)
+                          ? ""
+                          : "No WhatsApp hanya boleh berisi angka. Tanda + hanya boleh di awal.",
                   }));
                 }}
                 placeholder="08xxxxxxxxxx / +628xxxxxxxxxx"
@@ -456,7 +528,9 @@ export default function EditUserPage() {
               )}
             </div>
             <div className="space-y-2">
-              <label className="text-sm font-medium text-neutral-navy">Email</label>
+              <label className="text-sm font-medium text-neutral-navy">
+                Email
+              </label>
               <input
                 type="email"
                 value={email}
@@ -476,100 +550,18 @@ export default function EditUserPage() {
             </div>
           </div>
 
-          <div className="space-y-2">
-            <label className="text-sm font-medium text-neutral-navy">Link Profil Instagram</label>
-            <input
-              type="text"
-              value={insta}
-              onChange={(e) => {
-                const value = e.target.value;
-                setInsta(value);
-                if (!value || isValidInstagram(value)) {
-                  setFieldErrors((prev) => ({ ...prev, insta: "" }));
-                }
-              }}
-              placeholder="https://www.instagram.com/nama_pengguna"
-              className="w-full rounded-2xl border border-spirit-200/80 bg-white px-4 py-3 text-sm text-neutral-navy shadow-inner focus:border-spirit-400 focus:outline-none focus:ring-2 focus:ring-spirit-200"
-            />
-            {fieldErrors.insta && (
-              <p className="text-xs text-red-500">{fieldErrors.insta}</p>
-            )}
-          </div>
-
-          <div className="space-y-2">
-            <label className="text-sm font-medium text-neutral-navy">Link Profil TikTok</label>
-            <input
-              type="text"
-              value={tiktok}
-              onChange={(e) => {
-                const value = e.target.value;
-                setTiktok(value);
-                if (!value || isValidTiktok(value)) {
-                  setFieldErrors((prev) => ({ ...prev, tiktok: "" }));
-                }
-              }}
-              placeholder="https://www.tiktok.com/@nama_pengguna"
-              className="w-full rounded-2xl border border-spirit-200/80 bg-white px-4 py-3 text-sm text-neutral-navy shadow-inner focus:border-spirit-400 focus:outline-none focus:ring-2 focus:ring-spirit-200"
-            />
-            {fieldErrors.tiktok && (
-              <p className="text-xs text-red-500">{fieldErrors.tiktok}</p>
-            )}
-          </div>
-
-          <div className="grid gap-5 sm:grid-cols-2">
-            <div className="space-y-2">
-              <label className="text-sm font-medium text-neutral-navy">
-                Username Instagram Akun Kedua
-              </label>
-              <input
-                type="text"
-                value={secondaryInstagramUsername}
-                onChange={(e) => {
-                  const value = e.target.value;
-                  setSecondaryInstagramUsername(value);
-                  if (!value || isValidInstagram(value)) {
-                    setFieldErrors((prev) => ({
-                      ...prev,
-                      secondaryInstagramUsername: "",
-                    }));
-                  }
-                }}
-                placeholder="contoh: humas_polres"
-                className="w-full rounded-2xl border border-spirit-200/80 bg-white px-4 py-3 text-sm text-neutral-navy shadow-inner focus:border-spirit-400 focus:outline-none focus:ring-2 focus:ring-spirit-200"
-              />
-              {fieldErrors.secondaryInstagramUsername && (
-                <p className="text-xs text-red-500">
-                  {fieldErrors.secondaryInstagramUsername}
-                </p>
-              )}
-            </div>
-            <div className="space-y-2">
-              <label className="text-sm font-medium text-neutral-navy">
-                Username TikTok Akun Kedua
-              </label>
-              <input
-                type="text"
-                value={secondaryTiktokUsername}
-                onChange={(e) => {
-                  const value = e.target.value;
-                  setSecondaryTiktokUsername(value);
-                  if (!value || isValidTiktok(value)) {
-                    setFieldErrors((prev) => ({
-                      ...prev,
-                      secondaryTiktokUsername: "",
-                    }));
-                  }
-                }}
-                placeholder="contoh: humas_polres"
-                className="w-full rounded-2xl border border-spirit-200/80 bg-white px-4 py-3 text-sm text-neutral-navy shadow-inner focus:border-spirit-400 focus:outline-none focus:ring-2 focus:ring-spirit-200"
-              />
-              {fieldErrors.secondaryTiktokUsername && (
-                <p className="text-xs text-red-500">
-                  {fieldErrors.secondaryTiktokUsername}
-                </p>
-              )}
-            </div>
-          </div>
+          <SocialAccountFields
+            platform="Instagram"
+            values={instagramAccounts}
+            errors={fieldErrors.instagramAccounts}
+            onChange={setInstagramAccounts}
+          />
+          <SocialAccountFields
+            platform="TikTok"
+            values={tiktokAccounts}
+            errors={fieldErrors.tiktokAccounts}
+            onChange={setTiktokAccounts}
+          />
 
           <button
             type="submit"

--- a/cicero-dashboard/app/claim/edit/socialUtils.ts
+++ b/cicero-dashboard/app/claim/edit/socialUtils.ts
@@ -30,7 +30,8 @@ export function extractInstagramUsername(url?: string | null): string {
       return "";
     }
     const segments = u.pathname.split("/").filter(Boolean);
-    return segments[0] ? segments[0].replace(/^@/, "") : "";
+    const username = segments[0]?.replace(/^@/, "") || "";
+    return INSTAGRAM_USERNAME_PATTERN.test(username) ? username : "";
   } catch {
     return "";
   }
@@ -53,7 +54,7 @@ export function extractTiktokUsername(url?: string | null): string {
       ) {
         return "";
       }
-      return TIKTOK_USERNAME_PATTERN.test(normalized) ? normalized : "";
+      return TIKTOK_USERNAME_PATTERN.test(normalized) ? `@${normalized}` : "";
     }
     const u = new URL(link);
     const host = u.hostname.toLowerCase();
@@ -66,10 +67,72 @@ export function extractTiktokUsername(url?: string | null): string {
     }
     const segments = u.pathname.split("/").filter(Boolean);
     if (!segments[0]) return "";
-    return segments[0].startsWith("@") ? segments[0].slice(1) : segments[0];
+    const username = segments[0].replace(/^@/, "");
+    return TIKTOK_USERNAME_PATTERN.test(username) ? `@${username}` : "";
   } catch {
     return "";
   }
+}
+
+export type SocialPlatform = "instagram" | "tiktok";
+
+export type SocialAccountListResult =
+  | { ok: true; accounts: string[] }
+  | { ok: false; index: number; message: string };
+
+/** Normalize editable rows to the exact arrays accepted and returned by claim API. */
+export function normalizeSocialAccountList(
+  values: string[],
+  platform: SocialPlatform,
+): SocialAccountListResult {
+  const extractor =
+    platform === "instagram" ? extractInstagramUsername : extractTiktokUsername;
+  const platformLabel = platform === "instagram" ? "Instagram" : "TikTok";
+  const lastNonEmptyIndex = values.findLastIndex(
+    (value) => value.trim() !== "",
+  );
+  const accounts: string[] = [];
+  const seen = new Set<string>();
+
+  for (let index = 0; index <= lastNonEmptyIndex; index += 1) {
+    const value = values[index]?.trim() || "";
+    if (!value) {
+      return {
+        ok: false,
+        index,
+        message: `Akun ${platformLabel} tidak boleh kosong di tengah daftar.`,
+      };
+    }
+
+    const normalized = extractor(value);
+    if (!normalized) {
+      return {
+        ok: false,
+        index,
+        message: `Format akun ${platformLabel} tidak valid. Masukkan username, @username, atau URL profil.`,
+      };
+    }
+
+    const dedupeKey = normalized.replace(/^@/, "").toLowerCase();
+    if (dedupeKey === "cicero_devs") {
+      return {
+        ok: false,
+        index,
+        message: "Username cicero_devs tidak diperbolehkan.",
+      };
+    }
+    if (seen.has(dedupeKey)) {
+      return {
+        ok: false,
+        index,
+        message: `Username ${platformLabel} terduplikasi. Gunakan username yang berbeda.`,
+      };
+    }
+    seen.add(dedupeKey);
+    accounts.push(normalized);
+  }
+
+  return { ok: true, accounts };
 }
 
 export function isValidInstagram(url?: string | null): boolean {

--- a/cicero-dashboard/utils/api.ts
+++ b/cicero-dashboard/utils/api.ts
@@ -3918,8 +3918,9 @@ export type ClaimProfileDto = {
   email: string | null;
   insta: string | null;
   tiktok: string | null;
-  instagram_accounts: string[];
-  tiktok_accounts: string[];
+  /** Canonical account lists; absent only on legacy backend responses. */
+  instagram_accounts?: string[];
+  tiktok_accounts?: string[];
   ditbinmas: boolean;
   ditlantas: boolean;
   bidhumas: boolean;


### PR DESCRIPTION
### Motivation
- Replace legacy single/alias username fields with canonical per-platform account lists so the UI matches backend contract and supports multiple accounts. 
- Surface deterministic normalization and validation rules on the client to match backend behavior (reject empty middle rows, duplicated usernames, blocked username `cicero_devs`, and invalid formats). 

### Description
- Added deterministic normalization utilities in `app/claim/edit/socialUtils.ts`: `normalizeSocialAccountList(platform)` plus stricter URL/handle extraction refinements for Instagram and TikTok (Instagram returns username without `@`, TikTok returns canonical `@username`).
- Reworked claim edit UI in `app/claim/edit/page.jsx` to store `instagramAccounts` and `tiktokAccounts` as arrays, introduced `SocialAccountFields` component to render dynamic rows (add/remove, keep at least one row) and human-friendly labels/placeholders, and loaded account arrays from `user.instagram_accounts` / `user.tiktok_accounts` falling back to legacy `insta`/`tiktok` only when array is absent.
- On submit the page now uses `normalizeSocialAccountList` to validate/normalize lists and sends `instagram_accounts` and `tiktok_accounts` arrays to `PUT /api/claim/me`, removing legacy alias fields from payload.
- Updated claim DTOs in `utils/api.ts` to reflect canonical lists (`instagram_accounts` / `tiktok_accounts`) availability in responses.
- Tests updated/added: updated `__tests__/socialUsernameParsing.test.ts` to cover the extractor changes and added `normalizeSocialAccountList` specs; extended `__tests__/claimEditPage.test.tsx` to cover array loading, fallback alias behavior, add/remove rows, normalization, duplicate rejection, and that the submitted payload contains only the arrays.
- Minor test/mocks adjustments: router/mocks cleared between runs and mocks for `updateClaimProfile` added to validate outgoing payload.

### Testing
- Ran the updated unit tests with Jest for the modified suites: `__tests__/socialUsernameParsing.test.ts` and `__tests__/claimEditPage.test.tsx` using `npm test -- --runInBand __tests__/socialUsernameParsing.test.ts __tests__/claimEditPage.test.tsx` and all tests passed (2 suites, 22 tests total passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a915755748327a9894f52eadc0352)