### PR TITLE
feat(claim): tampilkan riwayat lifecycle komplain pada halaman Claim

### DIFF
--- a/cicero-dashboard/__tests__/ComplaintHistoryCard.test.tsx
+++ b/cicero-dashboard/__tests__/ComplaintHistoryCard.test.tsx
@@ -1,0 +1,56 @@
+import "@testing-library/jest-dom";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import ComplaintHistoryCard from "@/components/claim/ComplaintHistoryCard";
+import type { ClaimComplaintLifecycleDto } from "@/utils/api";
+
+const complaint: ClaimComplaintLifecycleDto = {
+  complaint_id: "complaint-1",
+  platform: "instagram",
+  content_id: "SHORTCODE-1",
+  issue_type: "activity_not_recorded",
+  status: "escalated",
+  triage: {
+    code: "ENGAGEMENT_NOT_IN_SNAPSHOT",
+    quality: "medium",
+    evidence: {
+      activity_recorded: false,
+      snapshot_available: true,
+      last_collected_at: null,
+      performed_at: null,
+    },
+  },
+  created_at: "2026-08-10T00:00:00.000Z",
+  updated_at: "2026-08-10T01:00:00.000Z",
+  escalated_at: "2026-08-10T01:00:00.000Z",
+  resolved_at: null,
+};
+
+describe("ComplaintHistoryCard", () => {
+  it("menampilkan loading dan empty state", () => {
+    const { rerender } = render(
+      <ComplaintHistoryCard complaints={[]} loading error="" onRetry={jest.fn()} />,
+    );
+    expect(screen.getByRole("status")).toHaveTextContent("Memuat riwayat komplain");
+    rerender(<ComplaintHistoryCard complaints={[]} loading={false} error="" onRetry={jest.fn()} />);
+    expect(screen.getByText("Belum ada riwayat komplain.")).toBeInTheDocument();
+  });
+
+  it("menampilkan nilai DTO backend dan label status presentasi yang stabil", () => {
+    render(<ComplaintHistoryCard complaints={[complaint]} loading={false} error="" onRetry={jest.fn()} />);
+    expect(screen.getByText("Instagram")).toBeInTheDocument();
+    expect(screen.getByText("SHORTCODE-1")).toBeInTheDocument();
+    expect(screen.getAllByText("Dieskalasi")).not.toHaveLength(0);
+    expect(screen.getByText("ENGAGEMENT_NOT_IN_SNAPSHOT")).toBeInTheDocument();
+    expect(screen.getByText("medium")).toBeInTheDocument();
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+
+  it("menampilkan error dan tombol coba lagi", () => {
+    const onRetry = jest.fn();
+    render(<ComplaintHistoryCard complaints={[]} loading={false} error="Backend gagal" onRetry={onRetry} />);
+    expect(screen.getByRole("alert")).toHaveTextContent("Backend gagal");
+    fireEvent.click(screen.getByRole("button", { name: "Coba lagi" }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+});

--- a/cicero-dashboard/__tests__/PendingContentCard.test.tsx
+++ b/cicero-dashboard/__tests__/PendingContentCard.test.tsx
@@ -144,18 +144,20 @@ describe("PendingContentCard", () => {
   });
 
   it("menampilkan deduplikasi complaint aktif dan mengeskalasi memakai status triase", async () => {
+    const onComplaintChanged = jest.fn().mockResolvedValue(undefined);
     triageClaimComplaint.mockResolvedValue({
       platform: "instagram", content_id: "IG1", triage_code: "ENGAGEMENT_NOT_IN_SNAPSHOT", triage_quality: "medium",
       title: "Belum terlihat", summary: "Belum ditemukan", evidence: [], solutions: [], last_collected_at: null,
       can_retry: false, retry_after: null, can_escalate: true, complaint_id: "c-aktif", complaint_created: false, complaint_status: "triaged",
     });
     escalateClaimComplaint.mockResolvedValue(undefined);
-    render(<PendingContentCard claimToken="claim-jwt" loading={false} error="" onRefresh={jest.fn()} data={responseData({ instagram: platform({ pending_content: 1, items: [{ shortcode: "IG1", url: null, caption: "Konten", content_time: null }] }) })} />);
+    render(<PendingContentCard claimToken="claim-jwt" loading={false} error="" onRefresh={jest.fn()} onComplaintChanged={onComplaintChanged} data={responseData({ instagram: platform({ pending_content: 1, items: [{ shortcode: "IG1", url: null, caption: "Konten", content_time: null }] }) })} />);
     fireEvent.click(screen.getByRole("button", { name: "Komplain" }));
     fireEvent.click(screen.getByRole("button", { name: "Kirim Komplain" }));
     expect(await screen.findByText("Complaint aktif yang sudah ada digunakan kembali.")).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: "Eskalasi" }));
     await waitFor(() => expect(escalateClaimComplaint).toHaveBeenCalledWith("claim-jwt", "c-aktif", "triaged"));
+    await waitFor(() => expect(onComplaintChanged).toHaveBeenCalledTimes(2));
   });
 
   it("memuat status terbaru setelah konflik sebelum menawarkan eskalasi ulang", async () => {

--- a/cicero-dashboard/__tests__/claimEditPage.test.tsx
+++ b/cicero-dashboard/__tests__/claimEditPage.test.tsx
@@ -3,6 +3,7 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import EditUserPage from "@/app/claim/edit/page";
 import {
   getClaimPendingContent,
+  getClaimComplaints,
   getClaimProfile,
   updateClaimProfile,
   validateClaimSocialProfile,
@@ -25,8 +26,14 @@ jest.mock("@/components/claim/PendingContentCard", () => ({
   default: () => <div data-testid="pending-content" />,
 }));
 
+jest.mock("@/components/claim/ComplaintHistoryCard", () => ({
+  __esModule: true,
+  default: () => <div data-testid="complaint-history" />,
+}));
+
 jest.mock("@/utils/api", () => ({
   getClaimPendingContent: jest.fn(),
+  getClaimComplaints: jest.fn(),
   getClaimProfile: jest.fn(),
   normalizeWhatsapp: jest.fn((value: string) => value),
   updateClaimProfile: jest.fn(),
@@ -53,6 +60,7 @@ describe("EditUserPage", () => {
       },
     });
     (getClaimPendingContent as jest.Mock).mockResolvedValue({ data: null });
+    (getClaimComplaints as jest.Mock).mockResolvedValue([]);
     (updateClaimProfile as jest.Mock).mockResolvedValue({ success: true });
     (validateClaimSocialProfile as jest.Mock).mockResolvedValue({
       success: true,
@@ -79,6 +87,7 @@ describe("EditUserPage", () => {
     expect(screen.getByLabelText("NRP")).toHaveAttribute("readonly");
     expect(getClaimProfile).toHaveBeenCalledWith("claim-jwt");
     expect(getClaimPendingContent).toHaveBeenCalledWith("claim-jwt");
+    expect(getClaimComplaints).toHaveBeenCalledWith("claim-jwt");
   });
 
   it("memuat seluruh array kanonis dan tidak memakai alias", async () => {

--- a/cicero-dashboard/__tests__/claimPendingContentApi.test.ts
+++ b/cicero-dashboard/__tests__/claimPendingContentApi.test.ts
@@ -84,4 +84,28 @@ describe("claim complaint lifecycle API", () => {
     await expect(getClaimComplaint("claim-jwt", "c-1")).resolves.toEqual({ complaint_id: "c-1", status: "resolved" });
     expect(global.fetch).toHaveBeenCalledWith("https://api.cicero.test/api/claim/complaints/c-1", expect.objectContaining({ method: "GET" }));
   });
+
+  it("memuat daftar milik pengguna terautentikasi tanpa identitas query atau body", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: [{ complaint_id: "c-1", status: "triaged" }] }),
+    });
+    const { getClaimComplaints } = await import("@/utils/api");
+
+    await expect(getClaimComplaints("claim-jwt")).resolves.toEqual([
+      { complaint_id: "c-1", status: "triaged" },
+    ]);
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://api.cicero.test/api/claim/complaints",
+      {
+        method: "GET",
+        headers: { Authorization: "Bearer claim-jwt" },
+        credentials: "include",
+      },
+    );
+    const [url, init] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(url).not.toMatch(/[?&](user_id|nrp|client_id)=/);
+    expect(init).not.toHaveProperty("body");
+  });
 });

--- a/cicero-dashboard/app/claim/edit/page.jsx
+++ b/cicero-dashboard/app/claim/edit/page.jsx
@@ -12,8 +12,10 @@ import {
 } from "lucide-react";
 
 import ClaimLayout from "@/components/claim/ClaimLayout";
+import ComplaintHistoryCard from "@/components/claim/ComplaintHistoryCard";
 import PendingContentCard from "@/components/claim/PendingContentCard";
 import {
+  getClaimComplaints,
   getClaimPendingContent,
   getClaimProfile,
   normalizeWhatsapp,
@@ -166,6 +168,9 @@ export default function EditUserPage() {
   const [pendingContent, setPendingContent] = useState(null);
   const [contentLoading, setContentLoading] = useState(true);
   const [contentError, setContentError] = useState("");
+  const [complaints, setComplaints] = useState([]);
+  const [complaintsLoading, setComplaintsLoading] = useState(true);
+  const [complaintsError, setComplaintsError] = useState("");
   const [error, setError] = useState("");
   const [message, setMessage] = useState("");
   const [fieldErrors, setFieldErrors] = useState({
@@ -181,6 +186,7 @@ export default function EditUserPage() {
       const token = sessionStorage.getItem("claim_token");
       setClaimToken(token || "");
       loadUser(token || "");
+      loadComplaints(token || "");
     }
   }, [router]);
 
@@ -249,6 +255,22 @@ export default function EditUserPage() {
       setContentError(err?.message?.trim() || "Terjadi kesalahan pada server");
     } finally {
       setContentLoading(false);
+    }
+  }
+
+  async function loadComplaints(token = claimToken) {
+    setComplaintsLoading(true);
+    setComplaintsError("");
+    try {
+      setComplaints(await getClaimComplaints(token));
+    } catch (err) {
+      if (err?.status === 401 || err?.status === 403) {
+        router.replace("/claim");
+        return;
+      }
+      setComplaintsError(err?.message?.trim() || "Terjadi kesalahan pada server");
+    } finally {
+      setComplaintsLoading(false);
     }
   }
 
@@ -442,11 +464,19 @@ export default function EditUserPage() {
           error={contentError}
           onRefresh={loadPendingContent}
           claimToken={claimToken}
+          onComplaintChanged={loadComplaints}
           onOpenProfile={() =>
             document
               .getElementById("claim-profile-form")
               ?.scrollIntoView({ behavior: "smooth" })
           }
+        />
+
+        <ComplaintHistoryCard
+          complaints={complaints}
+          loading={complaintsLoading}
+          error={complaintsError}
+          onRetry={loadComplaints}
         />
 
         <section className="rounded-3xl border border-spirit-200/80 bg-gradient-to-br from-white/80 via-spirit-50/70 to-trust-50/70 px-6 py-5 text-sm text-neutral-slate shadow-inner">

--- a/cicero-dashboard/components/claim/ComplaintHistoryCard.tsx
+++ b/cicero-dashboard/components/claim/ComplaintHistoryCard.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { RefreshCw, TriangleAlert } from "lucide-react";
+
+import type { ClaimComplaintLifecycleDto } from "@/utils/api";
+
+type Props = {
+  complaints: ClaimComplaintLifecycleDto[];
+  loading: boolean;
+  error: string;
+  onRetry: () => void | Promise<void>;
+};
+
+const STATUS_LABELS: Readonly<Record<string, string>> = {
+  triaged: "Ditriase",
+  escalated: "Dieskalasi",
+  resolved: "Selesai",
+};
+
+const PLATFORM_LABELS: Readonly<Record<string, string>> = {
+  instagram: "Instagram",
+  tiktok: "TikTok",
+};
+
+function displayStatus(status: string) {
+  return STATUS_LABELS[status] ?? status;
+}
+
+function formatTimestamp(value: string | null) {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return new Intl.DateTimeFormat("id-ID", {
+    dateStyle: "medium",
+    timeStyle: "short",
+    timeZone: "Asia/Jakarta",
+  }).format(date);
+}
+
+export default function ComplaintHistoryCard({
+  complaints,
+  loading,
+  error,
+  onRetry,
+}: Props) {
+  return (
+    <section
+      aria-busy={loading}
+      aria-labelledby="complaint-history-title"
+      className="space-y-4 rounded-3xl border border-spirit-200/80 bg-white/90 p-5 shadow-sm"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 id="complaint-history-title" className="text-lg font-semibold text-neutral-navy">
+            Riwayat Komplain
+          </h2>
+          <p className="mt-1 text-sm text-neutral-slate">
+            Status dan hasil triase ditampilkan sesuai lifecycle dari CICERO.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onRetry}
+          disabled={loading}
+          className="inline-flex items-center gap-2 rounded-xl border border-spirit-200 px-3 py-2 text-sm font-semibold text-spirit-600 disabled:opacity-60"
+        >
+          <RefreshCw className={`h-4 w-4 ${loading ? "animate-spin" : ""}`} />
+          Muat ulang
+        </button>
+      </div>
+
+      {loading && complaints.length === 0 && (
+        <p role="status" className="text-sm text-neutral-slate">Memuat riwayat komplain...</p>
+      )}
+
+      {error && (
+        <div role="alert" className="rounded-2xl border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+          <div className="flex items-start gap-2">
+            <TriangleAlert className="mt-0.5 h-4 w-4 shrink-0" />
+            <span>Gagal memuat riwayat komplain: {error}</span>
+          </div>
+          <button type="button" onClick={onRetry} className="mt-3 rounded-xl border border-red-300 px-3 py-2 font-semibold">
+            Coba lagi
+          </button>
+        </div>
+      )}
+
+      {!loading && !error && complaints.length === 0 && (
+        <p className="rounded-2xl bg-neutral-50 p-4 text-sm text-neutral-slate">
+          Belum ada riwayat komplain.
+        </p>
+      )}
+
+      {complaints.length > 0 && (
+        <ul className="grid gap-3 lg:grid-cols-2">
+          {complaints.map((complaint) => (
+            <li key={complaint.complaint_id} className="rounded-2xl border border-neutral-200 bg-white p-4">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <p className="font-semibold text-neutral-navy">
+                  {PLATFORM_LABELS[complaint.platform] ?? complaint.platform}
+                </p>
+                <span className="rounded-full bg-spirit-100 px-2.5 py-1 text-xs font-semibold text-spirit-700">
+                  {displayStatus(complaint.status)}
+                </span>
+              </div>
+              <dl className="mt-3 grid gap-2 text-sm text-neutral-slate sm:grid-cols-2">
+                <div><dt className="text-xs font-semibold uppercase">ID konten</dt><dd className="break-all text-neutral-navy">{complaint.content_id}</dd></div>
+                <div><dt className="text-xs font-semibold uppercase">ID komplain</dt><dd className="break-all text-neutral-navy">{complaint.complaint_id}</dd></div>
+                <div><dt className="text-xs font-semibold uppercase">Kode triase</dt><dd className="break-words text-neutral-navy">{complaint.triage.code}</dd></div>
+                <div><dt className="text-xs font-semibold uppercase">Kualitas triase</dt><dd className="text-neutral-navy">{complaint.triage.quality}</dd></div>
+                <div><dt className="text-xs font-semibold uppercase">Dibuat</dt><dd className="text-neutral-navy">{formatTimestamp(complaint.created_at)}</dd></div>
+                <div><dt className="text-xs font-semibold uppercase">Dieskalasi</dt><dd className="text-neutral-navy">{formatTimestamp(complaint.escalated_at)}</dd></div>
+                <div><dt className="text-xs font-semibold uppercase">Selesai</dt><dd className="text-neutral-navy">{formatTimestamp(complaint.resolved_at)}</dd></div>
+              </dl>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/cicero-dashboard/components/claim/PendingContentCard.tsx
+++ b/cicero-dashboard/components/claim/PendingContentCard.tsx
@@ -23,6 +23,7 @@ type Props = {
   onRefresh: () => void | Promise<void>;
   claimToken?: string;
   onOpenProfile?: () => void;
+  onComplaintChanged?: () => void | Promise<void>;
 };
 
 type Selection = { item: ClaimPendingContentItem; platform: Platform; username: string };
@@ -78,9 +79,10 @@ function PlatformGroup({ platform, content, onComplaint }: { platform: Platform;
   </section>;
 }
 
-function ComplaintDialog({ selection, token, filters, onClose, onRefresh, onOpenProfile }: {
+function ComplaintDialog({ selection, token, filters, onClose, onRefresh, onOpenProfile, onComplaintChanged }: {
   selection: Selection; token: string; filters: ClaimPendingContentResponse["data"]["filters"];
   onClose: () => void; onRefresh: () => void | Promise<void>; onOpenProfile?: () => void;
+  onComplaintChanged?: () => void | Promise<void>;
 }) {
   const [performedAt, setPerformedAt] = useState("");
   const [result, setResult] = useState<ClaimComplaintTriage | null>(null);
@@ -113,6 +115,7 @@ function ComplaintDialog({ selection, token, filters, onClose, onRefresh, onOpen
         ...(filters.end_date ? { end_date: filters.end_date } : {}),
       });
       setResult(triage);
+      await onComplaintChanged?.();
       if (triage.triage_code === "ACTIVITY_ALREADY_RECORDED") await onRefresh();
     } catch (err) { setError(err instanceof Error ? err.message : "Gagal memeriksa kendala aktivitas"); }
     finally { setSubmitting(false); }
@@ -123,6 +126,7 @@ function ComplaintDialog({ selection, token, filters, onClose, onRefresh, onOpen
     setEscalating(true); setError("");
     try {
       await escalateClaimComplaint(token, result.complaint_id, result.complaint_status);
+      await onComplaintChanged?.();
       onClose();
     } catch (err) {
       if (err instanceof ClaimComplaintLifecycleError && err.status === 409 && err.errorCode === "CLAIM_COMPLAINT_STATUS_CONFLICT") {
@@ -172,13 +176,13 @@ function ComplaintDialog({ selection, token, filters, onClose, onRefresh, onOpen
   </Dialog.Root>;
 }
 
-export default function PendingContentCard({ data, loading, error, onRefresh, claimToken = "", onOpenProfile }: Props) {
+export default function PendingContentCard({ data, loading, error, onRefresh, claimToken = "", onOpenProfile, onComplaintChanged }: Props) {
   const [selection, setSelection] = useState<Selection | null>(null);
   return <section className="space-y-5 rounded-3xl border border-spirit-200/80 bg-white/90 p-5 shadow-sm" aria-busy={loading}>
     <div className="flex flex-wrap items-start justify-between gap-3"><div><h2 className="text-lg font-semibold text-neutral-navy">Aktivitas Konten Tertunda</h2><p className="mt-1 max-w-2xl text-sm text-neutral-slate">Data berdasarkan hasil sinkronisasi CICERO dan mungkin membutuhkan waktu untuk diperbarui.</p></div><button type="button" onClick={onRefresh} disabled={loading} className="inline-flex items-center gap-2 rounded-xl border border-spirit-200 px-3 py-2 text-sm font-semibold text-spirit-600 disabled:opacity-60"><RefreshCw className={`h-4 w-4 ${loading ? "animate-spin" : ""}`} />Refresh</button></div>
     {loading && !data && <p role="status" className="text-sm text-neutral-slate">Memuat konten tertunda...</p>}
     {error && <div role="alert" className="flex gap-2 rounded-2xl bg-red-50 p-4 text-sm text-red-600"><TriangleAlert className="h-4 w-4 shrink-0" /> Gagal memuat konten tertunda: {error}</div>}
     {data && <><div className="grid grid-cols-2 gap-3"><div className="rounded-2xl bg-gradient-to-br from-fuchsia-50 to-orange-50 p-4"><p className="text-xs text-neutral-slate">Instagram tertunda</p><p className="text-2xl font-bold text-neutral-navy">{data.instagram.pending_content}</p></div><div className="rounded-2xl bg-neutral-100 p-4"><p className="text-xs text-neutral-slate">TikTok tertunda</p><p className="text-2xl font-bold text-neutral-navy">{data.tiktok.pending_content}</p></div></div><PlatformGroup platform="instagram" content={data.instagram} onComplaint={setSelection} /><PlatformGroup platform="tiktok" content={data.tiktok} onComplaint={setSelection} /></>}
-    {selection && data && <ComplaintDialog selection={selection} token={claimToken} filters={data.filters} onClose={() => setSelection(null)} onRefresh={onRefresh} onOpenProfile={onOpenProfile} />}
+    {selection && data && <ComplaintDialog selection={selection} token={claimToken} filters={data.filters} onClose={() => setSelection(null)} onRefresh={onRefresh} onOpenProfile={onOpenProfile} onComplaintChanged={onComplaintChanged} />}
   </section>;
 }

--- a/cicero-dashboard/utils/api.ts
+++ b/cicero-dashboard/utils/api.ts
@@ -4053,10 +4053,38 @@ export type ClaimComplaintTriage = {
   complaint_status: string | null;
 };
 
-export type ClaimComplaintLifecycle = {
+export type ClaimComplaintLifecycleTriage = {
+  code: string;
+  quality: "low" | "medium" | "high" | string;
+  evidence: {
+    activity_recorded: boolean | null;
+    snapshot_available: boolean | null;
+    last_collected_at: string | null;
+    performed_at: string | null;
+  };
+};
+
+export type ClaimComplaintLifecycleDto = {
   complaint_id: string;
+  platform: "instagram" | "tiktok";
+  content_id: string;
+  issue_type: string;
   status: string;
-  [key: string]: unknown;
+  triage: ClaimComplaintLifecycleTriage;
+  created_at: string;
+  updated_at: string;
+  escalated_at: string | null;
+  resolved_at: string | null;
+};
+
+export type ClaimComplaintLifecycleResponse = {
+  success: boolean;
+  data: ClaimComplaintLifecycleDto;
+};
+
+export type ClaimComplaintLifecycleListResponse = {
+  success: boolean;
+  data: ClaimComplaintLifecycleDto[];
 };
 
 export class ClaimComplaintLifecycleError extends Error {
@@ -4332,7 +4360,7 @@ export async function escalateClaimComplaint(
 export async function getClaimComplaint(
   token: string,
   complaintId: string,
-): Promise<ClaimComplaintLifecycle> {
+): Promise<ClaimComplaintLifecycleDto> {
   const response = await fetch(
     buildApiUrl(`/api/claim/complaints/${encodeURIComponent(complaintId)}`),
     {
@@ -4349,7 +4377,31 @@ export async function getClaimComplaint(
       typeof body?.error_code === "string" ? body.error_code : undefined,
     );
   }
-  return body.data as ClaimComplaintLifecycle;
+  return body.data as ClaimComplaintLifecycleDto;
+}
+
+/**
+ * Loads complaints owned by the authenticated claim user. Ownership is derived
+ * exclusively by the backend from the claim credential; no identity query or
+ * request body is accepted here.
+ */
+export async function getClaimComplaints(
+  token?: string,
+): Promise<ClaimComplaintLifecycleDto[]> {
+  const response = await fetch(buildApiUrl("/api/claim/complaints"), {
+    method: "GET",
+    headers: claimAuthHeaders(token),
+    credentials: "include",
+  });
+  const body = await response.json().catch(() => null);
+  if (!response.ok) {
+    throw new ClaimComplaintLifecycleError(
+      extractResponseMessage(body, "Gagal memuat riwayat komplain"),
+      response.status,
+      typeof body?.error_code === "string" ? body.error_code : undefined,
+    );
+  }
+  return (body?.data ?? []) as ClaimComplaintLifecycleDto[];
 }
 
 export async function updateClaimProfile(


### PR DESCRIPTION
### Motivation

- Menyajikan riwayat lifecycle komplain yang otentik berasal dari backend agar pengguna dapat melihat status, kode triase, kualitas triase, dan timestamp lifecycle tanpa menyimpulkan keputusan di frontend.
- Menyediakan helper API read-only untuk daftar/detail complaint yang selalu mengandalkan identitas pemilik dari autentikasi backend (tidak mengirimkan user identity lewat query/body).
- Memastikan UI dapat memuat ulang daftar riwayat setelah operasi triase atau eskalasi sehingga tampilan tidak bergantung pada state dialog lama.

### Description

- Menambahkan tipe DTO lifecycle complaint dan tipe-bantuan baru di `cicero-dashboard/utils/api.ts`, serta helper `getClaimComplaints(token?)` dan menyesuaikan `getClaimComplaint` agar mengembalikan DTO lengkap beserta penanganan error lifecycle.
- Membuat komponen presentasi `cicero-dashboard/components/claim/ComplaintHistoryCard.tsx` yang menampilkan platform, content id, complaint id, status, triage code/quality, serta created/escalated/resolved timestamps, dengan loading/empty/error states dan tombol retry.
- Mengubah `cicero-dashboard/components/claim/PendingContentCard.tsx` untuk menerima prop `onComplaintChanged` dan memanggilnya setelah triase sukses dan setelah eskalasi sukses sehingga daftar lifecycle dapat di-refresh dari luar dialog.
- Merender kartu riwayat pada halaman edit claim (`cicero-dashboard/app/claim/edit/page.jsx`) dan menambahkan `loadComplaints` untuk memuat daftar menggunakan token claim aktif tanpa mengirim identitas di query/body.
- Menambahkan dan memperbarui tes unit yang relevan: `__tests__/ComplaintHistoryCard.test.tsx` (baru), penyesuaian `__tests__/PendingContentCard.test.tsx` dan `__tests__/claimEditPage.test.tsx`, serta tambahan validasi API di `__tests__/claimPendingContentApi.test.ts` untuk memastikan request daftar tidak membawa identitas pengguna.

### Testing

- Targeted Jest: menjalankan `npx jest __tests__/claimPendingContentApi.test.ts __tests__/ComplaintHistoryCard.test.tsx __tests__/PendingContentCard.test.tsx __tests__/claimEditPage.test.tsx --runInBand` menghasilkan semua suite terpilih lulus (4 suite, 38 tests passed).
- Full test run: `npm test -- --runInBand` menghasilkan mayoritas suite lulus (284 passed) dengan satu kegagalan yang ada sebelumnya di `__tests__/Sidebar.test.tsx` yang tidak terkait perubahan lifecycle ini.
- Type check: `npx tsc --noEmit` menemukan error tipe pada test-suite lain yang sudah ada (tidak berkaitan dengan file lifecycle yang ditambahkan), sehingga pemeriksaan tipe penuh masih terhambat oleh masalah tipe eksisting.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7ab34b4a148327b078382983c968a8)