### PR TITLE
feat(claim): reuse triage complaint lifecycle for escalation and handle status conflicts

### DIFF
--- a/cicero-dashboard/__tests__/PendingContentCard.test.tsx
+++ b/cicero-dashboard/__tests__/PendingContentCard.test.tsx
@@ -5,10 +5,12 @@ import type { ClaimPendingContentResponse } from "@/utils/api";
 
 const triageClaimComplaint = jest.fn();
 const escalateClaimComplaint = jest.fn();
+const getClaimComplaint = jest.fn();
 jest.mock("@/utils/api", () => ({
   ...jest.requireActual("@/utils/api"),
   triageClaimComplaint: (...args: unknown[]) => triageClaimComplaint(...args),
   escalateClaimComplaint: (...args: unknown[]) => escalateClaimComplaint(...args),
+  getClaimComplaint: (...args: unknown[]) => getClaimComplaint(...args),
 }));
 
 const platform = (overrides = {}) => ({
@@ -99,6 +101,7 @@ describe("PendingContentCard", () => {
       platform: platformName, content_id: id, triage_code: "ENGAGEMENT_NOT_IN_SNAPSHOT", triage_quality: "medium",
       title: "Aktivitas belum terlihat", summary: "Bukti belum ditemukan.", evidence: [{ label: "Username tersimpan", value: "cicero", status: "tersedia" }],
       solutions: [{ order: 1, label: "Periksa kembali konten." }], last_collected_at: null, can_retry: true, retry_after: null, can_escalate: true,
+      complaint_id: "complaint-1", complaint_created: true, complaint_status: "triaged",
     });
     const item = platformName === "instagram" ? { shortcode: id } : { video_id: id };
     render(<PendingContentCard claimToken="claim-jwt" loading={false} error="" onRefresh={jest.fn()} data={responseData({ [platformName]: platform({ pending_content: 1, items: [{ ...item, url: null, caption: `Konten ${label}`, content_time: null }] }) })} />);
@@ -113,6 +116,8 @@ describe("PendingContentCard", () => {
     expect(screen.getByText("Kualitas triase: medium")).toBeTruthy();
     expect(screen.getByRole("button", { name: "Periksa ulang" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Eskalasi" })).toBeTruthy();
+    expect(screen.getByText("Complaint baru dibuat.")).toBeTruthy();
+    expect(screen.getByText("Status lifecycle terakhir: triaged")).toBeTruthy();
   });
 
   it("tidak menyediakan Komplain saat akun belum terisi", () => {
@@ -126,6 +131,7 @@ describe("PendingContentCard", () => {
       platform: "instagram", content_id: "IG1", triage_code: "ACTIVITY_ALREADY_RECORDED", triage_quality: "high",
       title: "Aktivitas sudah tercatat", summary: "Muat ulang untuk hasil terbaru.", evidence: [], solutions: [{ order: 1, label: "Muat ulang." }],
       last_collected_at: "2026-08-09T03:05:00.000Z", can_retry: false, retry_after: null, can_escalate: false,
+      complaint_id: null, complaint_created: false, complaint_status: null,
     });
     render(<PendingContentCard claimToken="claim-jwt" loading={false} error="" onRefresh={onRefresh} data={responseData({ instagram: platform({ pending_content: 1, items: [{ shortcode: "IG1", url: null, caption: "Konten", content_time: null }] }) })} />);
     fireEvent.click(screen.getByRole("button", { name: "Komplain" }));
@@ -134,6 +140,54 @@ describe("PendingContentCard", () => {
     await waitFor(() => expect(onRefresh).toHaveBeenCalledTimes(1));
     expect(triageClaimComplaint).toHaveBeenCalledTimes(1);
     expect(screen.getByText("Aktivitas sudah tercatat")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Eskalasi" })).toBeNull();
+  });
+
+  it("menampilkan deduplikasi complaint aktif dan mengeskalasi memakai status triase", async () => {
+    triageClaimComplaint.mockResolvedValue({
+      platform: "instagram", content_id: "IG1", triage_code: "ENGAGEMENT_NOT_IN_SNAPSHOT", triage_quality: "medium",
+      title: "Belum terlihat", summary: "Belum ditemukan", evidence: [], solutions: [], last_collected_at: null,
+      can_retry: false, retry_after: null, can_escalate: true, complaint_id: "c-aktif", complaint_created: false, complaint_status: "triaged",
+    });
+    escalateClaimComplaint.mockResolvedValue(undefined);
+    render(<PendingContentCard claimToken="claim-jwt" loading={false} error="" onRefresh={jest.fn()} data={responseData({ instagram: platform({ pending_content: 1, items: [{ shortcode: "IG1", url: null, caption: "Konten", content_time: null }] }) })} />);
+    fireEvent.click(screen.getByRole("button", { name: "Komplain" }));
+    fireEvent.click(screen.getByRole("button", { name: "Kirim Komplain" }));
+    expect(await screen.findByText("Complaint aktif yang sudah ada digunakan kembali.")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Eskalasi" }));
+    await waitFor(() => expect(escalateClaimComplaint).toHaveBeenCalledWith("claim-jwt", "c-aktif", "triaged"));
+  });
+
+  it("memuat status terbaru setelah konflik sebelum menawarkan eskalasi ulang", async () => {
+    const { ClaimComplaintLifecycleError } = jest.requireActual("@/utils/api");
+    triageClaimComplaint.mockResolvedValue({
+      platform: "instagram", content_id: "IG1", triage_code: "ENGAGEMENT_NOT_IN_SNAPSHOT", triage_quality: "medium",
+      title: "Belum terlihat", summary: "Belum ditemukan", evidence: [], solutions: [], last_collected_at: null,
+      can_retry: false, retry_after: null, can_escalate: true, complaint_id: "c-1", complaint_created: false, complaint_status: "triaged",
+    });
+    escalateClaimComplaint.mockRejectedValue(new ClaimComplaintLifecycleError("Status berubah", 409, "CLAIM_COMPLAINT_STATUS_CONFLICT"));
+    getClaimComplaint.mockResolvedValue({ complaint_id: "c-1", status: "reviewed" });
+    render(<PendingContentCard claimToken="claim-jwt" loading={false} error="" onRefresh={jest.fn()} data={responseData({ instagram: platform({ pending_content: 1, items: [{ shortcode: "IG1", url: null, caption: "Konten", content_time: null }] }) })} />);
+    fireEvent.click(screen.getByRole("button", { name: "Komplain" }));
+    fireEvent.click(screen.getByRole("button", { name: "Kirim Komplain" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Eskalasi" }));
+    await waitFor(() => expect(getClaimComplaint).toHaveBeenCalledWith("claim-jwt", "c-1"));
+    expect(screen.getByRole("alert").textContent).toContain("Status berubah");
+    expect(screen.getByText("Status lifecycle terakhir: reviewed")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Eskalasi" }));
+    await waitFor(() => expect(escalateClaimComplaint).toHaveBeenLastCalledWith("claim-jwt", "c-1", "reviewed"));
+  });
+
+  it("tidak menawarkan eskalasi tanpa complaint_id", async () => {
+    triageClaimComplaint.mockResolvedValue({
+      platform: "instagram", content_id: "IG1", triage_code: "NO_COMPLAINT", triage_quality: "high",
+      title: "Selesai", summary: "Tidak perlu complaint", evidence: [], solutions: [], last_collected_at: null,
+      can_retry: false, retry_after: null, can_escalate: true, complaint_id: null, complaint_created: false, complaint_status: "triaged",
+    });
+    render(<PendingContentCard claimToken="claim-jwt" loading={false} error="" onRefresh={jest.fn()} data={responseData({ instagram: platform({ pending_content: 1, items: [{ shortcode: "IG1", url: null, caption: "Konten", content_time: null }] }) })} />);
+    fireEvent.click(screen.getByRole("button", { name: "Komplain" }));
+    fireEvent.click(screen.getByRole("button", { name: "Kirim Komplain" }));
+    await screen.findByText("Selesai");
     expect(screen.queryByRole("button", { name: "Eskalasi" })).toBeNull();
   });
 });

--- a/cicero-dashboard/__tests__/claimPendingContentApi.test.ts
+++ b/cicero-dashboard/__tests__/claimPendingContentApi.test.ts
@@ -24,3 +24,64 @@ describe("getClaimPendingContent", () => {
     await expect(getClaimPendingContent()).rejects.toThrow("Gagal memuat konten yang belum tercatat");
   });
 });
+
+describe("claim complaint lifecycle API", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    process.env.NEXT_PUBLIC_API_URL = "https://api.cicero.test";
+    global.fetch = jest.fn();
+  });
+
+  const triageData = {
+    platform: "instagram",
+    content_id: "IG1",
+    complaint_id: "complaint/1",
+    complaint_created: true,
+    complaint_status: "triaged",
+  };
+
+  it.each([201, 200])("mengembalikan metadata complaint dari triase HTTP %s", async (status) => {
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: true, status, json: async () => ({ success: true, data: { ...triageData, complaint_created: status === 201 } }) });
+    const { triageClaimComplaint } = await import("@/utils/api");
+    await expect(triageClaimComplaint("claim-jwt", { platform: "instagram", issue_type: "activity_not_recorded", shortcode: "IG1" })).resolves.toMatchObject({
+      complaint_id: "complaint/1",
+      complaint_created: status === 201,
+      complaint_status: "triaged",
+    });
+    expect(global.fetch).toHaveBeenCalledWith("https://api.cicero.test/api/claim/complaints/triage", expect.objectContaining({ method: "POST" }));
+  });
+
+  it("langsung mengeskalasi complaint dengan expected_status tanpa membuat ulang", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: true, status: 200, json: async () => ({ success: true }) });
+    const { escalateClaimComplaint } = await import("@/utils/api");
+    await escalateClaimComplaint("claim-jwt", "complaint/1", "triaged");
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledWith("https://api.cicero.test/api/claim/complaints/complaint%2F1/escalate", expect.objectContaining({
+      method: "POST",
+      body: JSON.stringify({ expected_status: "triaged" }),
+    }));
+  });
+
+  it("mempertahankan kode, status, dan pesan backend pada konflik lifecycle", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: false, status: 409, json: async () => ({ error_code: "CLAIM_COMPLAINT_STATUS_CONFLICT", message: "Status complaint telah berubah" }) });
+    const { escalateClaimComplaint } = await import("@/utils/api");
+    await expect(escalateClaimComplaint("claim-jwt", "c-1", "triaged")).rejects.toMatchObject({
+      status: 409,
+      errorCode: "CLAIM_COMPLAINT_STATUS_CONFLICT",
+      message: "Status complaint telah berubah",
+    });
+  });
+
+  it.each([404, 422])("meneruskan pesan backend untuk response %s tanpa status buatan frontend", async (status) => {
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: false, status, json: async () => ({ error_code: "BACKEND_CODE", message: `Pesan backend ${status}` }) });
+    const { escalateClaimComplaint } = await import("@/utils/api");
+    await expect(escalateClaimComplaint("claim-jwt", "c-1", "triaged")).rejects.toMatchObject({ status, message: `Pesan backend ${status}` });
+  });
+
+  it("memuat lifecycle complaint terbaru", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: true, status: 200, json: async () => ({ data: { complaint_id: "c-1", status: "resolved" } }) });
+    const { getClaimComplaint } = await import("@/utils/api");
+    await expect(getClaimComplaint("claim-jwt", "c-1")).resolves.toEqual({ complaint_id: "c-1", status: "resolved" });
+    expect(global.fetch).toHaveBeenCalledWith("https://api.cicero.test/api/claim/complaints/c-1", expect.objectContaining({ method: "GET" }));
+  });
+});

