### PR TITLE
Validate claim tokens and prevent malformed claim sessions

### DIFF
--- a/cicero-dashboard/__tests__/api.test.ts
+++ b/cicero-dashboard/__tests__/api.test.ts
@@ -9,6 +9,7 @@ import {
   loginClaimUser,
   registerClaimCredential,
   getClaimProfile,
+  isValidClaimToken,
   normalizeWhatsapp,
   updateClaimProfile,
   validateClaimSocialProfile,
@@ -320,7 +321,7 @@ test("registerClaimCredential calls claim register endpoint", async () => {
 test("loginClaimUser calls user-login endpoint", async () => {
   (global.fetch as jest.Mock).mockResolvedValueOnce({
     ok: true,
-    json: () => Promise.resolve({ success: true, token: "jwt-token", user: { nrp: "123" } }),
+    json: () => Promise.resolve({ success: true, token: "header.payload.signature", user: { nrp: "123" } }),
   });
 
   const response = await loginClaimUser({ nrp: "123", password: "Abcd1234!" });
@@ -329,7 +330,36 @@ test("loginClaimUser calls user-login endpoint", async () => {
   expect(url).toContain("/api/auth/user-login");
   expect(options.method).toBe("POST");
   expect(JSON.parse(options.body)).toEqual({ nrp: "123", password: "Abcd1234!" });
-  expect(response.token).toBe("jwt-token");
+  expect(response.token).toBe("header.payload.signature");
+});
+
+test.each([
+  ["missing", {}],
+  ["object-valued", { token: { access: "header.payload.signature" } }],
+  ["stringified object", { token: "[object Object]" }],
+  ["two segments", { token: "header.payload" }],
+  ["empty segment", { token: "header..signature" }],
+])("loginClaimUser rejects a successful response with a %s token", async (_label, body) => {
+  (global.fetch as jest.Mock).mockResolvedValueOnce({
+    ok: true,
+    json: () => Promise.resolve({ success: true, ...body }),
+  });
+
+  await expect(
+    loginClaimUser({ nrp: "123", password: "Abcd1234!" }),
+  ).rejects.toThrow(/token claim/i);
+});
+
+test.each([
+  [undefined, false],
+  [{ token: "header.payload.signature" }, false],
+  ["", false],
+  ["[object Object]", false],
+  ["header.payload", false],
+  ["header..signature", false],
+  ["header.payload.signature", true],
+])("isValidClaimToken validates JWT-shaped strings", (token, expected) => {
+  expect(isValidClaimToken(token)).toBe(expected);
 });
 
 test("getClaimProfile uses authenticated claim profile endpoint", async () => {
@@ -338,14 +368,14 @@ test("getClaimProfile uses authenticated claim profile endpoint", async () => {
     json: () => Promise.resolve({ success: true, data: { nrp: "123" } }),
   });
 
-  await getClaimProfile("jwt-token");
+  await getClaimProfile("header.payload.signature");
 
   const [url, options] = (global.fetch as jest.Mock).mock.calls[0];
   expect(url).toContain("/api/claim/me");
   expect(options).toMatchObject({
     method: "GET",
     credentials: "include",
-    headers: { Authorization: "Bearer jwt-token" },
+    headers: { Authorization: "Bearer header.payload.signature" },
   });
   expect(options.body).toBeUndefined();
 });
@@ -359,7 +389,7 @@ test("validateClaimSocialProfile posts payload with claim authentication", async
 
   await validateClaimSocialProfile(
     { platform: "instagram", username: "https://instagram.com/Cicero" },
-    "claim-jwt",
+    "header.payload.signature",
   );
 
   const [url, options] = (global.fetch as jest.Mock).mock.calls[0];
@@ -369,7 +399,7 @@ test("validateClaimSocialProfile posts payload with claim authentication", async
     credentials: "include",
     headers: {
       "Content-Type": "application/json",
-      Authorization: "Bearer claim-jwt",
+      Authorization: "Bearer header.payload.signature",
     },
   });
   expect(JSON.parse(options.body)).toEqual({
@@ -411,12 +441,12 @@ test("claim update sends whatsapp with 62 prefix for local numbers", async () =>
 
   await updateClaimProfile({
     whatsapp: whatsappNormalized,
-  }, "jwt-token");
+  }, "header.payload.signature");
 
   const [url, options] = (global.fetch as jest.Mock).mock.calls[0];
   expect(url).toContain("/api/claim/me");
   expect(options.credentials).toBe("include");
-  expect(options.headers.Authorization).toBe("Bearer jwt-token");
+  expect(options.headers.Authorization).toBe("Bearer header.payload.signature");
   expect(JSON.parse(options.body)).toEqual({ whatsapp: "628123" });
 });
 

--- a/cicero-dashboard/__tests__/claimEditPage.test.tsx
+++ b/cicero-dashboard/__tests__/claimEditPage.test.tsx
@@ -32,6 +32,7 @@ jest.mock("@/components/claim/ComplaintHistoryCard", () => ({
 }));
 
 jest.mock("@/utils/api", () => ({
+  isValidClaimToken: jest.requireActual("@/utils/api").isValidClaimToken,
   getClaimPendingContent: jest.fn(),
   getClaimComplaints: jest.fn(),
   getClaimProfile: jest.fn(),
@@ -44,7 +45,7 @@ describe("EditUserPage", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     sessionStorage.clear();
-    sessionStorage.setItem("claim_token", "claim-jwt");
+    sessionStorage.setItem("claim_token", "header.payload.signature");
     replace.mockClear();
     (getClaimProfile as jest.Mock).mockResolvedValue({
       success: true,
@@ -85,10 +86,24 @@ describe("EditUserPage", () => {
       screen.getByLabelText("NRP"),
     );
     expect(screen.getByLabelText("NRP")).toHaveAttribute("readonly");
-    expect(getClaimProfile).toHaveBeenCalledWith("claim-jwt");
-    expect(getClaimPendingContent).toHaveBeenCalledWith("claim-jwt");
-    expect(getClaimComplaints).toHaveBeenCalledWith("claim-jwt");
+    expect(getClaimProfile).toHaveBeenCalledWith("header.payload.signature");
+    expect(getClaimPendingContent).toHaveBeenCalledWith("header.payload.signature");
+    expect(getClaimComplaints).toHaveBeenCalledWith("header.payload.signature");
   });
+
+  it.each(["[object Object]", "header.payload", "header..signature"])(
+    "membersihkan sesi invalid dan redirect tanpa API terlindungi: %s",
+    async (token) => {
+      sessionStorage.setItem("claim_token", token);
+      render(<EditUserPage />);
+
+      await waitFor(() => expect(replace).toHaveBeenCalledWith("/claim"));
+      expect(sessionStorage.getItem("claim_token")).toBeNull();
+      expect(getClaimProfile).not.toHaveBeenCalled();
+      expect(getClaimPendingContent).not.toHaveBeenCalled();
+      expect(getClaimComplaints).not.toHaveBeenCalled();
+    },
+  );
 
   it("memuat seluruh array kanonis dan tidak memakai alias", async () => {
     render(<EditUserPage />);
@@ -153,7 +168,7 @@ describe("EditUserPage", () => {
 
     await waitFor(() => expect(updateClaimProfile).toHaveBeenCalled());
     const [payload, token] = (updateClaimProfile as jest.Mock).mock.calls[0];
-    expect(token).toBe("claim-jwt");
+    expect(token).toBe("header.payload.signature");
     expect(payload.instagram_accounts).toEqual(["Polri", "kedua_ig"]);
     expect(payload.tiktok_accounts).toEqual(["@humas_polri", "@kedua_tt"]);
     expect(payload).not.toHaveProperty("insta");
@@ -191,7 +206,7 @@ describe("EditUserPage", () => {
     expect(screen.getByText(/bukan keaslian akun/i)).toBeInTheDocument();
     expect(validateClaimSocialProfile).toHaveBeenCalledWith(
       { platform: "instagram", username: "utama.ig" },
-      "claim-jwt",
+      "header.payload.signature",
     );
   });
 

--- a/cicero-dashboard/__tests__/claimPage.test.tsx
+++ b/cicero-dashboard/__tests__/claimPage.test.tsx
@@ -1,3 +1,4 @@
+import "@testing-library/jest-dom";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import ClaimPage from "@/app/claim/page";
 import { loginClaimUser } from "@/utils/api";
@@ -9,6 +10,7 @@ jest.mock("next/navigation", () => ({
 }));
 
 jest.mock("@/utils/api", () => ({
+  isValidClaimToken: jest.requireActual("@/utils/api").isValidClaimToken,
   loginClaimUser: jest.fn(),
   registerClaimCredential: jest.fn(),
   requestClaimPasswordResetOtp: jest.fn(),
@@ -22,7 +24,7 @@ describe("ClaimPage session", () => {
     push.mockClear();
     (loginClaimUser as jest.Mock).mockResolvedValue({
       success: true,
-      token: "claim-jwt",
+      token: "header.payload.signature",
     });
   });
 
@@ -38,6 +40,25 @@ describe("ClaimPage session", () => {
     await waitFor(() => expect(push).toHaveBeenCalledWith("/claim/edit"));
     expect(sessionStorage.getItem("claim_password")).toBeNull();
     expect(sessionStorage.getItem("claim_nrp")).toBeNull();
-    expect(sessionStorage.getItem("claim_token")).toBe("claim-jwt");
+    expect(sessionStorage.getItem("claim_token")).toBe("header.payload.signature");
+  });
+
+  it.each([
+    ["missing", undefined],
+    ["object", { access: "header.payload.signature" }],
+    ["stringified object", "[object Object]"],
+    ["invalid segments", "header.payload"],
+  ])("tetap di login dan membersihkan sesi untuk token %s", async (_label, token) => {
+    sessionStorage.setItem("claim_token", "old.invalid");
+    (loginClaimUser as jest.Mock).mockResolvedValueOnce({ success: true, token });
+    render(<ClaimPage />);
+
+    fireEvent.change(screen.getByLabelText("NRP"), { target: { value: "12345" } });
+    fireEvent.change(screen.getByLabelText("Password"), { target: { value: "Password1!" } });
+    fireEvent.click(screen.getByRole("button", { name: /login & lanjutkan/i }));
+
+    expect(await screen.findByText(/token sesi tidak valid/i)).toBeInTheDocument();
+    expect(sessionStorage.getItem("claim_token")).toBeNull();
+    expect(push).not.toHaveBeenCalled();
   });
 });

--- a/cicero-dashboard/__tests__/claimPendingContentApi.test.ts
+++ b/cicero-dashboard/__tests__/claimPendingContentApi.test.ts
@@ -43,7 +43,7 @@ describe("claim complaint lifecycle API", () => {
   it.each([201, 200])("mengembalikan metadata complaint dari triase HTTP %s", async (status) => {
     (global.fetch as jest.Mock).mockResolvedValue({ ok: true, status, json: async () => ({ success: true, data: { ...triageData, complaint_created: status === 201 } }) });
     const { triageClaimComplaint } = await import("@/utils/api");
-    await expect(triageClaimComplaint("claim-jwt", { platform: "instagram", issue_type: "activity_not_recorded", shortcode: "IG1" })).resolves.toMatchObject({
+    await expect(triageClaimComplaint("header.payload.signature", { platform: "instagram", issue_type: "activity_not_recorded", shortcode: "IG1" })).resolves.toMatchObject({
       complaint_id: "complaint/1",
       complaint_created: status === 201,
       complaint_status: "triaged",
@@ -54,7 +54,7 @@ describe("claim complaint lifecycle API", () => {
   it("langsung mengeskalasi complaint dengan expected_status tanpa membuat ulang", async () => {
     (global.fetch as jest.Mock).mockResolvedValue({ ok: true, status: 200, json: async () => ({ success: true }) });
     const { escalateClaimComplaint } = await import("@/utils/api");
-    await escalateClaimComplaint("claim-jwt", "complaint/1", "triaged");
+    await escalateClaimComplaint("header.payload.signature", "complaint/1", "triaged");
     expect(global.fetch).toHaveBeenCalledTimes(1);
     expect(global.fetch).toHaveBeenCalledWith("https://api.cicero.test/api/claim/complaints/complaint%2F1/escalate", expect.objectContaining({
       method: "POST",
@@ -65,7 +65,7 @@ describe("claim complaint lifecycle API", () => {
   it("mempertahankan kode, status, dan pesan backend pada konflik lifecycle", async () => {
     (global.fetch as jest.Mock).mockResolvedValue({ ok: false, status: 409, json: async () => ({ error_code: "CLAIM_COMPLAINT_STATUS_CONFLICT", message: "Status complaint telah berubah" }) });
     const { escalateClaimComplaint } = await import("@/utils/api");
-    await expect(escalateClaimComplaint("claim-jwt", "c-1", "triaged")).rejects.toMatchObject({
+    await expect(escalateClaimComplaint("header.payload.signature", "c-1", "triaged")).rejects.toMatchObject({
       status: 409,
       errorCode: "CLAIM_COMPLAINT_STATUS_CONFLICT",
       message: "Status complaint telah berubah",
@@ -75,13 +75,13 @@ describe("claim complaint lifecycle API", () => {
   it.each([404, 422])("meneruskan pesan backend untuk response %s tanpa status buatan frontend", async (status) => {
     (global.fetch as jest.Mock).mockResolvedValue({ ok: false, status, json: async () => ({ error_code: "BACKEND_CODE", message: `Pesan backend ${status}` }) });
     const { escalateClaimComplaint } = await import("@/utils/api");
-    await expect(escalateClaimComplaint("claim-jwt", "c-1", "triaged")).rejects.toMatchObject({ status, message: `Pesan backend ${status}` });
+    await expect(escalateClaimComplaint("header.payload.signature", "c-1", "triaged")).rejects.toMatchObject({ status, message: `Pesan backend ${status}` });
   });
 
   it("memuat lifecycle complaint terbaru", async () => {
     (global.fetch as jest.Mock).mockResolvedValue({ ok: true, status: 200, json: async () => ({ data: { complaint_id: "c-1", status: "resolved" } }) });
     const { getClaimComplaint } = await import("@/utils/api");
-    await expect(getClaimComplaint("claim-jwt", "c-1")).resolves.toEqual({ complaint_id: "c-1", status: "resolved" });
+    await expect(getClaimComplaint("header.payload.signature", "c-1")).resolves.toEqual({ complaint_id: "c-1", status: "resolved" });
     expect(global.fetch).toHaveBeenCalledWith("https://api.cicero.test/api/claim/complaints/c-1", expect.objectContaining({ method: "GET" }));
   });
 
@@ -93,14 +93,14 @@ describe("claim complaint lifecycle API", () => {
     });
     const { getClaimComplaints } = await import("@/utils/api");
 
-    await expect(getClaimComplaints("claim-jwt")).resolves.toEqual([
+    await expect(getClaimComplaints("header.payload.signature")).resolves.toEqual([
       { complaint_id: "c-1", status: "triaged" },
     ]);
     expect(global.fetch).toHaveBeenCalledWith(
       "https://api.cicero.test/api/claim/complaints",
       {
         method: "GET",
-        headers: { Authorization: "Bearer claim-jwt" },
+        headers: { Authorization: "Bearer header.payload.signature" },
         credentials: "include",
       },
     );
@@ -108,4 +108,20 @@ describe("claim complaint lifecycle API", () => {
     expect(url).not.toMatch(/[?&](user_id|nrp|client_id)=/);
     expect(init).not.toHaveProperty("body");
   });
+
+  it.each([undefined, "", "[object Object]", "header.payload", "header..signature"])(
+    "tidak mengirim Bearer header untuk token malformed: %p",
+    async (token) => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ data: [] }),
+      });
+      const { getClaimComplaints } = await import("@/utils/api");
+
+      await getClaimComplaints(token as string | undefined);
+
+      expect((global.fetch as jest.Mock).mock.calls[0][1].headers).toBeUndefined();
+    },
+  );
 });

--- a/cicero-dashboard/app/claim/edit/page.jsx
+++ b/cicero-dashboard/app/claim/edit/page.jsx
@@ -18,6 +18,7 @@ import {
   getClaimComplaints,
   getClaimPendingContent,
   getClaimProfile,
+  isValidClaimToken,
   normalizeWhatsapp,
   updateClaimProfile,
   validateClaimSocialProfile,
@@ -184,9 +185,14 @@ export default function EditUserPage() {
   useEffect(() => {
     if (typeof window !== "undefined") {
       const token = sessionStorage.getItem("claim_token");
-      setClaimToken(token || "");
-      loadUser(token || "");
-      loadComplaints(token || "");
+      if (!isValidClaimToken(token)) {
+        sessionStorage.removeItem("claim_token");
+        router.replace("/claim");
+        return;
+      }
+      setClaimToken(token);
+      loadUser(token);
+      loadComplaints(token);
     }
   }, [router]);
 

--- a/cicero-dashboard/app/claim/page.jsx
+++ b/cicero-dashboard/app/claim/page.jsx
@@ -6,6 +6,7 @@ import { LockKeyhole, LogIn, ShieldCheck, UserPlus } from "lucide-react";
 
 import ClaimLayout from "@/components/claim/ClaimLayout";
 import {
+  isValidClaimToken,
   loginClaimUser,
   registerClaimCredential,
   requestClaimPasswordResetOtp,
@@ -58,7 +59,7 @@ export default function ClaimPage() {
     if (typeof window === "undefined") return;
     sessionStorage.removeItem("claim_nrp");
     sessionStorage.removeItem("claim_password");
-    if (token) sessionStorage.setItem("claim_token", token);
+    if (isValidClaimToken(token)) sessionStorage.setItem("claim_token", token);
     else sessionStorage.removeItem("claim_token");
   };
 
@@ -122,11 +123,16 @@ export default function ClaimPage() {
     setLoading(true);
     try {
       const res = await loginClaimUser({ nrp: trimmedNrp, password: trimmedPassword });
-      if (res.success !== false) {
+      if (res.success !== false && isValidClaimToken(res.token)) {
         saveClaimSession(res.token);
         router.push("/claim/edit");
       } else {
-        setError(res.message || "Login gagal.");
+        saveClaimSession(res.token);
+        setError(
+          res.success === false
+            ? res.message || "Login gagal."
+            : "Login gagal karena token sesi tidak valid. Silakan coba lagi.",
+        );
       }
     } catch (err) {
       setError(err?.message?.trim() || "Login gagal.");

--- a/cicero-dashboard/utils/api.ts
+++ b/cicero-dashboard/utils/api.ts
@@ -4173,9 +4173,14 @@ export async function loginClaimUser(
     throw new Error(message);
   }
 
+  const success = data?.success ?? res.ok;
+  if (success !== false && !isValidClaimToken(data?.token)) {
+    throw new Error("Respons login tidak valid: token claim tidak tersedia atau malformed.");
+  }
+
   return {
     ...data,
-    success: data?.success ?? res.ok,
+    success,
     message,
     token: data?.token,
     user: data?.user,
@@ -4244,8 +4249,14 @@ export async function getUserById(nrp: string): Promise<any> {
   return res.json();
 }
 
-function claimAuthHeaders(token?: string) {
-  return token ? { Authorization: `Bearer ${token}` } : undefined;
+export function isValidClaimToken(token: unknown): token is string {
+  if (typeof token !== "string" || token.length === 0) return false;
+  const segments = token.split(".");
+  return segments.length === 3 && segments.every((segment) => segment.length > 0);
+}
+
+function claimAuthHeaders(token?: unknown) {
+  return isValidClaimToken(token) ? { Authorization: `Bearer ${token}` } : undefined;
 }
 
 function claimResponseError(status: number, data: any, fallback: string): Error {


### PR DESCRIPTION
### Motivation
- Protect claim-only flows from malformed or object-valued tokens by enforcing a simple JWT-shaped token contract before persistence or use.
- Avoid relying on nominally successful backend responses that omit or mis-shape the top-level `token` value, which otherwise allow navigation into protected pages.
- Ensure protected claim APIs never receive an `Authorization: Bearer ...` header when the input token is invalid or not a plain JWT-shaped string.

### Description
- Added `isValidClaimToken(token: unknown): token is string` in `cicero-dashboard/utils/api.ts` that accepts only non-empty strings with exactly three non-empty dot-separated segments and does not decode or log any token payload.
- Updated `claimAuthHeaders` to only emit `Authorization: Bearer ...` when `isValidClaimToken` returns true, so malformed tokens never produce a Bearer header to protected APIs.
- Hardened `loginClaimUser` so a nominally successful response without a valid top-level `token` is treated as a login-contract error and will throw instead of returning success.
- Changed session handling in `cicero-dashboard/app/claim/page.jsx` so `saveClaimSession` only stores validated token strings and removes `claim_token` when validation fails, and avoids stringifying objects into `sessionStorage`.
- Updated `/claim/edit` page (`cicero-dashboard/app/claim/edit/page.jsx`) to validate the stored `claim_token` before calling `getClaimProfile`, `getClaimPendingContent`, or `getClaimComplaints`, removing invalid tokens and redirecting to `/claim` when invalid so protected calls are not executed.
- Added Jest tests covering: missing tokens, object-valued tokens, the string `"[object Object]"`, invalid segment counts and empty segments, valid JWT-shaped strings, cleanup of invalid stored sessions with prevented protected API calls, and ensuring `claimAuthHeaders` never emits a Bearer header for malformed inputs (test files modified/added under `cicero-dashboard/__tests__`).

### Testing
- Ran `npm test -- --runInBand __tests__/api.test.ts __tests__/claimPage.test.tsx __tests__/claimEditPage.test.tsx __tests__/claimPendingContentApi.test.ts` and the targeted suites covering claim behavior passed.
- Ran the full test suite with `npm test -- --runInBand` which completed with 308 passing tests and a single existing unrelated `Sidebar.test.tsx` failure (not introduced by these changes). 
- Ran TypeScript check with `npx tsc --noEmit` which reported pre-existing type errors inside unrelated test files, not caused by the claim-token changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7ad75b5a508327b57831edfb36d066)