### PR TITLE
feat(claim): replace complaints UI with social account quality guidance

### DIFF
--- a/cicero-dashboard/__tests__/claimEditPage.test.tsx
+++ b/cicero-dashboard/__tests__/claimEditPage.test.tsx
@@ -2,8 +2,6 @@ import "@testing-library/jest-dom";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import EditUserPage from "@/app/claim/edit/page";
 import {
-  getClaimPendingContent,
-  getClaimComplaints,
   getClaimProfile,
   updateClaimProfile,
   validateClaimSocialProfile,
@@ -21,20 +19,8 @@ jest.mock("@/components/claim/ClaimLayout", () => ({
   default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
-jest.mock("@/components/claim/PendingContentCard", () => ({
-  __esModule: true,
-  default: () => <div data-testid="pending-content" />,
-}));
-
-jest.mock("@/components/claim/ComplaintHistoryCard", () => ({
-  __esModule: true,
-  default: () => <div data-testid="complaint-history" />,
-}));
-
 jest.mock("@/utils/api", () => ({
   isValidClaimToken: jest.requireActual("@/utils/api").isValidClaimToken,
-  getClaimPendingContent: jest.fn(),
-  getClaimComplaints: jest.fn(),
   getClaimProfile: jest.fn(),
   normalizeWhatsapp: jest.fn((value: string) => value),
   updateClaimProfile: jest.fn(),
@@ -60,8 +46,6 @@ describe("EditUserPage", () => {
         tiktok_accounts: ["@utama.tt", "@kedua_tt"],
       },
     });
-    (getClaimPendingContent as jest.Mock).mockResolvedValue({ data: null });
-    (getClaimComplaints as jest.Mock).mockResolvedValue([]);
     (updateClaimProfile as jest.Mock).mockResolvedValue({ success: true });
     (validateClaimSocialProfile as jest.Mock).mockResolvedValue({
       success: true,
@@ -87,8 +71,7 @@ describe("EditUserPage", () => {
     );
     expect(screen.getByLabelText("NRP")).toHaveAttribute("readonly");
     expect(getClaimProfile).toHaveBeenCalledWith("header.payload.signature");
-    expect(getClaimPendingContent).toHaveBeenCalledWith("header.payload.signature");
-    expect(getClaimComplaints).toHaveBeenCalledWith("header.payload.signature");
+    expect(screen.getByRole("heading", { name: "Kualitas akun media sosial" })).toBeInTheDocument();
   });
 
   it.each(["[object Object]", "header.payload", "header..signature"])(
@@ -100,8 +83,6 @@ describe("EditUserPage", () => {
       await waitFor(() => expect(replace).toHaveBeenCalledWith("/claim"));
       expect(sessionStorage.getItem("claim_token")).toBeNull();
       expect(getClaimProfile).not.toHaveBeenCalled();
-      expect(getClaimPendingContent).not.toHaveBeenCalled();
-      expect(getClaimComplaints).not.toHaveBeenCalled();
     },
   );
 
@@ -203,7 +184,8 @@ describe("EditUserPage", () => {
     expect(screen.getByText(/Cicero Resmi/)).toBeInTheDocument();
     expect(screen.getByText(/Publik/)).toBeInTheDocument();
     expect(screen.getByText(/partial \(80\/100\)/)).toBeInTheDocument();
-    expect(screen.getByText(/bukan keaslian akun/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/bukan keaslian akun/i).length).toBeGreaterThan(0);
+    expect(screen.getByText("Perlu dilengkapi · 80/100")).toBeInTheDocument();
     expect(validateClaimSocialProfile).toHaveBeenCalledWith(
       { platform: "instagram", username: "utama.ig" },
       "header.payload.signature",

--- a/cicero-dashboard/app/claim/edit/page.jsx
+++ b/cicero-dashboard/app/claim/edit/page.jsx
@@ -12,11 +12,8 @@ import {
 } from "lucide-react";
 
 import ClaimLayout from "@/components/claim/ClaimLayout";
-import ComplaintHistoryCard from "@/components/claim/ComplaintHistoryCard";
-import PendingContentCard from "@/components/claim/PendingContentCard";
+import SocialAccountQualityCard from "@/components/claim/SocialAccountQualityCard";
 import {
-  getClaimComplaints,
-  getClaimPendingContent,
   getClaimProfile,
   isValidClaimToken,
   normalizeWhatsapp,
@@ -166,12 +163,6 @@ export default function EditUserPage() {
   const [loading, setLoading] = useState(false);
   const [profileLoading, setProfileLoading] = useState(true);
   const [profileError, setProfileError] = useState("");
-  const [pendingContent, setPendingContent] = useState(null);
-  const [contentLoading, setContentLoading] = useState(true);
-  const [contentError, setContentError] = useState("");
-  const [complaints, setComplaints] = useState([]);
-  const [complaintsLoading, setComplaintsLoading] = useState(true);
-  const [complaintsError, setComplaintsError] = useState("");
   const [error, setError] = useState("");
   const [message, setMessage] = useState("");
   const [fieldErrors, setFieldErrors] = useState({
@@ -192,7 +183,6 @@ export default function EditUserPage() {
       }
       setClaimToken(token);
       loadUser(token);
-      loadComplaints(token);
     }
   }, [router]);
 
@@ -236,7 +226,6 @@ export default function EditUserPage() {
         Array(normalizedInstagram.length || 1).fill(null),
       );
       setTiktokValidations(Array(normalizedTiktok.length || 1).fill(null));
-      loadPendingContent(token);
     } catch (err) {
       if (err?.status === 401 || err?.status === 403) {
         router.replace("/claim");
@@ -248,35 +237,6 @@ export default function EditUserPage() {
       setProfileError(message);
     } finally {
       setProfileLoading(false);
-    }
-  }
-
-  async function loadPendingContent(token = claimToken) {
-    setContentLoading(true);
-    setContentError("");
-    try {
-      const response = await getClaimPendingContent(token);
-      setPendingContent(response.data);
-    } catch (err) {
-      setContentError(err?.message?.trim() || "Terjadi kesalahan pada server");
-    } finally {
-      setContentLoading(false);
-    }
-  }
-
-  async function loadComplaints(token = claimToken) {
-    setComplaintsLoading(true);
-    setComplaintsError("");
-    try {
-      setComplaints(await getClaimComplaints(token));
-    } catch (err) {
-      if (err?.status === 401 || err?.status === 403) {
-        router.replace("/claim");
-        return;
-      }
-      setComplaintsError(err?.message?.trim() || "Terjadi kesalahan pada server");
-    } finally {
-      setComplaintsLoading(false);
     }
   }
 
@@ -464,25 +424,16 @@ export default function EditUserPage() {
       cardAccent="spirit"
     >
       <div className="space-y-8">
-        <PendingContentCard
-          data={pendingContent}
-          loading={contentLoading}
-          error={contentError}
-          onRefresh={loadPendingContent}
-          claimToken={claimToken}
-          onComplaintChanged={loadComplaints}
+        <SocialAccountQualityCard
+          instagramAccounts={instagramAccounts}
+          tiktokAccounts={tiktokAccounts}
+          instagramValidations={instagramValidations}
+          tiktokValidations={tiktokValidations}
           onOpenProfile={() =>
             document
               .getElementById("claim-profile-form")
               ?.scrollIntoView({ behavior: "smooth" })
           }
-        />
-
-        <ComplaintHistoryCard
-          complaints={complaints}
-          loading={complaintsLoading}
-          error={complaintsError}
-          onRetry={loadComplaints}
         />
 
         <section className="rounded-3xl border border-spirit-200/80 bg-gradient-to-br from-white/80 via-spirit-50/70 to-trust-50/70 px-6 py-5 text-sm text-neutral-slate shadow-inner">

--- a/cicero-dashboard/components/claim/SocialAccountQualityCard.jsx
+++ b/cicero-dashboard/components/claim/SocialAccountQualityCard.jsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { CheckCircle2, CircleHelp, ExternalLink, ShieldAlert, Sparkles } from "lucide-react";
+
+const QUALITY_LABELS = {
+  complete: "Lengkap",
+  partial: "Perlu dilengkapi",
+  limited: "Terbatas",
+};
+
+function accountAssessment(value, validation) {
+  if (!value.trim()) {
+    return { tone: "neutral", label: "Belum diisi", advice: "Tambahkan username akun yang aktif jika Anda memilikinya." };
+  }
+  if (!validation || validation.status === "loading") {
+    return { tone: "neutral", label: validation?.status === "loading" ? "Sedang diperiksa" : "Belum diperiksa", advice: "Klik Periksa username untuk melihat kualitas data akun ini." };
+  }
+  if (validation.status === "error" || validation.status === "warning") {
+    return { tone: "warning", label: "Perlu diperiksa ulang", advice: validation.message };
+  }
+  if (!validation.data?.found) {
+    return { tone: "warning", label: "Username perlu diperbaiki", advice: "Pastikan ejaan username sesuai profil dan akun masih aktif, lalu periksa kembali." };
+  }
+
+  const profile = validation.data;
+  const score = Number.isFinite(profile.data_quality?.score) ? profile.data_quality.score : null;
+  if (profile.is_private) {
+    return { tone: "warning", label: "Akun privat", score, advice: "Ubah akun menjadi publik agar informasi profil dapat diperiksa dengan lebih lengkap." };
+  }
+  if (["partial", "limited"].includes(profile.data_quality?.label) || (score !== null && score < 70)) {
+    return {
+      tone: "warning",
+      label: QUALITY_LABELS[profile.data_quality?.label] || "Data akun terbatas",
+      score,
+      advice: profile.data_quality?.explanation || "Lengkapi profil dan pastikan akun dapat diakses publik, lalu periksa kembali.",
+    };
+  }
+  return {
+    tone: "good",
+    label: QUALITY_LABELS[profile.data_quality?.label] || profile.data_quality?.label || "Profil ditemukan",
+    score,
+    advice: profile.data_quality?.explanation || "Data profil tersedia. Pastikan username tetap sesuai dengan akun aktif Anda.",
+  };
+}
+
+function AccountRow({ platform, value, validation, index }) {
+  const assessment = accountAssessment(value, validation);
+  const good = assessment.tone === "good";
+  const warning = assessment.tone === "warning";
+  return (
+    <li className="rounded-2xl border border-spirit-100 bg-white/90 p-4 shadow-sm">
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wide text-neutral-slate">{platform} {index + 1}</p>
+          <p className="mt-1 break-all font-semibold text-neutral-navy">{value.trim() || "Belum ada username"}</p>
+        </div>
+        <span className={`rounded-full px-3 py-1 text-xs font-semibold ${good ? "bg-emerald-100 text-emerald-700" : warning ? "bg-amber-100 text-amber-800" : "bg-neutral-100 text-neutral-slate"}`}>
+          {assessment.label}{assessment.score !== undefined && assessment.score !== null ? ` · ${assessment.score}/100` : ""}
+        </span>
+      </div>
+      <p className="mt-3 text-sm text-neutral-slate">{assessment.advice}</p>
+    </li>
+  );
+}
+
+export default function SocialAccountQualityCard({ instagramAccounts, tiktokAccounts, instagramValidations, tiktokValidations, onOpenProfile }) {
+  const accounts = [
+    ...instagramAccounts.map((value, index) => ({ platform: "Instagram", value, validation: instagramValidations[index], index })),
+    ...tiktokAccounts.map((value, index) => ({ platform: "TikTok", value, validation: tiktokValidations[index], index })),
+  ];
+
+  return (
+    <section aria-labelledby="social-quality-title" className="overflow-hidden rounded-3xl border border-spirit-200/80 bg-gradient-to-br from-white via-spirit-50/60 to-trust-50/70 shadow-sm">
+      <div className="border-b border-spirit-100 px-6 py-5">
+        <div className="flex items-start gap-3">
+          <div className="rounded-2xl bg-spirit-100 p-2.5 text-spirit-600"><Sparkles className="h-5 w-5" /></div>
+          <div>
+            <h2 id="social-quality-title" className="text-lg font-bold text-neutral-navy">Kualitas akun media sosial</h2>
+            <p className="mt-1 text-sm text-neutral-slate">Periksa setiap username untuk mengetahui kelengkapan data profil dan langkah perbaikannya.</p>
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-5 p-6">
+        <ul className="grid gap-3 lg:grid-cols-2">
+          {accounts.map((account) => <AccountRow key={`${account.platform}-${account.index}`} {...account} />)}
+        </ul>
+
+        <div className="grid gap-3 md:grid-cols-3">
+          <div className="rounded-2xl bg-white/70 p-4"><CheckCircle2 className="h-5 w-5 text-emerald-600" /><p className="mt-2 font-semibold text-neutral-navy">Tulis dengan tepat</p><p className="mt-1 text-xs text-neutral-slate">Salin username langsung dari profil untuk menghindari salah eja.</p></div>
+          <div className="rounded-2xl bg-white/70 p-4"><ShieldAlert className="h-5 w-5 text-amber-600" /><p className="mt-2 font-semibold text-neutral-navy">Gunakan akun publik</p><p className="mt-1 text-xs text-neutral-slate">Profil privat membatasi data yang dapat diperiksa oleh sistem.</p></div>
+          <div className="rounded-2xl bg-white/70 p-4"><CircleHelp className="h-5 w-5 text-spirit-600" /><p className="mt-2 font-semibold text-neutral-navy">Periksa setelah mengubah</p><p className="mt-1 text-xs text-neutral-slate">Klik Periksa username lagi setelah memperbaiki username atau profil.</p></div>
+        </div>
+
+        <div className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-spirit-200 bg-white/80 px-4 py-3">
+          <p className="text-xs text-neutral-slate">Skor menunjukkan kelengkapan data yang tersedia, bukan keaslian atau kepemilikan akun.</p>
+          <button type="button" onClick={onOpenProfile} className="inline-flex items-center gap-2 rounded-xl bg-spirit-600 px-4 py-2 text-sm font-semibold text-white hover:bg-spirit-700">
+            Periksa dan perbaiki username <ExternalLink className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
### Motivation

- The existing complaint/riwayat UI on the claim page was confusing and offered limited guidance for users about their social accounts. 
- Provide clearer, actionable feedback by showing social profile quality and concrete advice so users can fix or improve usernames before submitting.

### Description

- Replaced the pending-complaint and complaint-history UI on the claim edit page with a new `SocialAccountQualityCard` component that summarizes Instagram/TikTok account quality, shows scores and guidance, and links back to the form for fixes (`cicero-dashboard/components/claim/SocialAccountQualityCard.jsx`).
- Updated claim edit page to stop loading pending content and complaint history and to render the social-quality card instead, while retaining all social validation flows (`cicero-dashboard/app/claim/edit/page.jsx`).
- Implemented assessment logic that maps backend `data_quality` to localized labels and advice, treats private/limited/partial profiles as warnings, and surfaces scores when present (`accountAssessment` logic in the new component).
- Adjusted unit tests to reflect the UI change and validate that social validation DTOs are displayed as expected (`cicero-dashboard/__tests__/claimEditPage.test.tsx`).

### Testing

- Ran the focused unit test suite with `npm test -- --runInBand __tests__/claimEditPage.test.tsx` and all tests passed (`14 passed`).
- Performed a production Next.js build with `npm run build` which completed successfully and generated optimized static pages.
- Verified repository checks (`git diff --check`) and local type/build validations during the build; no errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7ae59f290883279f7758faa5f3ef17)