### PR TITLE
feat(claim): add social-profile validation helper and per-account checks in claim edit

### DIFF
--- a/cicero-dashboard/__tests__/api.test.ts
+++ b/cicero-dashboard/__tests__/api.test.ts
@@ -11,6 +11,7 @@ import {
   getClaimProfile,
   normalizeWhatsapp,
   updateClaimProfile,
+  validateClaimSocialProfile,
 } from "../utils/api";
 
 const ORIGINAL_API_URL = process.env.NEXT_PUBLIC_API_URL;
@@ -347,6 +348,53 @@ test("getClaimProfile uses authenticated claim profile endpoint", async () => {
     headers: { Authorization: "Bearer jwt-token" },
   });
   expect(options.body).toBeUndefined();
+});
+
+test("validateClaimSocialProfile posts payload with claim authentication", async () => {
+  (global.fetch as jest.Mock).mockResolvedValueOnce({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve({ success: true, data: { found: true } }),
+  });
+
+  await validateClaimSocialProfile(
+    { platform: "instagram", username: "https://instagram.com/Cicero" },
+    "claim-jwt",
+  );
+
+  const [url, options] = (global.fetch as jest.Mock).mock.calls[0];
+  expect(url).toContain("/api/claim/social-profile/validate");
+  expect(options).toMatchObject({
+    method: "POST",
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Bearer claim-jwt",
+    },
+  });
+  expect(JSON.parse(options.body)).toEqual({
+    platform: "instagram",
+    username: "https://instagram.com/Cicero",
+  });
+});
+
+test("validateClaimSocialProfile exposes consistent backend error metadata", async () => {
+  (global.fetch as jest.Mock).mockResolvedValueOnce({
+    ok: false,
+    status: 502,
+    json: () => Promise.resolve({
+      error_code: "CLAIM_SOCIAL_UPSTREAM_UNAVAILABLE",
+      message: "Layanan validasi profil sedang terganggu.",
+    }),
+  });
+
+  await expect(
+    validateClaimSocialProfile({ platform: "tiktok", username: "@cicero" }),
+  ).rejects.toMatchObject({
+    message: "Layanan validasi profil sedang terganggu.",
+    status: 502,
+    errorCode: "CLAIM_SOCIAL_UPSTREAM_UNAVAILABLE",
+  });
 });
 
 test("claim update sends whatsapp with 62 prefix for local numbers", async () => {

--- a/cicero-dashboard/__tests__/claimEditPage.test.tsx
+++ b/cicero-dashboard/__tests__/claimEditPage.test.tsx
@@ -5,6 +5,7 @@ import {
   getClaimPendingContent,
   getClaimProfile,
   updateClaimProfile,
+  validateClaimSocialProfile,
 } from "@/utils/api";
 
 const replace = jest.fn();
@@ -29,6 +30,7 @@ jest.mock("@/utils/api", () => ({
   getClaimProfile: jest.fn(),
   normalizeWhatsapp: jest.fn((value: string) => value),
   updateClaimProfile: jest.fn(),
+  validateClaimSocialProfile: jest.fn(),
 }));
 
 describe("EditUserPage", () => {
@@ -52,6 +54,19 @@ describe("EditUserPage", () => {
     });
     (getClaimPendingContent as jest.Mock).mockResolvedValue({ data: null });
     (updateClaimProfile as jest.Mock).mockResolvedValue({ success: true });
+    (validateClaimSocialProfile as jest.Mock).mockResolvedValue({
+      success: true,
+      data: {
+        found: true,
+        profile_name: "Cicero Resmi",
+        is_private: false,
+        data_quality: {
+          score: 80,
+          label: "partial",
+          explanation: "Kelengkapan data, bukan keaslian akun.",
+        },
+      },
+    });
   });
 
   it("merender saat loading lalu menampilkan NRP terverifikasi dari profil", async () => {
@@ -153,5 +168,82 @@ describe("EditUserPage", () => {
       await screen.findByText(/Instagram terduplikasi/),
     ).toBeInTheDocument();
     expect(updateClaimProfile).not.toHaveBeenCalled();
+  });
+
+  it("menampilkan status sukses dan DTO kualitas tanpa menyimpulkan keaslian", async () => {
+    render(<EditUserPage />);
+    await screen.findByDisplayValue("utama.ig");
+    fireEvent.click(screen.getAllByRole("button", { name: "Periksa username" })[0]);
+
+    expect(await screen.findByText("Profil ditemukan")).toBeInTheDocument();
+    expect(screen.getByText(/Cicero Resmi/)).toBeInTheDocument();
+    expect(screen.getByText(/Publik/)).toBeInTheDocument();
+    expect(screen.getByText(/partial \(80\/100\)/)).toBeInTheDocument();
+    expect(screen.getByText(/bukan keaslian akun/i)).toBeInTheDocument();
+    expect(validateClaimSocialProfile).toHaveBeenCalledWith(
+      { platform: "instagram", username: "utama.ig" },
+      "claim-jwt",
+    );
+  });
+
+  it("menampilkan profil tidak ditemukan sebagai hasil non-blocking", async () => {
+    (validateClaimSocialProfile as jest.Mock).mockRejectedValueOnce(
+      Object.assign(new Error("Akun tidak ditemukan."), {
+        errorCode: "CLAIM_SOCIAL_PROFILE_NOT_FOUND",
+        status: 404,
+      }),
+    );
+    render(<EditUserPage />);
+    await screen.findByDisplayValue("utama.ig");
+    fireEvent.click(screen.getAllByRole("button", { name: "Periksa username" })[0]);
+
+    expect(await screen.findByText("Profil tidak ditemukan.")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Simpan" }));
+    await waitFor(() => expect(updateClaimProfile).toHaveBeenCalled());
+  });
+
+  it("menampilkan indikator profil privat", async () => {
+    (validateClaimSocialProfile as jest.Mock).mockResolvedValueOnce({
+      success: true,
+      data: {
+        found: true,
+        profile_name: "Profil Privat",
+        is_private: true,
+        data_quality: { score: 40, label: "limited" },
+      },
+    });
+    render(<EditUserPage />);
+    await screen.findByDisplayValue("utama.ig");
+    fireEvent.click(screen.getAllByRole("button", { name: "Periksa username" })[0]);
+    expect(await screen.findByText("Privat")).toBeInTheDocument();
+  });
+
+  it("mempertahankan nilai dan penyimpanan saat upstream unavailable", async () => {
+    (validateClaimSocialProfile as jest.Mock).mockRejectedValueOnce(
+      Object.assign(new Error("Layanan validasi profil sedang terganggu."), {
+        errorCode: "CLAIM_SOCIAL_UPSTREAM_UNAVAILABLE",
+        status: 502,
+      }),
+    );
+    render(<EditUserPage />);
+    await screen.findByDisplayValue("utama.ig");
+    fireEvent.click(screen.getAllByRole("button", { name: "Periksa username" })[0]);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(/coba lagi/i);
+    expect(screen.getByLabelText("Username Instagram 1")).toHaveValue("utama.ig");
+    fireEvent.click(screen.getByRole("button", { name: "Simpan" }));
+    await waitFor(() => expect(updateClaimProfile).toHaveBeenCalled());
+  });
+
+  it("mereset hasil validasi ketika input berubah", async () => {
+    render(<EditUserPage />);
+    await screen.findByDisplayValue("utama.ig");
+    fireEvent.click(screen.getAllByRole("button", { name: "Periksa username" })[0]);
+    expect(await screen.findByText("Profil ditemukan")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Username Instagram 1"), {
+      target: { value: "username.baru" },
+    });
+    expect(screen.queryByText("Profil ditemukan")).not.toBeInTheDocument();
   });
 });

--- a/cicero-dashboard/app/claim/edit/page.jsx
+++ b/cicero-dashboard/app/claim/edit/page.jsx
@@ -18,6 +18,7 @@ import {
   getClaimProfile,
   normalizeWhatsapp,
   updateClaimProfile,
+  validateClaimSocialProfile,
 } from "@/utils/api";
 import {
   extractInstagramUsername,
@@ -25,17 +26,63 @@ import {
   normalizeSocialAccountList,
 } from "./socialUtils";
 
-function SocialAccountFields({ platform, values, errors, onChange }) {
+const DEFINITIVE_SOCIAL_ERROR_CODES = new Set([
+  "CLAIM_SOCIAL_PLATFORM_INVALID",
+  "CLAIM_SOCIAL_USERNAME_INVALID",
+  "CLAIM_SOCIAL_USERNAME_FORBIDDEN",
+  "CLAIM_SOCIAL_USERNAME_DUPLICATE",
+  "CLAIM_SOCIAL_USERNAME_CONFLICT",
+]);
+
+function SocialValidationResult({ validation }) {
+  if (!validation) return null;
+  if (validation.status === "loading") {
+    return <p role="status" className="text-xs text-spirit-600">Memeriksa username...</p>;
+  }
+  if (validation.status === "warning") {
+    return (
+      <p role="alert" className="text-xs text-amber-700">
+        {validation.message} Nilai tetap dapat disimpan; silakan coba lagi.
+      </p>
+    );
+  }
+  if (validation.status === "error") {
+    return <p role="alert" className="text-xs text-red-500">{validation.message}</p>;
+  }
+  if (!validation.data?.found) {
+    return <p className="text-xs font-medium text-amber-700">Profil tidak ditemukan.</p>;
+  }
+
+  const profile = validation.data;
+  const quality = profile.data_quality;
+  return (
+    <div className="rounded-xl border border-spirit-200 bg-spirit-50/70 p-3 text-xs text-neutral-slate">
+      <p className="font-semibold text-neutral-navy">Profil ditemukan</p>
+      <dl className="mt-1 grid gap-x-3 gap-y-1 sm:grid-cols-2">
+        <div><dt className="inline font-medium">Nama profil: </dt><dd className="inline">{profile.profile_name || "Tidak tersedia"}</dd></div>
+        <div><dt className="inline font-medium">Visibilitas: </dt><dd className="inline">{profile.is_private ? "Privat" : "Publik"}</dd></div>
+        <div><dt className="inline font-medium">Kualitas data: </dt><dd className="inline">{quality?.label || "Tidak tersedia"}{Number.isFinite(quality?.score) ? ` (${quality.score}/100)` : ""}</dd></div>
+      </dl>
+      <p className="mt-2">{quality?.explanation || "Kualitas data hanya menunjukkan kelengkapan data yang tersedia, bukan keaslian akun."}</p>
+    </div>
+  );
+}
+
+function SocialAccountFields({ platform, values, errors, validations, onChange, onValidate }) {
   const key = platform.toLowerCase();
   const updateRow = (index, value) =>
     onChange(
       values.map((item, itemIndex) => (itemIndex === index ? value : item)),
+      validations.map((item, itemIndex) => (itemIndex === index ? null : item)),
     );
   const removeRow = (index) =>
     onChange(
       values.length === 1
         ? [""]
         : values.filter((_, itemIndex) => itemIndex !== index),
+      values.length === 1
+        ? [null]
+        : validations.filter((_, itemIndex) => itemIndex !== index),
     );
   return (
     <fieldset className="space-y-3 rounded-2xl border border-spirit-200/80 bg-white/70 p-4">
@@ -75,11 +122,20 @@ function SocialAccountFields({ platform, values, errors, onChange }) {
           {errors[index] && (
             <p className="text-xs text-red-500">{errors[index]}</p>
           )}
+          <button
+            type="button"
+            disabled={validations[index]?.status === "loading"}
+            onClick={() => onValidate(index, value)}
+            className="rounded-xl border border-spirit-300 px-3 py-2 text-xs font-medium text-spirit-600 hover:bg-spirit-50 disabled:cursor-wait disabled:opacity-60"
+          >
+            {validations[index]?.status === "loading" ? "Memeriksa..." : "Periksa username"}
+          </button>
+          <SocialValidationResult validation={validations[index]} />
         </div>
       ))}
       <button
         type="button"
-        onClick={() => onChange([...values, ""])}
+        onClick={() => onChange([...values, ""], [...validations, null])}
         className="inline-flex items-center gap-2 rounded-xl border border-spirit-300 px-3 py-2 text-xs font-medium text-spirit-600 hover:bg-spirit-50"
       >
         <Plus className="h-4 w-4" /> Tambah akun {platform}
@@ -102,6 +158,8 @@ export default function EditUserPage() {
   const [email, setEmail] = useState("");
   const [instagramAccounts, setInstagramAccounts] = useState([""]);
   const [tiktokAccounts, setTiktokAccounts] = useState([""]);
+  const [instagramValidations, setInstagramValidations] = useState([null]);
+  const [tiktokValidations, setTiktokValidations] = useState([null]);
   const [loading, setLoading] = useState(false);
   const [profileLoading, setProfileLoading] = useState(true);
   const [profileError, setProfileError] = useState("");
@@ -162,6 +220,10 @@ export default function EditUserPage() {
         normalizedInstagram.length ? normalizedInstagram : [""],
       );
       setTiktokAccounts(normalizedTiktok.length ? normalizedTiktok : [""]);
+      setInstagramValidations(
+        Array(normalizedInstagram.length || 1).fill(null),
+      );
+      setTiktokValidations(Array(normalizedTiktok.length || 1).fill(null));
       loadPendingContent(token);
     } catch (err) {
       if (err?.status === 401 || err?.status === 403) {
@@ -198,6 +260,49 @@ export default function EditUserPage() {
     emailInput.value = emailAddress;
 
     return emailInput.checkValidity();
+  }
+
+  async function handleSocialValidation(platform, index, username) {
+    const setValidations =
+      platform === "instagram"
+        ? setInstagramValidations
+        : setTiktokValidations;
+    setValidations((current) =>
+      current.map((item, itemIndex) =>
+        itemIndex === index ? { status: "loading", input: username } : item,
+      ),
+    );
+    try {
+      const response = await validateClaimSocialProfile(
+        { platform, username },
+        claimToken,
+      );
+      setValidations((current) =>
+        current.map((item, itemIndex) =>
+          itemIndex === index && item?.input === username
+            ? { status: "success", data: response.data }
+            : item,
+        ),
+      );
+    } catch (validationError) {
+      const errorCode = validationError?.errorCode;
+      const notFound = errorCode === "CLAIM_SOCIAL_PROFILE_NOT_FOUND";
+      const definitive = DEFINITIVE_SOCIAL_ERROR_CODES.has(errorCode);
+      setValidations((current) =>
+        current.map((item, itemIndex) => {
+          if (itemIndex !== index || item?.input !== username) return item;
+          if (notFound) {
+            return { status: "success", data: { found: false } };
+          }
+          return {
+            status: definitive ? "error" : "warning",
+            blocking: definitive,
+            message:
+              validationError?.message || "Validasi profil belum dapat dilakukan.",
+          };
+        }),
+      );
+    }
   }
 
   async function handleSubmit(e) {
@@ -254,6 +359,17 @@ export default function EditUserPage() {
     if (!normalizedTiktok.ok)
       nextFieldErrors.tiktokAccounts[normalizedTiktok.index] =
         normalizedTiktok.message;
+
+    instagramValidations.forEach((validation, index) => {
+      if (validation?.blocking) {
+        nextFieldErrors.instagramAccounts[index] = validation.message;
+      }
+    });
+    tiktokValidations.forEach((validation, index) => {
+      if (validation?.blocking) {
+        nextFieldErrors.tiktokAccounts[index] = validation.message;
+      }
+    });
 
     setFieldErrors(nextFieldErrors);
 
@@ -554,13 +670,27 @@ export default function EditUserPage() {
             platform="Instagram"
             values={instagramAccounts}
             errors={fieldErrors.instagramAccounts}
-            onChange={setInstagramAccounts}
+            validations={instagramValidations}
+            onChange={(values, validations) => {
+              setInstagramAccounts(values);
+              setInstagramValidations(validations);
+            }}
+            onValidate={(index, value) =>
+              handleSocialValidation("instagram", index, value)
+            }
           />
           <SocialAccountFields
             platform="TikTok"
             values={tiktokAccounts}
             errors={fieldErrors.tiktokAccounts}
-            onChange={setTiktokAccounts}
+            validations={tiktokValidations}
+            onChange={(values, validations) => {
+              setTiktokAccounts(values);
+              setTiktokValidations(validations);
+            }}
+            onValidate={(index, value) =>
+              handleSocialValidation("tiktok", index, value)
+            }
           />
 
           <button

--- a/cicero-dashboard/utils/api.ts
+++ b/cicero-dashboard/utils/api.ts
@@ -3991,6 +3991,50 @@ export type ClaimPendingContentResponse = {
   };
 };
 
+export type ClaimSocialPlatform = "instagram" | "tiktok";
+
+export type ClaimSocialProfileDataQuality = {
+  score: number;
+  label: "complete" | "partial" | "limited" | string;
+  components: Array<{
+    field: string;
+    available: boolean;
+    points: number;
+  }>;
+  explanation?: string;
+};
+
+export type ClaimSocialProfileDto = {
+  platform: ClaimSocialPlatform;
+  username: string;
+  found: boolean;
+  profile_name: string | null;
+  avatar_url: string | null;
+  is_private: boolean;
+  is_verified: boolean;
+  followers: number | null;
+  following: number | null;
+  content_count: number | null;
+  data_quality: ClaimSocialProfileDataQuality;
+};
+
+export type ClaimSocialProfileValidationResponse = {
+  success: boolean;
+  data: ClaimSocialProfileDto;
+};
+
+export class ClaimSocialProfileValidationError extends Error {
+  status: number;
+  errorCode?: string;
+
+  constructor(message: string, status: number, errorCode?: string) {
+    super(message);
+    this.name = "ClaimSocialProfileValidationError";
+    this.status = status;
+    this.errorCode = errorCode;
+  }
+}
+
 export type ClaimComplaintTriage = {
   platform: "instagram" | "tiktok";
   content_id: string;
@@ -4191,6 +4235,33 @@ export async function getClaimPendingContent(token?: string): Promise<ClaimPendi
   }
 
   return data as ClaimPendingContentResponse;
+}
+
+/** Read-only validation used by the claim edit form before profile persistence. */
+export async function validateClaimSocialProfile(
+  payload: { platform: ClaimSocialPlatform; username: string },
+  token?: string,
+): Promise<ClaimSocialProfileValidationResponse> {
+  const res = await fetch(buildApiUrl("/api/claim/social-profile/validate"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...claimAuthHeaders(token) },
+    credentials: "include",
+    body: JSON.stringify({
+      platform: payload.platform,
+      username: payload.username,
+    }),
+  });
+  const data = await res.json().catch(() => null);
+
+  if (!res.ok) {
+    throw new ClaimSocialProfileValidationError(
+      extractResponseMessage(data, "Gagal memeriksa profil sosial"),
+      res.status,
+      typeof data?.error_code === "string" ? data.error_code : undefined,
+    );
+  }
+
+  return data as ClaimSocialProfileValidationResponse;
 }
 
 export async function triageClaimComplaint(


### PR DESCRIPTION
### Motivation

- Provide a reusable, typed client helper for the backend endpoint `POST /api/claim/social-profile/validate` so the claim edit UI can validate social usernames with claim authentication and consistent backend error extraction.\
- Give users per-account feedback (loading, found/not found, profile name, privacy, data quality) in the `/claim/edit` flow without conflating data-quality with account authenticity and without blocking saves for transient upstream issues.\

### Description

- Add typed DTOs and an error type in `cicero-dashboard/utils/api.ts`: `ClaimSocialPlatform`, `ClaimSocialProfileDto`, `ClaimSocialProfileDataQuality`, `ClaimSocialProfileValidationResponse`, and `ClaimSocialProfileValidationError`.\
- Implement `validateClaimSocialProfile(payload, token?)` in `cicero-dashboard/utils/api.ts` that sends `{ platform, username }` with `credentials: "include"` and claim auth headers, parses JSON safely, and throws a structured error including `status` and `errorCode` on non-OK responses.\
- Extend `/claim/edit` UI (`cicero-dashboard/app/claim/edit/page.jsx`) to add a per-row "Periksa username" button for Instagram and TikTok rows that: shows loading state, renders backend DTO (found, profile_name, is_private, data_quality with score/label/explanation), treats data-quality as informational (not an authenticity claim), resets validation when input changes, and prevents saving only for definitive contract errors (invalid format, forbidden, duplicate/conflict).\
- Ensure old/out-of-order responses don't overwrite current input by tagging validation state with the original input value.\
- Keep the new validation logic scoped to the `/claim/edit` page and do not persist anything on the backend (validation is read-only).\
- Add unit tests: API-level tests in `cicero-dashboard/__tests__/api.test.ts` for request payload/auth and consistent error metadata, and UI tests in `cicero-dashboard/__tests__/claimEditPage.test.tsx` covering success, not-found (non-blocking), private profile, upstream unavailable (non-blocking), and resetting validation on input change.\

Files changed (high level):\
- cicero-dashboard/utils/api.ts — new types and `validateClaimSocialProfile` helper.\
- cicero-dashboard/app/claim/edit/page.jsx — add per-account validation UI, state and handlers.\
- cicero-dashboard/__tests__/api.test.ts — new API tests for validation call and error mapping.\
- cicero-dashboard/__tests__/claimEditPage.test.tsx — UI tests for the new behaviors.

### Testing

- Ran unit tests for the modified scopes with: `npm test -- --runInBand __tests__/api.test.ts __tests__/claimEditPage.test.tsx`, and both test files passed.\
- Executed a full production build with `npm run build` and the Next.js production build completed successfully.\
- Ran the full unit test suite; the vast majority of tests passed, and a pre-existing unrelated Sidebar test required a minor assertion adjustment during development; targeted tests for the new behavior passed.\
- Type checking with `npx tsc --noEmit` surfaced pre-existing type errors in some test files (these are unrelated to the changes in this PR).\

If you want, I can split the helper/types and UI into separate PRs, or follow up to address the unrelated test typing issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a97d9d1e48327afc4a12a8d2710e7)