--- a/cicero-dashboard/components/claim/PendingContentCard.tsx
+++ b/cicero-dashboard/components/claim/PendingContentCard.tsx
@@ -6,7 +6,9 @@ import { ExternalLink, Instagram, RefreshCw, TriangleAlert, X } from "lucide-rea
 
 import {
   escalateClaimComplaint,
+  getClaimComplaint,
   triageClaimComplaint,
+  ClaimComplaintLifecycleError,
   type ClaimComplaintTriage,
   type ClaimPendingContentResponse,
   type ClaimPendingContentItem,
@@ -117,10 +119,24 @@ function ComplaintDialog({ selection, token, filters, onClose, onRefresh, onOpen
   }
 
   async function escalate() {
-    if (!result || escalating) return;
+    if (!result?.complaint_id || !result.complaint_status || escalating) return;
     setEscalating(true); setError("");
-    try { await escalateClaimComplaint(token, result); onClose(); }
-    catch (err) { setError(err instanceof Error ? err.message : "Gagal mengeskalasi komplain"); }
+    try {
+      await escalateClaimComplaint(token, result.complaint_id, result.complaint_status);
+      onClose();
+    } catch (err) {
+      if (err instanceof ClaimComplaintLifecycleError && err.status === 409 && err.errorCode === "CLAIM_COMPLAINT_STATUS_CONFLICT") {
+        try {
+          const latest = await getClaimComplaint(token, result.complaint_id);
+          setResult((current) => current ? { ...current, complaint_status: latest.status } : current);
+          setError(`${err.message} Status terbaru telah dimuat; silakan coba eskalasi kembali.`);
+        } catch (refreshError) {
+          setError(refreshError instanceof Error ? refreshError.message : "Gagal memuat status komplain terbaru");
+        }
+      } else {
+        setError(err instanceof Error ? err.message : "Gagal mengeskalasi komplain");
+      }
+    }
     finally { setEscalating(false); }
   }
 
@@ -140,6 +156,7 @@ function ComplaintDialog({ selection, token, filters, onClose, onRefresh, onOpen
         {error && <p role="alert" className="mt-4 rounded-xl bg-red-50 p-3 text-sm text-red-600">{error}</p>}
         {result && <section className="mt-5 space-y-4" aria-label="Hasil triase">
           <div><h3 className="text-lg font-bold text-neutral-navy">{result.title}</h3><p className="text-sm text-neutral-slate">{result.summary}</p><p className="mt-2 text-xs font-semibold uppercase">Kualitas triase: {result.triage_quality}</p></div>
+          {result.complaint_id && <div className="rounded-xl bg-spirit-50 p-3 text-sm text-spirit-800"><p>{result.complaint_created ? "Complaint baru dibuat." : "Complaint aktif yang sudah ada digunakan kembali."}</p><p className="mt-1 font-semibold">Status lifecycle terakhir: {result.complaint_status ?? "Tidak tersedia"}</p></div>}
           <div><h4 className="font-semibold">Bukti</h4><dl className="mt-2 space-y-2">{result.evidence.map((entry, index) => <div key={`${entry.label}-${index}`} className="rounded-xl bg-neutral-50 p-3 text-sm"><dt className="font-semibold">{entry.label}</dt><dd>{entry.value ?? "Tidak tersedia"} <span className="text-neutral-slate">({entry.status})</span></dd></div>)}</dl></div>
           <div><h4 className="font-semibold">Langkah solusi</h4><ol className="mt-2 list-decimal space-y-1 pl-5 text-sm">{[...result.solutions].sort((a, b) => a.order - b.order).map((step) => <li key={`${step.order}-${step.label}`}>{step.label}</li>)}</ol></div>
           {result.last_collected_at && <p className="text-xs text-neutral-slate">Sinkronisasi terakhir: {new Date(result.last_collected_at).toLocaleString("id-ID", { timeZone: "Asia/Jakarta" })}</p>}
@@ -148,7 +165,7 @@ function ComplaintDialog({ selection, token, filters, onClose, onRefresh, onOpen
           {result?.triage_code === "ACTIVITY_ALREADY_RECORDED" && <button type="button" onClick={onRefresh} className="rounded-xl border px-4 py-2 text-sm font-semibold">Refresh pending content</button>}
           {needsProfileUpdate && <button type="button" onClick={() => { onClose(); onOpenProfile?.(); }} className="rounded-xl border px-4 py-2 text-sm font-semibold">Buka Update Data Personil</button>}
           {result?.can_retry && <button type="button" disabled={!retryReady || submitting} onClick={submit} className="rounded-xl border px-4 py-2 text-sm font-semibold disabled:opacity-50">{retryReady ? "Periksa ulang" : `Periksa setelah ${new Date(retryAt).toLocaleString("id-ID")}`}</button>}
-          {result?.can_escalate && <button type="button" disabled={escalating} onClick={escalate} className="rounded-xl bg-red-600 px-4 py-2 text-sm font-semibold text-white disabled:opacity-50">{escalating ? "Mengeskalasi..." : "Eskalasi"}</button>}
+          {result?.can_escalate && result.complaint_id && result.complaint_status && <button type="button" disabled={escalating} onClick={escalate} className="rounded-xl bg-red-600 px-4 py-2 text-sm font-semibold text-white disabled:opacity-50">{escalating ? "Mengeskalasi..." : "Eskalasi"}</button>}
           {!result && <button type="button" disabled={submitting || !identifier || !token} onClick={submit} className="rounded-xl bg-spirit-600 px-4 py-2 text-sm font-semibold text-white disabled:opacity-50">{submitting ? "Memeriksa..." : "Kirim Komplain"}</button>}
         </div>
       </Dialog.Content></Dialog.Portal>

--- a/cicero-dashboard/utils/api.ts
+++ b/cicero-dashboard/utils/api.ts
@@ -4048,7 +4048,28 @@ export type ClaimComplaintTriage = {
   can_retry: boolean;
   retry_after: string | null;
   can_escalate: boolean;
+  complaint_id: string | null;
+  complaint_created: boolean;
+  complaint_status: string | null;
 };
+
+export type ClaimComplaintLifecycle = {
+  complaint_id: string;
+  status: string;
+  [key: string]: unknown;
+};
+
+export class ClaimComplaintLifecycleError extends Error {
+  status: number;
+  errorCode?: string;
+
+  constructor(message: string, status: number, errorCode?: string) {
+    super(message);
+    this.name = "ClaimComplaintLifecycleError";
+    this.status = status;
+    this.errorCode = errorCode;
+  }
+}
 
 export type ClaimComplaintTriagePayload = {
   platform: "instagram" | "tiktok";
@@ -4286,30 +4307,49 @@ export async function triageClaimComplaint(
 
 export async function escalateClaimComplaint(
   token: string,
-  triage: ClaimComplaintTriage,
+  complaintId: string,
+  complaintStatus: string,
 ): Promise<void> {
-  const createResponse = await fetch(buildApiUrl("/api/claim/complaints"), {
-    method: "POST",
-    headers: { "Content-Type": "application/json", ...claimAuthHeaders(token) },
-    credentials: "include",
-    body: JSON.stringify({ triage }),
-  });
-  const created = await createResponse.json().catch(() => null);
-  if (!createResponse.ok || !created?.data?.complaint_id) {
-    throw new Error(extractResponseMessage(created, "Gagal membuat eskalasi komplain"));
-  }
   const escalationResponse = await fetch(
-    buildApiUrl(`/api/claim/complaints/${encodeURIComponent(created.data.complaint_id)}/escalate`),
+    buildApiUrl(`/api/claim/complaints/${encodeURIComponent(complaintId)}/escalate`),
     {
       method: "POST",
       headers: { "Content-Type": "application/json", ...claimAuthHeaders(token) },
       credentials: "include",
+      body: JSON.stringify({ expected_status: complaintStatus }),
     },
   );
   const escalated = await escalationResponse.json().catch(() => null);
   if (!escalationResponse.ok) {
-    throw new Error(extractResponseMessage(escalated, "Gagal mengeskalasi komplain"));
+    throw new ClaimComplaintLifecycleError(
+      extractResponseMessage(escalated, "Gagal mengeskalasi komplain"),
+      escalationResponse.status,
+      typeof escalated?.error_code === "string" ? escalated.error_code : undefined,
+    );
   }
+}
+
+export async function getClaimComplaint(
+  token: string,
+  complaintId: string,
+): Promise<ClaimComplaintLifecycle> {
+  const response = await fetch(
+    buildApiUrl(`/api/claim/complaints/${encodeURIComponent(complaintId)}`),
+    {
+      method: "GET",
+      headers: claimAuthHeaders(token),
+      credentials: "include",
+    },
+  );
+  const body = await response.json().catch(() => null);
+  if (!response.ok) {
+    throw new ClaimComplaintLifecycleError(
+      extractResponseMessage(body, "Gagal memuat status komplain terbaru"),
+      response.status,
+      typeof body?.error_code === "string" ? body.error_code : undefined,
+    );
+  }
+  return body.data as ClaimComplaintLifecycle;
 }
 
 export async function updateClaimProfile(


### PR DESCRIPTION
### Motivation

- Align dashboard behavior with backend triage that returns complaint lifecycle metadata so the UI can reuse existing complaints instead of recreating them and escalate with an expected status.
- Surface lifecycle state to agents and handle optimistic concurrency conflicts (409) by reloading the latest complaint status before retrying escalation.

### Description

- Extend `ClaimComplaintTriage` with `complaint_id: string | null`, `complaint_created: boolean`, and `complaint_status: string | null`, and add `ClaimComplaintLifecycle` and `ClaimComplaintLifecycleError` types in `cicero-dashboard/utils/api.ts`.
- Change `escalateClaimComplaint` to accept `(token, complaintId, complaintStatus)` and call `POST /api/claim/complaints/:complaintId/escalate` with body `{ expected_status: complaintStatus }`, and introduce `getClaimComplaint` to fetch lifecycle state from `GET /api/claim/complaints/:complaintId`.
- Update `cicero-dashboard/components/claim/PendingContentCard.tsx` to only show the Eskalasi button when `can_escalate`, `complaint_id`, and `complaint_status` are present, display whether the complaint was newly created or an existing one was reused via `complaint_created`, show the last lifecycle status, and handle `409 CLAIM_COMPLAINT_STATUS_CONFLICT` by loading the latest lifecycle before offering a retry while preserving backend messages for `404`/`422`.
- Add and update tests: `cicero-dashboard/__tests__/claimPendingContentApi.test.ts` covers triage responses (201/200), direct escalation with `expected_status`, conflict handling (409) and GET lifecycle; `cicero-dashboard/__tests__/PendingContentCard.test.tsx` adds component-level tests for complaint deduplication, escalation with triage status, conflict refresh flow, and absence of escalation when `complaint_id` is missing.

### Testing

- Ran unit tests for the modified files with `npm test -- --runInBand __tests__/claimPendingContentApi.test.ts __tests__/PendingContentCard.test.tsx` and all tests in those files passed.
- Ran the whole test suite with `npm test -- --runInBand` where 280 of 281 tests passed and a pre-existing unrelated failure remains in `Sidebar.test.tsx` (not caused by these changes).
- Ran `npx tsc --noEmit` which reported unrelated, pre-existing TypeScript errors in other test files but did not block the behavior validated by the updated unit tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7aad8b0d0c8327b8a91e89d27394f1)