### PR TITLE
feat(claim): tampilkan pending content di halaman edit claim

### DIFF
--- a/cicero-dashboard/__tests__/claimEditPage.test.tsx
+++ b/cicero-dashboard/__tests__/claimEditPage.test.tsx
@@ -2,6 +2,7 @@ import "@testing-library/jest-dom";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import EditUserPage from "@/app/claim/edit/page";
 import {
+  getClaimPendingContent,
   getClaimProfile,
   updateClaimProfile,
   validateClaimSocialProfile,
@@ -21,6 +22,7 @@ jest.mock("@/components/claim/ClaimLayout", () => ({
 
 jest.mock("@/utils/api", () => ({
   isValidClaimToken: jest.requireActual("@/utils/api").isValidClaimToken,
+  getClaimPendingContent: jest.fn(),
   getClaimProfile: jest.fn(),
   normalizeWhatsapp: jest.fn((value: string) => value),
   updateClaimProfile: jest.fn(),
@@ -28,6 +30,34 @@ jest.mock("@/utils/api", () => ({
 }));
 
 describe("EditUserPage", () => {
+  const pendingContent = {
+    filters: { periode: "harian", tanggal: "2026-08-12" },
+    instagram: {
+      username_available: true,
+      usernames: ["utama.ig"],
+      pending_content: 1,
+      items: [{
+        shortcode: "IG123",
+        video_id: null,
+        caption: "Tugas Instagram",
+        content_time: "2026-08-12T01:00:00.000Z",
+        url: "https://www.instagram.com/p/IG123/",
+      }],
+    },
+    tiktok: {
+      username_available: true,
+      usernames: ["utama.tt"],
+      pending_content: 1,
+      items: [{
+        shortcode: null,
+        video_id: "TT123",
+        caption: "Tugas TikTok",
+        content_time: "2026-08-12T02:00:00.000Z",
+        url: "https://www.tiktok.com/@cicero/video/TT123",
+      }],
+    },
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
     sessionStorage.clear();
@@ -47,6 +77,10 @@ describe("EditUserPage", () => {
       },
     });
     (updateClaimProfile as jest.Mock).mockResolvedValue({ success: true });
+    (getClaimPendingContent as jest.Mock).mockResolvedValue({
+      success: true,
+      data: pendingContent,
+    });
     (validateClaimSocialProfile as jest.Mock).mockResolvedValue({
       success: true,
       data: {
@@ -62,10 +96,57 @@ describe("EditUserPage", () => {
     });
   });
 
+  it("memuat dan menampilkan tugas pending content setelah autentikasi", async () => {
+    render(<EditUserPage />);
+
+    expect(await screen.findByText("Tugas Instagram")).toBeInTheDocument();
+    expect(screen.getByText("Tugas TikTok")).toBeInTheDocument();
+    expect(getClaimPendingContent).toHaveBeenCalledWith("header.payload.signature");
+    const links = screen.getAllByRole("link", { name: /Buka Konten/ });
+    expect(links).toHaveLength(2);
+    expect(links[0]).toHaveAttribute("href", "https://www.instagram.com/p/IG123/");
+    expect(links[1]).toHaveAttribute("href", "https://www.tiktok.com/@cicero/video/TT123");
+  });
+
+  it("memuat ulang pending content ketika Refresh dipilih", async () => {
+    render(<EditUserPage />);
+    await screen.findByText("Tugas Instagram");
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+
+    await waitFor(() => expect(getClaimPendingContent).toHaveBeenCalledTimes(2));
+  });
+
+  it("menampilkan empty state untuk platform tanpa tugas", async () => {
+    (getClaimPendingContent as jest.Mock).mockResolvedValueOnce({
+      success: true,
+      data: {
+        ...pendingContent,
+        instagram: { ...pendingContent.instagram, pending_content: 0, items: [] },
+        tiktok: { ...pendingContent.tiktok, pending_content: 0, items: [] },
+      },
+    });
+    render(<EditUserPage />);
+
+    expect(await screen.findByText("Tidak ada konten tertunda untuk Instagram.")).toBeInTheDocument();
+    expect(screen.getByText("Tidak ada konten tertunda untuk TikTok.")).toBeInTheDocument();
+  });
+
+  it("tetap menampilkan formulir profil saat pending content gagal dimuat", async () => {
+    (getClaimPendingContent as jest.Mock).mockRejectedValueOnce(
+      new Error("Layanan pending content terganggu"),
+    );
+    render(<EditUserPage />);
+
+    expect(await screen.findByText(/Layanan pending content terganggu/)).toBeInTheDocument();
+    expect(await screen.findByDisplayValue("12345")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Simpan" })).toBeEnabled();
+  });
+
   it("merender saat loading lalu menampilkan NRP terverifikasi dari profil", async () => {
     render(<EditUserPage />);
 
-    expect(screen.getByRole("status")).toHaveTextContent("Memuat profil...");
+    expect(screen.getByText("Memuat profil...")).toBeInTheDocument();
     expect(await screen.findByDisplayValue("12345")).toBe(
       screen.getByLabelText("NRP"),
     );
@@ -83,6 +164,19 @@ describe("EditUserPage", () => {
       await waitFor(() => expect(replace).toHaveBeenCalledWith("/claim"));
       expect(sessionStorage.getItem("claim_token")).toBeNull();
       expect(getClaimProfile).not.toHaveBeenCalled();
+      expect(getClaimPendingContent).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([401, 403])(
+    "redirect ke halaman claim ketika pending content merespons %s",
+    async (status) => {
+      (getClaimPendingContent as jest.Mock).mockRejectedValueOnce(
+        Object.assign(new Error("Sesi tidak valid"), { status }),
+      );
+      render(<EditUserPage />);
+
+      await waitFor(() => expect(replace).toHaveBeenCalledWith("/claim"));
     },
   );
 

--- a/cicero-dashboard/app/claim/edit/page.jsx
+++ b/cicero-dashboard/app/claim/edit/page.jsx
@@ -12,8 +12,10 @@ import {
 } from "lucide-react";
 
 import ClaimLayout from "@/components/claim/ClaimLayout";
+import PendingContentCard from "@/components/claim/PendingContentCard";
 import SocialAccountQualityCard from "@/components/claim/SocialAccountQualityCard";
 import {
+  getClaimPendingContent,
   getClaimProfile,
   isValidClaimToken,
   normalizeWhatsapp,
@@ -163,6 +165,9 @@ export default function EditUserPage() {
   const [loading, setLoading] = useState(false);
   const [profileLoading, setProfileLoading] = useState(true);
   const [profileError, setProfileError] = useState("");
+  const [pendingContent, setPendingContent] = useState(null);
+  const [pendingContentLoading, setPendingContentLoading] = useState(false);
+  const [pendingContentError, setPendingContentError] = useState("");
   const [error, setError] = useState("");
   const [message, setMessage] = useState("");
   const [fieldErrors, setFieldErrors] = useState({
@@ -183,8 +188,31 @@ export default function EditUserPage() {
       }
       setClaimToken(token);
       loadUser(token);
+      loadPendingContent(token);
     }
   }, [router]);
+
+  async function loadPendingContent(token = claimToken) {
+    if (!token) return;
+    setPendingContentLoading(true);
+    setPendingContentError("");
+    try {
+      const response = await getClaimPendingContent(token);
+      setPendingContent(response.data || null);
+    } catch (err) {
+      if (err?.status === 401 || err?.status === 403) {
+        router.replace("/claim");
+        return;
+      }
+      setPendingContentError(
+        err?.message?.trim()
+          ? err.message
+          : "Gagal mengambil konten tertunda",
+      );
+    } finally {
+      setPendingContentLoading(false);
+    }
+  }
 
   async function loadUser(token) {
     setProfileLoading(true);
@@ -424,6 +452,19 @@ export default function EditUserPage() {
       cardAccent="spirit"
     >
       <div className="space-y-8">
+        <PendingContentCard
+          data={pendingContent}
+          loading={pendingContentLoading}
+          error={pendingContentError}
+          claimToken={claimToken}
+          onRefresh={() => loadPendingContent(claimToken)}
+          onOpenProfile={() =>
+            document
+              .getElementById("claim-profile-form")
+              ?.scrollIntoView({ behavior: "smooth" })
+          }
+        />
+
         <SocialAccountQualityCard
           instagramAccounts={instagramAccounts}
           tiktokAccounts={tiktokAccounts}


### PR DESCRIPTION
### Motivation

- Menyajikan informasi konten Instagram/TikTok tertunda kepada pengguna saat memperbarui profil agar pengguna dapat menindaklanjuti tugas terkait sebelum atau saat memperbarui profil.

### Description

- Mengimpor `PendingContentCard` dan `getClaimPendingContent` serta menambahkan state `pendingContent`, `pendingContentLoading`, dan `pendingContentError` di `cicero-dashboard/app/claim/edit/page.jsx`.
- Menambahkan fungsi `loadPendingContent(token)` yang memanggil `getClaimPendingContent(token)` menggunakan token claim tervalidasi dari `sessionStorage` dan mempertahankan redirect ke `/claim` untuk respons `401/403`.
- Memanggil `loadPendingContent` setelah token tervalidasi dan merender `PendingContentCard` sebelum formulir profil, meneruskan `data`, `loading`, `error`, `claimToken`, `onRefresh`, dan `onOpenProfile` yang menggulir ke elemen `claim-profile-form`.
- Menyesuaikan mock API di pengujian dan menambahkan pengujian integrasi di `cicero-dashboard/__tests__/claimEditPage.test.tsx` untuk memverifikasi pemanggilan endpoint, rendering daftar tugas dan CTA `Buka Konten`, perilaku `Refresh`, empty state, non-blocking error, serta redirect pada `401/403`.

### Testing

- Menjalankan `npm test -- --runInBand __tests__/claimEditPage.test.tsx` yang menghasilkan semua pengujian di file tersebut lulus (`20 passed`).
- Menjalankan `npx tsc --noEmit` yang melaporkan error TypeScript yang sudah ada sebelumnya pada pengujian lain dan tidak terkait perubahan ini.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7c6c748e3c83278e25505b0ae707ff)